### PR TITLE
SOF-185: Change Upsert to Insert for Specimen, and BoundingBox

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/BoundingBoxRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/BoundingBoxRepositoryImplementation.kt
@@ -1,15 +1,25 @@
 package com.vci.vectorcamapp.core.data.repository
 
+import android.database.sqlite.SQLiteConstraintException
 import com.vci.vectorcamapp.core.data.mappers.toEntity
 import com.vci.vectorcamapp.core.data.room.dao.BoundingBoxDao
 import com.vci.vectorcamapp.core.domain.model.BoundingBox
 import com.vci.vectorcamapp.core.domain.repository.BoundingBoxRepository
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import javax.inject.Inject
 
 class BoundingBoxRepositoryImplementation @Inject constructor(
     private val boundingBoxDao: BoundingBoxDao
 ) : BoundingBoxRepository {
-    override suspend fun upsertBoundingBox(boundingBox: BoundingBox, specimenId: String): Boolean {
-        return boundingBoxDao.upsertBoundingBox(boundingBox.toEntity(specimenId)) != -1L
+    override suspend fun insertBoundingBox(boundingBox: BoundingBox, specimenId: String): Result<Unit, RoomDbError> {
+        return try {
+            boundingBoxDao.insertBoundingBox(boundingBox.toEntity(specimenId))
+            Result.Success(Unit)
+        } catch (e: SQLiteConstraintException) {
+            Result.Error(RoomDbError.DUPLICATE_BOUNDING_BOX_ID)
+        } catch (e: Exception) {
+            Result.Error(RoomDbError.UNKNOWN_ERROR)
+        }
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenRepositoryImplementation.kt
@@ -1,11 +1,14 @@
 package com.vci.vectorcamapp.core.data.repository
 
+import android.database.sqlite.SQLiteConstraintException
 import com.vci.vectorcamapp.core.data.mappers.toDomain
 import com.vci.vectorcamapp.core.data.mappers.toEntity
 import com.vci.vectorcamapp.core.data.room.dao.SpecimenDao
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenAndBoundingBox
 import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.UUID
@@ -14,8 +17,15 @@ import javax.inject.Inject
 class SpecimenRepositoryImplementation @Inject constructor(
     private val specimenDao: SpecimenDao
 ) : SpecimenRepository {
-    override suspend fun upsertSpecimen(specimen: Specimen, sessionId: UUID): Boolean {
-        return specimenDao.upsertSpecimen(specimen.toEntity(sessionId)) != -1L
+    override suspend fun insertSpecimen(specimen: Specimen, sessionId: UUID): Result<Unit, RoomDbError> {
+        return try {
+            specimenDao.insertSpecimen(specimen.toEntity(sessionId))
+            Result.Success(Unit)
+        } catch (e: SQLiteConstraintException) {
+            Result.Error(RoomDbError.DUPLICATE_SPECIMEN_ID)
+        } catch (e: Exception) {
+            Result.Error(RoomDbError.UNKNOWN_ERROR)
+        }
     }
 
     override suspend fun deleteSpecimen(specimen: Specimen, sessionId: UUID): Boolean {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/BoundingBoxDao.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/BoundingBoxDao.kt
@@ -1,12 +1,13 @@
 package com.vci.vectorcamapp.core.data.room.dao
 
 import androidx.room.Dao
-import androidx.room.Upsert
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import com.vci.vectorcamapp.core.data.room.entities.BoundingBoxEntity
 
 @Dao
 interface BoundingBoxDao {
 
-    @Upsert
-    suspend fun upsertBoundingBox(boundingBoxEntity: BoundingBoxEntity): Long
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insertBoundingBox(boundingBoxEntity: BoundingBoxEntity)
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SpecimenDao.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SpecimenDao.kt
@@ -2,9 +2,10 @@ package com.vci.vectorcamapp.core.data.room.dao
 
 import androidx.room.Dao
 import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
-import androidx.room.Upsert
 import com.vci.vectorcamapp.core.data.room.entities.SpecimenEntity
 import com.vci.vectorcamapp.core.data.room.entities.relations.SpecimenAndBoundingBoxRelation
 import kotlinx.coroutines.flow.Flow
@@ -12,8 +13,8 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SpecimenDao {
 
-    @Upsert
-    suspend fun upsertSpecimen(specimen: SpecimenEntity): Long
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insertSpecimen(specimen: SpecimenEntity)
 
     @Delete
     suspend fun deleteSpecimen(specimen: SpecimenEntity): Int

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/BoundingBoxRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/BoundingBoxRepository.kt
@@ -1,7 +1,9 @@
 package com.vci.vectorcamapp.core.domain.repository
 
 import com.vci.vectorcamapp.core.domain.model.BoundingBox
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 
 interface BoundingBoxRepository {
-    suspend fun upsertBoundingBox(boundingBox: BoundingBox, specimenId: String) : Boolean
+    suspend fun insertBoundingBox(boundingBox: BoundingBox, specimenId: String) : Result<Unit, RoomDbError>
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SpecimenRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SpecimenRepository.kt
@@ -2,11 +2,13 @@ package com.vci.vectorcamapp.core.domain.repository
 
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenAndBoundingBox
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface SpecimenRepository {
-    suspend fun upsertSpecimen(specimen: Specimen, sessionId: UUID): Boolean
+    suspend fun insertSpecimen(specimen: Specimen, sessionId: UUID): Result<Unit, RoomDbError>
     suspend fun deleteSpecimen(specimen: Specimen, sessionId: UUID): Boolean
     fun observeSpecimenAndBoundingBox(specimenId: String): Flow<SpecimenAndBoundingBox?>
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/util/room/RoomDbError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/util/room/RoomDbError.kt
@@ -1,0 +1,9 @@
+package com.vci.vectorcamapp.core.domain.util.room
+
+import com.vci.vectorcamapp.core.domain.util.Error
+
+enum class RoomDbError : Error {
+    DUPLICATE_SPECIMEN_ID,
+    DUPLICATE_BOUNDING_BOX_ID,
+    UNKNOWN_ERROR
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/room/RoomDbErrorToString.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/room/RoomDbErrorToString.kt
@@ -1,0 +1,14 @@
+package com.vci.vectorcamapp.core.presentation.util.room
+
+import android.content.Context
+import com.vci.vectorcamapp.R
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
+
+fun RoomDbError.toString(context: Context) : String {
+    val resId = when(this) {
+        RoomDbError.DUPLICATE_SPECIMEN_ID -> R.string.roomdb_error_duplicate_specimen_id
+        RoomDbError.DUPLICATE_BOUNDING_BOX_ID -> R.string.roomdb_error_duplicate_bounding_box_id
+        RoomDbError.UNKNOWN_ERROR -> R.string.roomdb_error_unknown_error
+    }
+    return context.getString(resId)
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.repository.BoundingBoxRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
+import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.imaging.ImagingError
 import com.vci.vectorcamapp.core.domain.util.onError
 import com.vci.vectorcamapp.core.domain.util.onSuccess
@@ -203,11 +204,22 @@ class ImagingViewModel @Inject constructor(
                                 boundingBoxUi
                             )
 
-                            val specimenInserted =
-                                specimenRepository.upsertSpecimen(specimen, currentSession.id)
-                            val boundingBoxInserted =
-                                boundingBoxRepository.upsertBoundingBox(boundingBox, specimen.id)
-                            specimenInserted && boundingBoxInserted
+                            val specimenResult =
+                                specimenRepository.insertSpecimen(specimen, currentSession.id)
+                            val boundingBoxResult =
+                                boundingBoxRepository.insertBoundingBox(boundingBox, specimen.id)
+
+                            specimenResult.onError { error ->
+                                Log.d("ROOM ERROR", "Specimen error: $error")
+                                return@runAsTransaction false
+                            }
+
+                            boundingBoxResult.onError { error ->
+                                Log.d("ROOM ERROR", "Bounding box error: $error")
+                                return@runAsTransaction false
+                            }
+
+                            true
                         }
 
                         if (success) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,4 +57,13 @@
 
     <!-- Imaging error: Unknown error -->
     <string name="imaging_error_unknown">An unknown error occurred. Please contact support if this issue persists.</string>
+
+    <!-- RoomDb error: Duplicate Specimen Id -->
+    <string name="roomdb_error_duplicate_specimen_id">A specimen with the same ID already exists in this or a previous session.</string>
+
+    <!-- RoomDb error: Duplicate Bounding Box Id -->
+    <string name="roomdb_error_duplicate_bounding_box_id">There was an error registering the bounding box for this specimen. Please try capturing the image again.</string>
+
+    <!-- RoomDb error: Unknown error -->
+    <string name="roomdb_error_unknown_error">An unknown error occurred while saving data. Please contact support if this issue persists.</string>
 </resources>


### PR DESCRIPTION
This update changes the database operations for Specimen and BoundingBox from upsert to insert with conflict handling. Instead of silently overwriting existing records, the app now detects duplicate specimen IDs or bounding boxes and surfaces appropriate errors. This ensures that each specimen and its associated bounding box remain unique within a session, improving data integrity and providing users with clearer feedback in the event of conflicts.

Testing involved verifying that duplicate specimen IDs trigger the correct error, and that newly captured specimens continue to be saved correctly without regressions.