### PR TITLE
SOF-149: Create an “Incomplete Sessions” screen showing a list of all saved but unsubmitted sessions with summary info.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/CameraRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/CameraRepositoryImplementation.kt
@@ -12,10 +12,9 @@ import androidx.camera.core.ImageProxy
 import androidx.camera.view.LifecycleCameraController
 import androidx.core.content.ContextCompat
 import com.vci.vectorcamapp.R
-import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.model.Session
 import com.vci.vectorcamapp.core.domain.util.Result
-import com.vci.vectorcamapp.core.domain.util.imaging.ImagingError
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 import com.vci.vectorcamapp.imaging.domain.repository.CameraRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/CameraRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/CameraRepository.kt
@@ -5,7 +5,7 @@ import android.net.Uri
 import androidx.camera.core.ImageProxy
 import androidx.camera.view.LifecycleCameraController
 import com.vci.vectorcamapp.core.domain.model.Session
-import com.vci.vectorcamapp.core.domain.util.imaging.ImagingError
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 import com.vci.vectorcamapp.core.domain.util.Result
 
 interface CameraRepository {

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/util/ImagingError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/util/ImagingError.kt
@@ -1,4 +1,4 @@
-package com.vci.vectorcamapp.core.domain.util.imaging
+package com.vci.vectorcamapp.imaging.domain.util
 
 import com.vci.vectorcamapp.core.domain.util.Error
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingEvent.kt
@@ -1,6 +1,6 @@
 package com.vci.vectorcamapp.imaging.presentation
 
-import com.vci.vectorcamapp.core.domain.util.imaging.ImagingError
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 
 sealed interface ImagingEvent {
     data class DisplayImagingError(val error: ImagingError) : ImagingEvent

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -10,7 +10,7 @@ import com.vci.vectorcamapp.core.domain.repository.BoundingBoxRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
 import com.vci.vectorcamapp.core.domain.util.Result
-import com.vci.vectorcamapp.core.domain.util.imaging.ImagingError
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 import com.vci.vectorcamapp.core.domain.util.onError
 import com.vci.vectorcamapp.core.domain.util.onSuccess
 import com.vci.vectorcamapp.imaging.domain.repository.CameraRepository

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/gallery/CapturedSpecimenOverlay.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/gallery/CapturedSpecimenOverlay.kt
@@ -22,9 +22,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.imaging.presentation.components.camera.BoundingBoxOverlay
@@ -41,9 +44,10 @@ fun CapturedSpecimenOverlay(
     onRetakeImage: (() -> Unit)? = null,
     onSaveImageToSession: (() -> Unit)? = null,
 ) {
+    val context = LocalContext.current
+
     Box(
-        modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.BottomCenter
+        modifier = modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter
     ) {
         if (specimenBitmap != null) {
             Image(
@@ -54,7 +58,8 @@ fun CapturedSpecimenOverlay(
             )
         } else if (specimen.imageUri != Uri.EMPTY) {
             AsyncImage(
-                model = specimen.imageUri,
+                model = ImageRequest.Builder(context).data(specimen.imageUri).crossfade(true)
+                    .build(),
                 contentDescription = specimen.id,
                 contentScale = ContentScale.Fit,
                 modifier = Modifier.fillMaxSize()
@@ -62,8 +67,7 @@ fun CapturedSpecimenOverlay(
         }
 
         BoundingBoxOverlay(
-            boundingBoxUi = boundingBoxUi,
-            modifier = modifier.fillMaxSize()
+            boundingBoxUi = boundingBoxUi, modifier = modifier.fillMaxSize()
         )
 
         Column(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/util/ImagingErrorToString.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/util/ImagingErrorToString.kt
@@ -1,8 +1,8 @@
-package com.vci.vectorcamapp.core.presentation.util.imaging
+package com.vci.vectorcamapp.imaging.presentation.util
 
 import android.content.Context
 import com.vci.vectorcamapp.R
-import com.vci.vectorcamapp.core.domain.util.imaging.ImagingError
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 
 fun ImagingError.toString(context: Context): String {
     val resId = when(this) {

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -21,8 +21,8 @@ fun IncompleteSessionScreen(
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        items(items = state.sessions, key = { it.id }) { session ->
-            IncompleteSessionCard(session = session)
+        items(items = state.sessions.asReversed(), key = { it.id }) { session ->
+            IncompleteSessionCard(session = session, modifier = modifier)
         }
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -1,0 +1,28 @@
+package com.vci.vectorcamapp.incomplete_session.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.vci.vectorcamapp.incomplete_session.presentation.components.IncompleteSessionCard
+
+@Composable
+fun IncompleteSessionScreen(
+    state: IncompleteSessionState,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(items = state.sessions, key = { it.id }) { session ->
+            IncompleteSessionCard(session = session)
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionState.kt
@@ -1,0 +1,7 @@
+package com.vci.vectorcamapp.incomplete_session.presentation
+
+import com.vci.vectorcamapp.core.domain.model.Session
+
+data class IncompleteSessionState(
+    val sessions: List<Session> = emptyList(),
+)

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
@@ -1,0 +1,26 @@
+package com.vci.vectorcamapp.incomplete_session.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vci.vectorcamapp.core.domain.repository.SessionRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class IncompleteSessionViewModel @Inject constructor(
+    private val sessionRepository: SessionRepository
+) : ViewModel() {
+
+    private val _incompleteSessions = sessionRepository.observeIncompleteSessions()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
+    private val _state = MutableStateFlow(IncompleteSessionState())
+    val state = combine(_incompleteSessions, _state) { incompleteSessions, state ->
+        state.copy(
+            sessions = incompleteSessions
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), IncompleteSessionState())
+}

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class IncompleteSessionViewModel @Inject constructor(
-    private val sessionRepository: SessionRepository
+    sessionRepository: SessionRepository
 ) : ViewModel() {
 
     private val _incompleteSessions = sessionRepository.observeIncompleteSessions()

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -1,0 +1,10 @@
+package com.vci.vectorcamapp.incomplete_session.presentation.components
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.vci.vectorcamapp.core.domain.model.Session
+
+@Composable
+fun IncompleteSessionCard(session: Session) {
+    Text(session.id.toString())
+}

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -1,10 +1,49 @@
 package com.vci.vectorcamapp.incomplete_session.presentation.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.vci.vectorcamapp.core.domain.model.Session
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 @Composable
-fun IncompleteSessionCard(session: Session) {
-    Text(session.id.toString())
+fun IncompleteSessionCard(session: Session, modifier: Modifier = Modifier) {
+
+    val dateTimeFormatter = remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
+    val formattedDateTime = dateTimeFormatter.format(session.createdAt)
+
+    Card(
+        modifier = modifier.fillMaxWidth().wrapContentHeight(),
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = "Session ID: ${session.id}",
+                style = MaterialTheme.typography.bodySmall
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Created: $formattedDateTime",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingEvent.kt
@@ -2,4 +2,5 @@ package com.vci.vectorcamapp.landing.presentation
 
 sealed interface LandingEvent {
     data object NavigateToNewSurveillanceSessionScreen: LandingEvent
+    data object NavigateToIncompleteSessionsScreen: LandingEvent
 }

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -61,9 +61,7 @@ class LandingViewModel @Inject constructor(
                 }
 
                 LandingAction.ViewIncompleteSessions -> {
-                    Log.d(
-                        "Navigation", "ViewIncompleteSessions"
-                    )
+                    _events.send(LandingEvent.NavigateToIncompleteSessionsScreen)
                 }
 
                 LandingAction.ViewCompleteSessions -> {

--- a/app/src/main/java/com/vci/vectorcamapp/navigation/Destination.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/navigation/Destination.kt
@@ -11,4 +11,7 @@ sealed interface Destination {
 
     @Serializable
     data object Imaging : Destination
+
+    @Serializable
+    data object IncompleteSession : Destination
 }

--- a/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
@@ -10,12 +10,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.vci.vectorcamapp.core.presentation.util.ObserveAsEvents
-import com.vci.vectorcamapp.core.presentation.util.imaging.toString
+import com.vci.vectorcamapp.imaging.presentation.util.toString
 import com.vci.vectorcamapp.imaging.presentation.ImagingEvent
 import com.vci.vectorcamapp.imaging.presentation.ImagingScreen
 import com.vci.vectorcamapp.imaging.presentation.ImagingViewModel
@@ -23,6 +22,8 @@ import com.vci.vectorcamapp.landing.presentation.LandingEvent
 import com.vci.vectorcamapp.landing.presentation.LandingScreen
 import com.vci.vectorcamapp.landing.presentation.LandingViewModel
 import com.vci.vectorcamapp.animation.presentation.LoadingAnimation
+import com.vci.vectorcamapp.incomplete_session.presentation.IncompleteSessionScreen
+import com.vci.vectorcamapp.incomplete_session.presentation.IncompleteSessionViewModel
 import com.vci.vectorcamapp.surveillance_form.presentation.SurveillanceFormEvent
 import com.vci.vectorcamapp.surveillance_form.presentation.SurveillanceFormScreen
 import com.vci.vectorcamapp.surveillance_form.presentation.SurveillanceFormViewModel
@@ -42,6 +43,10 @@ fun NavGraph() {
                 when (event) {
                     LandingEvent.NavigateToNewSurveillanceSessionScreen -> navController.navigate(
                         Destination.SurveillanceForm
+                    )
+
+                    LandingEvent.NavigateToIncompleteSessionsScreen -> navController.navigate(
+                        Destination.IncompleteSession
                     )
                 }
             }
@@ -113,6 +118,17 @@ fun NavGraph() {
                 ImagingScreen(
                     state = state,
                     onAction = viewModel::onAction,
+                    modifier = Modifier.padding(innerPadding)
+                )
+            }
+        }
+        composable<Destination.IncompleteSession> {
+            val viewModel = hiltViewModel<IncompleteSessionViewModel>()
+            val state by viewModel.state.collectAsStateWithLifecycle()
+
+            Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                IncompleteSessionScreen(
+                    state = state,
                     modifier = Modifier.padding(innerPadding)
                 )
             }


### PR DESCRIPTION
This PR adds the Incomplete Sessions screen, which displays all saved but unsubmitted sessions in a scrollable list. Each session is shown using a simple card that includes a shortened session ID and a formatted creation date and time to help users distinguish between entries.

The screen uses a LazyColumn and observes data from SessionRepository via IncompleteSessionViewModel. The UI updates reactively as sessions are added or removed.

Tested manually by creating sessions in the app, verifying that they appear on the Incomplete Sessions screen with correct timestamps and IDs, and confirming that the list updates as expected. No crashes or rendering issues observed.