### PR TITLE
SOF-189: Create a room entity for a Surveillance form.

### DIFF
--- a/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/3.json
+++ b/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/3.json
@@ -1,0 +1,336 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "53b86dd59b7435d690408144127d854e",
+    "entities": [
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `submittedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_submittedAt",
+            "unique": false,
+            "columnNames": [
+              "submittedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_submittedAt` ON `${TABLE_NAME}` (`submittedAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "specimen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `species` TEXT, `sex` TEXT, `abdomenStatus` TEXT, `imageUri` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "species",
+            "columnName": "species",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sex",
+            "columnName": "sex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatus",
+            "columnName": "abdomenStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUri",
+            "columnName": "imageUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bounding_box",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`specimenId` TEXT NOT NULL, `topLeftX` REAL NOT NULL, `topLeftY` REAL NOT NULL, `width` REAL NOT NULL, `height` REAL NOT NULL, `confidence` REAL NOT NULL, `classId` INTEGER NOT NULL, PRIMARY KEY(`specimenId`), FOREIGN KEY(`specimenId`) REFERENCES `specimen`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "specimenId",
+            "columnName": "specimenId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topLeftX",
+            "columnName": "topLeftX",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topLeftY",
+            "columnName": "topLeftY",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "confidence",
+            "columnName": "confidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classId",
+            "columnName": "classId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "specimenId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "specimen",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "surveillance_form",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `country` TEXT NOT NULL, `district` TEXT NOT NULL, `healthCenter` TEXT NOT NULL, `sentinelSite` TEXT NOT NULL, `householdNumber` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `collectionDate` INTEGER NOT NULL, `collectionMethod` TEXT NOT NULL, `collectorName` TEXT NOT NULL, `collectorTitle` TEXT NOT NULL, `numPeopleSleptInHouse` INTEGER NOT NULL, `wasIrsConducted` INTEGER NOT NULL, `monthsSinceIrs` INTEGER, `numLlinsAvailable` INTEGER NOT NULL, `llinType` TEXT, `llinBrand` TEXT, `numPeopleSleptUnderLlin` INTEGER, `notes` TEXT NOT NULL, PRIMARY KEY(`sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthCenter",
+            "columnName": "healthCenter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentinelSite",
+            "columnName": "sentinelSite",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "householdNumber",
+            "columnName": "householdNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionDate",
+            "columnName": "collectionDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionMethod",
+            "columnName": "collectionMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorName",
+            "columnName": "collectorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorTitle",
+            "columnName": "collectorTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeopleSleptInHouse",
+            "columnName": "numPeopleSleptInHouse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wasIrsConducted",
+            "columnName": "wasIrsConducted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monthsSinceIrs",
+            "columnName": "monthsSinceIrs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "numLlinsAvailable",
+            "columnName": "numLlinsAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "llinType",
+            "columnName": "llinType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "llinBrand",
+            "columnName": "llinBrand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPeopleSleptUnderLlin",
+            "columnName": "numPeopleSleptUnderLlin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '53b86dd59b7435d690408144127d854e')"
+    ]
+  }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SurveillanceFormMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SurveillanceFormMapper.kt
@@ -1,0 +1,54 @@
+package com.vci.vectorcamapp.core.data.mappers
+
+import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import java.util.UUID
+
+fun SurveillanceFormEntity.toDomain() : SurveillanceForm {
+    return SurveillanceForm(
+        country = this.country,
+        district = this.district,
+        healthCenter = this.healthCenter,
+        sentinelSite = this.sentinelSite,
+        householdNumber = this.householdNumber,
+        latitude = this.latitude,
+        longitude = this.longitude,
+        collectionDate = this.collectionDate,
+        collectionMethod = this.collectionMethod,
+        collectorName = this.collectorName,
+        collectorTitle = this.collectorTitle,
+        numPeopleSleptInHouse = this.numPeopleSleptInHouse,
+        wasIrsConducted = this.wasIrsConducted,
+        monthsSinceIrs = this.monthsSinceIrs,
+        numLlinsAvailable = this.numLlinsAvailable,
+        llinType = this.llinType,
+        llinBrand = this.llinBrand,
+        numPeopleSleptUnderLlin = this.numPeopleSleptUnderLlin,
+        notes = this.notes
+    )
+}
+
+fun SurveillanceForm.toEntity(sessionId: UUID) : SurveillanceFormEntity {
+    return SurveillanceFormEntity(
+        sessionId = sessionId,
+        country = this.country,
+        district = this.district,
+        healthCenter = this.healthCenter,
+        sentinelSite = this.sentinelSite,
+        householdNumber = this.householdNumber,
+        latitude = this.latitude,
+        longitude = this.longitude,
+        collectionDate = this.collectionDate,
+        collectionMethod = this.collectionMethod,
+        collectorName = this.collectorName,
+        collectorTitle = this.collectorTitle,
+        numPeopleSleptInHouse = this.numPeopleSleptInHouse,
+        wasIrsConducted = this.wasIrsConducted,
+        monthsSinceIrs = this.monthsSinceIrs,
+        numLlinsAvailable = this.numLlinsAvailable,
+        llinType = this.llinType,
+        llinBrand = this.llinBrand,
+        numPeopleSleptUnderLlin = this.numPeopleSleptUnderLlin,
+        notes = this.notes,
+    )
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
@@ -6,6 +6,8 @@ import com.vci.vectorcamapp.core.data.room.dao.SessionDao
 import com.vci.vectorcamapp.core.domain.model.Session
 import com.vci.vectorcamapp.core.domain.model.composites.SessionWithSpecimens
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.UUID
@@ -14,8 +16,13 @@ import javax.inject.Inject
 class SessionRepositoryImplementation @Inject constructor(
     private val sessionDao: SessionDao
 ) : SessionRepository {
-    override suspend fun upsertSession(session: Session): Boolean {
-        return sessionDao.upsertSession(session.toEntity()) != -1L
+    override suspend fun upsertSession(session: Session): Result<Unit, RoomDbError> {
+        return try {
+            sessionDao.upsertSession(session.toEntity())
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(RoomDbError.UNKNOWN_ERROR)
+        }
     }
 
     override suspend fun deleteSession(session: Session): Boolean {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SurveillanceFormRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SurveillanceFormRepositoryImplementation.kt
@@ -1,0 +1,25 @@
+package com.vci.vectorcamapp.core.data.repository
+
+import com.vci.vectorcamapp.core.data.mappers.toEntity
+import com.vci.vectorcamapp.core.data.room.dao.SurveillanceFormDao
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.core.domain.repository.SurveillanceFormRepository
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
+import java.util.UUID
+import javax.inject.Inject
+
+class SurveillanceFormRepositoryImplementation @Inject constructor(
+    private val surveillanceFormDao: SurveillanceFormDao
+) : SurveillanceFormRepository {
+    override suspend fun upsertSurveillanceForm(
+        surveillanceForm: SurveillanceForm, sessionId: UUID
+    ): Result<Unit, RoomDbError> {
+        return try {
+            surveillanceFormDao.upsertSurveillanceForm(surveillanceForm.toEntity(sessionId))
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(RoomDbError.UNKNOWN_ERROR)
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
@@ -8,17 +8,20 @@ import com.vci.vectorcamapp.core.data.room.converters.UuidConverter
 import com.vci.vectorcamapp.core.data.room.dao.BoundingBoxDao
 import com.vci.vectorcamapp.core.data.room.dao.SessionDao
 import com.vci.vectorcamapp.core.data.room.dao.SpecimenDao
+import com.vci.vectorcamapp.core.data.room.dao.SurveillanceFormDao
 import com.vci.vectorcamapp.core.data.room.entities.BoundingBoxEntity
 import com.vci.vectorcamapp.core.data.room.entities.SessionEntity
 import com.vci.vectorcamapp.core.data.room.entities.SpecimenEntity
+import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
 
 @Database(
-    entities = [SessionEntity::class, SpecimenEntity::class, BoundingBoxEntity::class],
-    version = 2,
+    entities = [SessionEntity::class, SpecimenEntity::class, BoundingBoxEntity::class, SurveillanceFormEntity::class],
+    version = 3,
 )
 @TypeConverters(UuidConverter::class, UriConverter::class)
 abstract class VectorCamDatabase : RoomDatabase() {
     abstract val sessionDao: SessionDao
     abstract val specimenDao: SpecimenDao
     abstract val boundingBoxDao: BoundingBoxDao
+    abstract val surveillanceFormDao: SurveillanceFormDao
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SessionDao.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SessionDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Upsert
 import com.vci.vectorcamapp.core.data.room.entities.SessionEntity
+import com.vci.vectorcamapp.core.data.room.entities.relations.SessionAndSurveillanceFormRelation
 import com.vci.vectorcamapp.core.data.room.entities.relations.SessionWithSpecimensRelation
 import kotlinx.coroutines.flow.Flow
 import java.util.UUID
@@ -27,6 +28,10 @@ interface SessionDao {
 
     @Query("SELECT * FROM session WHERE submittedAt IS NULL")
     fun observeIncompleteSessions(): Flow<List<SessionEntity>>
+
+    @Transaction
+    @Query("SELECT * FROM session WHERE id = :sessionId")
+    fun observeSessionAndSurveillanceForm(sessionId: UUID): Flow<SessionAndSurveillanceFormRelation?>
 
     @Transaction
     @Query("SELECT * FROM session WHERE id = :sessionId")

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SurveillanceFormDao.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SurveillanceFormDao.kt
@@ -1,0 +1,12 @@
+package com.vci.vectorcamapp.core.data.room.dao
+
+import androidx.room.Dao
+import androidx.room.Upsert
+import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
+
+@Dao
+interface SurveillanceFormDao {
+
+    @Upsert
+    suspend fun upsertSurveillanceForm(surveillanceForm: SurveillanceFormEntity) : Long
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SurveillanceFormEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SurveillanceFormEntity.kt
@@ -1,0 +1,39 @@
+package com.vci.vectorcamapp.core.data.room.entities
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+@Entity(
+    tableName = "surveillance_form", foreignKeys = [ForeignKey(
+        entity = SessionEntity::class,
+        parentColumns = ["id"],
+        childColumns = ["sessionId"],
+        onDelete = ForeignKey.CASCADE,
+        onUpdate = ForeignKey.CASCADE
+    )]
+)
+data class SurveillanceFormEntity(
+    @PrimaryKey val sessionId: UUID = UUID(0, 0),
+    val country: String = "",
+    val district: String = "",
+    val healthCenter: String = "",
+    val sentinelSite: String = "",
+    val householdNumber: String = "",
+    val latitude: Float = 0F,
+    val longitude: Float = 0F,
+    val collectionDate: Long = 0L,
+    val collectionMethod: String = "",
+    val collectorName: String = "",
+    val collectorTitle: String = "",
+    val numPeopleSleptInHouse: Int = 0,
+    val wasIrsConducted: Boolean = false,
+    val monthsSinceIrs: Int? = null,
+    val numLlinsAvailable: Int = 0,
+    val llinType: String? = null,
+    val llinBrand: String? = null,
+    val numPeopleSleptUnderLlin: Int? = null,
+    val notes: String = ""
+)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/relations/SessionAndSurveillanceFormRelation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/relations/SessionAndSurveillanceFormRelation.kt
@@ -1,0 +1,15 @@
+package com.vci.vectorcamapp.core.data.room.entities.relations
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.vci.vectorcamapp.core.data.room.entities.SessionEntity
+import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
+
+data class SessionAndSurveillanceFormRelation(
+    @Embedded val sessionEntity: SessionEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "sessionId"
+    )
+    val surveillanceFormEntity: SurveillanceFormEntity
+)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -1,7 +1,9 @@
 package com.vci.vectorcamapp.core.data.room.migrations
 
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE
+import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_2_3_CREATE_SURVEILLANCE_FORM_TABLE
 
 val ALL_MIGRATIONS = arrayOf(
-    MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE
+    MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE,
+    MIGRATION_2_3_CREATE_SURVEILLANCE_FORM_TABLE
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_1_2_CreateBoundingBoxTable.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_1_2_CreateBoundingBoxTable.kt
@@ -18,8 +18,7 @@ val MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE = object : Migration(1, 2) {
                 PRIMARY KEY(`specimenId`),
                 FOREIGN KEY(`specimenId`) REFERENCES `specimen`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
             )
-        """.trimIndent()
+            """.trimIndent()
         )
     }
-
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_2_3_CreateSurveillanceFormTable.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_2_3_CreateSurveillanceFormTable.kt
@@ -1,0 +1,37 @@
+package com.vci.vectorcamapp.core.data.room.migrations.versions
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_2_3_CREATE_SURVEILLANCE_FORM_TABLE = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS surveillance_form (
+                `sessionId` TEXT NOT NULL,
+                `country` TEXT NOT NULL,
+                `district` TEXT NOT NULL,
+                `healthCenter` TEXT NOT NULL,
+                `sentinelSite` TEXT NOT NULL,
+                `householdNumber` TEXT NOT NULL,
+                `latitude` REAL NOT NULL,
+                `longitude` REAL NOT NULL,
+                `collectionDate` INTEGER NOT NULL,
+                `collectionMethod` TEXT NOT NULL,
+                `collectorName` TEXT NOT NULL,
+                `collectorTitle` TEXT NOT NULL,
+                `numPeopleSleptInHouse` INTEGER NOT NULL,
+                `wasIrsConducted` INTEGER NOT NULL,
+                `monthsSinceIrs` INTEGER,
+                `numLlinsAvailable` INTEGER NOT NULL,
+                `llinType` TEXT,
+                `llinBrand` TEXT,
+                `numPeopleSleptUnderLlin` INTEGER,
+                `notes` TEXT NOT NULL,
+                PRIMARY KEY(`sessionId`),
+                FOREIGN KEY(`sessionId`) REFERENCES `session`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
+            )
+            """.trimIndent()
+        )
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/CoreRepositoryModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/CoreRepositoryModule.kt
@@ -3,9 +3,11 @@ package com.vci.vectorcamapp.core.di
 import com.vci.vectorcamapp.core.data.repository.BoundingBoxRepositoryImplementation
 import com.vci.vectorcamapp.core.data.repository.SessionRepositoryImplementation
 import com.vci.vectorcamapp.core.data.repository.SpecimenRepositoryImplementation
+import com.vci.vectorcamapp.core.data.repository.SurveillanceFormRepositoryImplementation
 import com.vci.vectorcamapp.core.domain.repository.BoundingBoxRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
+import com.vci.vectorcamapp.core.domain.repository.SurveillanceFormRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -33,4 +35,10 @@ abstract class CoreRepositoryModule {
     abstract fun bindBoundingBoxRepository(
         boundingBoxRepositoryImplementation: BoundingBoxRepositoryImplementation
     ): BoundingBoxRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSurveillanceFormRepository(
+        surveillanceFormRepositoryImplementation: SurveillanceFormRepositoryImplementation
+    ): SurveillanceFormRepository
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.data.room.VectorCamDatabase
 import com.vci.vectorcamapp.core.data.room.dao.BoundingBoxDao
 import com.vci.vectorcamapp.core.data.room.dao.SessionDao
 import com.vci.vectorcamapp.core.data.room.dao.SpecimenDao
+import com.vci.vectorcamapp.core.data.room.dao.SurveillanceFormDao
 import com.vci.vectorcamapp.core.data.room.migrations.ALL_MIGRATIONS
 import dagger.Module
 import dagger.Provides
@@ -57,4 +58,7 @@ object RoomDatabaseModule {
 
     @Provides
     fun provideBoundingBoxDao(db: VectorCamDatabase): BoundingBoxDao = db.boundingBoxDao
+
+    @Provides
+    fun provideSurveillanceFormDao(db: VectorCamDatabase): SurveillanceFormDao = db.surveillanceFormDao
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/composites/SessionAndSurveillanceForm.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/composites/SessionAndSurveillanceForm.kt
@@ -1,0 +1,9 @@
+package com.vci.vectorcamapp.core.domain.model.composites
+
+import com.vci.vectorcamapp.core.domain.model.Session
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+
+data class SessionAndSurveillanceForm(
+    val session: Session,
+    val surveillanceForm: SurveillanceForm
+)

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SessionRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SessionRepository.kt
@@ -2,11 +2,13 @@ package com.vci.vectorcamapp.core.domain.repository
 
 import com.vci.vectorcamapp.core.domain.model.Session
 import com.vci.vectorcamapp.core.domain.model.composites.SessionWithSpecimens
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import java.util.UUID
 
 interface SessionRepository {
-    suspend fun upsertSession(session: Session): Boolean
+    suspend fun upsertSession(session: Session): Result<Unit, RoomDbError>
     suspend fun deleteSession(session: Session): Boolean
     suspend fun markSessionAsComplete(sessionId: UUID): Boolean
     fun observeCompleteSessions(): Flow<List<Session>>

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SurveillanceFormRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SurveillanceFormRepository.kt
@@ -1,0 +1,10 @@
+package com.vci.vectorcamapp.core.domain.repository
+
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
+import java.util.UUID
+
+interface SurveillanceFormRepository {
+    suspend fun upsertSurveillanceForm(surveillanceForm: SurveillanceForm, sessionId: UUID): Result<Unit, RoomDbError>
+}

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.model.Session
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
+import com.vci.vectorcamapp.core.domain.util.onError
+import com.vci.vectorcamapp.core.domain.util.onSuccess
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -44,10 +46,10 @@ class LandingViewModel @Inject constructor(
                         createdAt = System.currentTimeMillis(),
                         submittedAt = null
                     )
-                    if (sessionRepository.upsertSession(newSession)) {
+                    sessionRepository.upsertSession(newSession).onSuccess {
                         currentSessionCache.saveSession(newSession)
                         _events.send(LandingEvent.NavigateToNewSurveillanceSessionScreen)
-                    } else {
+                    }.onError {
                         Log.e("LandingViewModel", "Failed to create session.")
                     }
                 }

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormAction.kt
@@ -5,6 +5,7 @@ import com.vci.vectorcamapp.surveillance_form.domain.enums.LlinBrandOption
 import com.vci.vectorcamapp.surveillance_form.domain.enums.LlinTypeOption
 
 sealed interface SurveillanceFormAction {
+    data object SaveSessionProgress: SurveillanceFormAction
     data object SubmitSurveillanceForm: SurveillanceFormAction
     data class EnterCountry(val text: String) : SurveillanceFormAction
     data class EnterDistrict(val text: String) : SurveillanceFormAction

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.surveillance_form.presentation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -29,6 +30,10 @@ fun SurveillanceFormScreen(
     modifier: Modifier = Modifier
 ) {
     val verticalScrollState = rememberScrollState()
+
+    BackHandler {
+        onAction(SurveillanceFormAction.SaveSessionProgress)
+    }
 
     Column(
         modifier = modifier


### PR DESCRIPTION
This pull request adds a new Room entity for the SurveillanceForm, which captures metadata collected during a vector surveillance session based on the fields present in the HMIS paper forms. The entity is designed with a one-to-one relationship to the existing Session entity, using sessionId as the primary key to ensure alignment and data integrity. Fields include country, district, health center, sentinel site, household number, collection details, LLIN-related information, and additional contextual notes. Nullable fields are included to accommodate conditional form logic (e.g., IRS not conducted, LLINs not available). This entity sets the foundation for structured offline data capture, validation, and future synchronization with backend services.

Manual verification was conducted by filling out and editing the surveillance form through the UI. Corresponding entries in the surveillance_form table were confirmed to be inserted or updated as expected via inspection of the local Room database.