### PR TITLE
SOF-188: Saving image should abort if creation of a new specimen or bounding box fails.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/CameraRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/CameraRepository.kt
@@ -11,4 +11,5 @@ import com.vci.vectorcamapp.core.domain.util.Result
 interface CameraRepository {
     suspend fun captureImage(controller: LifecycleCameraController) : Result<ImageProxy, ImagingError>
     suspend fun saveImage(bitmap: Bitmap, filename: String, currentSession: Session) : Result<Uri, ImagingError>
+    suspend fun deleteSavedImage(uri: Uri)
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.repository.BoundingBoxRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
+import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.imaging.ImagingError
 import com.vci.vectorcamapp.core.domain.util.onError
 import com.vci.vectorcamapp.core.domain.util.onSuccess
@@ -229,19 +230,19 @@ class ImagingViewModel @Inject constructor(
 
                             specimenResult.onError { error ->
                                 Log.d("ROOM ERROR", "Specimen error: $error")
-                                return@runAsTransaction false
                             }
 
                             boundingBoxResult.onError { error ->
                                 Log.d("ROOM ERROR", "Bounding box error: $error")
-                                return@runAsTransaction false
                             }
 
-                            true
+                            (specimenResult !is Result.Error) && (boundingBoxResult !is Result.Error)
                         }
 
                         if (success) {
                             clearCurrentSpecimenStateFields()
+                        } else {
+                            cameraRepository.deleteSavedImage(imageUri)
                         }
                     }.onError { error ->
                         _events.send(ImagingEvent.DisplayImagingError(error))

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormViewModel.kt
@@ -72,6 +72,24 @@ class SurveillanceFormViewModel @Inject constructor(
                     val llinBrandResult =
                         surveillanceForm.llinBrand?.let { validationUseCases.validateLlinBrand(it) }
 
+                    _state.update {
+                        it.copy(
+                            surveillanceFormErrors = it.surveillanceFormErrors.copy(
+                                country = countryResult.errorOrNull(),
+                                district = districtResult.errorOrNull(),
+                                healthCenter = healthCenterResult.errorOrNull(),
+                                sentinelSite = sentinelSiteResult.errorOrNull(),
+                                householdNumber = householdNumberResult.errorOrNull(),
+                                collectionDate = collectionDateResult.errorOrNull(),
+                                collectionMethod = collectionMethodResult.errorOrNull(),
+                                collectorName = collectorNameResult.errorOrNull(),
+                                collectorTitle = collectorTitleResult.errorOrNull(),
+                                llinType = llinTypeResult?.errorOrNull(),
+                                llinBrand = llinBrandResult?.errorOrNull()
+                            )
+                        )
+                    }
+
                     val hasError = listOf(
                         countryResult,
                         districtResult,
@@ -96,24 +114,6 @@ class SurveillanceFormViewModel @Inject constructor(
                             _events.send(SurveillanceFormEvent.NavigateToImagingScreen)
                         }.onError { error ->
                             Log.e("ROOM DB ERROR", error.toString())
-                        }
-                    } else {
-                        _state.update {
-                            it.copy(
-                                surveillanceFormErrors = it.surveillanceFormErrors.copy(
-                                    country = countryResult.errorOrNull(),
-                                    district = districtResult.errorOrNull(),
-                                    healthCenter = healthCenterResult.errorOrNull(),
-                                    sentinelSite = sentinelSiteResult.errorOrNull(),
-                                    householdNumber = householdNumberResult.errorOrNull(),
-                                    collectionDate = collectionDateResult.errorOrNull(),
-                                    collectionMethod = collectionMethodResult.errorOrNull(),
-                                    collectorName = collectorNameResult.errorOrNull(),
-                                    collectorTitle = collectorTitleResult.errorOrNull(),
-                                    llinType = llinTypeResult?.errorOrNull(),
-                                    llinBrand = llinBrandResult?.errorOrNull()
-                                )
-                            )
                         }
                     }
                 }


### PR DESCRIPTION
This PR introduces fail-safe logic to maintain data integrity between saved images and their corresponding database entries. The image is first saved to the device’s storage, and then a transactional operation is performed to insert the associated Specimen and BoundingBox records into the Room database. If either of these insertions fails, indicating that the operation is not atomic, the previously saved image is deleted from storage to prevent orphaned files. This ensures consistency between the image file system and the app’s internal data structures. The implementation includes error handling to cleanly roll back the saved image in the event of a database failure. Testing was performed to confirm that image deletion occurs reliably when metadata creation fails, and that both the image and metadata are retained when the operation succeeds.