### PR TITLE
SOF-206: Create a new ProtoDataStore object for a unique device.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/DeviceCacheImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/DeviceCacheImplementation.kt
@@ -1,0 +1,30 @@
+package com.vci.vectorcamapp.core.data.cache
+
+import androidx.datastore.core.DataStore
+import com.vci.vectorcamapp.core.data.dto.DeviceDto
+import com.vci.vectorcamapp.core.data.mappers.toDomain
+import com.vci.vectorcamapp.core.data.mappers.toDto
+import com.vci.vectorcamapp.core.domain.cache.DeviceCache
+import com.vci.vectorcamapp.core.domain.model.Device
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+class DeviceCacheImplementation @Inject constructor(
+    private val dataStore: DataStore<DeviceDto>
+) : DeviceCache {
+    override suspend fun saveDevice(device: Device, programId: Int) {
+        dataStore.updateData {
+            device.toDto(programId)
+        }
+    }
+
+    override suspend fun getDevice(): Device? {
+        val deviceDto = dataStore.data.firstOrNull()
+        return if (deviceDto == null || deviceDto.isEmpty()) null else deviceDto.toDomain()
+    }
+
+    override suspend fun getProgramId(): Int? {
+        val deviceDto = dataStore.data.firstOrNull()
+        return if (deviceDto == null || deviceDto.isEmpty()) null else deviceDto.programId
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/DeviceDtoSerializer.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/DeviceDtoSerializer.kt
@@ -1,0 +1,43 @@
+package com.vci.vectorcamapp.core.data.cache.serializers
+
+import androidx.datastore.core.Serializer
+import com.vci.vectorcamapp.core.data.dto.DeviceDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+object DeviceDtoSerializer : Serializer<DeviceDto> {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        prettyPrint = false
+    }
+
+    override val defaultValue: DeviceDto = DeviceDto()
+
+    override suspend fun readFrom(input: InputStream): DeviceDto {
+        return try {
+            json.decodeFromString(
+                deserializer = DeviceDto.serializer(),
+                string = input.readBytes().decodeToString()
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            defaultValue
+        }
+    }
+
+    override suspend fun writeTo(t: DeviceDto, output: OutputStream) {
+        withContext(Dispatchers.IO) {
+            output.write(
+                json.encodeToString(
+                    serializer = DeviceDto.serializer(),
+                    value = t
+                ).encodeToByteArray()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/DeviceDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/DeviceDto.kt
@@ -1,0 +1,13 @@
+package com.vci.vectorcamapp.core.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DeviceDto(
+    val id: Int = -1,
+    val programId: Int = -1,
+    val model: String = "",
+    val registeredAt: Long = 0L,
+) {
+    fun isEmpty() = id == -1
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/DeviceMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/DeviceMapper.kt
@@ -1,0 +1,21 @@
+package com.vci.vectorcamapp.core.data.mappers
+
+import com.vci.vectorcamapp.core.data.dto.DeviceDto
+import com.vci.vectorcamapp.core.domain.model.Device
+
+fun DeviceDto.toDomain() : Device {
+    return Device(
+        id = this.id,
+        model = this.model,
+        registeredAt = this.registeredAt
+    )
+}
+
+fun Device.toDto(programId: Int) : DeviceDto {
+    return DeviceDto(
+        id = this.id,
+        programId = programId,
+        model = this.model,
+        registeredAt = this.registeredAt
+    )
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/CacheModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/CacheModule.kt
@@ -3,7 +3,9 @@ package com.vci.vectorcamapp.core.di
 import android.util.Log
 import com.vci.vectorcamapp.BuildConfig
 import com.vci.vectorcamapp.core.data.cache.CurrentSessionCacheImplementation
+import com.vci.vectorcamapp.core.data.cache.DeviceCacheImplementation
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
+import com.vci.vectorcamapp.core.domain.cache.DeviceCache
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -23,6 +25,12 @@ import javax.inject.Singleton
 //    abstract fun bindCurrentSessionCache(
 //        currentSessionCacheImplementation: CurrentSessionCacheImplementation
 //    ) : CurrentSessionCache
+//
+//    @Binds
+//    @Singleton
+//    abstract fun bindDeviceCache(
+//        deviceCacheImplementation: DeviceCacheImplementation
+//    ) : DeviceCache
 //}
 
 // TODO: ⚠️ For development only: wipe database on every launch
@@ -41,6 +49,14 @@ object CacheModule {
                 impl.clearSession()
             }
         }
+        return impl
+    }
+
+    @Provides
+    @Singleton
+    fun provideDeviceCache(
+        impl: DeviceCacheImplementation
+    ): DeviceCache {
         return impl
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/DataStoreModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/DataStoreModule.kt
@@ -5,7 +5,9 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.dataStoreFile
+import com.vci.vectorcamapp.core.data.cache.serializers.DeviceDtoSerializer
 import com.vci.vectorcamapp.core.data.cache.serializers.SessionDtoSerializer
+import com.vci.vectorcamapp.core.data.dto.DeviceDto
 import com.vci.vectorcamapp.core.data.dto.SessionDto
 import dagger.Module
 import dagger.Provides
@@ -18,6 +20,7 @@ import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
 
 private const val CURRENT_SESSION_DATA_STORE_FILE_NAME = "current_session.pb"
+private const val DEVICE_DATA_STORE_FILE_NAME = "device.pb"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -30,6 +33,17 @@ object DataStoreModule {
             serializer = SessionDtoSerializer,
             produceFile = { context.dataStoreFile(CURRENT_SESSION_DATA_STORE_FILE_NAME)},
             corruptionHandler = ReplaceFileCorruptionHandler { SessionDto() },
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+        )
+    }
+
+    @Provides
+    @Singleton
+    fun provideDeviceDataStore(@ApplicationContext context: Context) : DataStore<DeviceDto> {
+        return DataStoreFactory.create(
+            serializer = DeviceDtoSerializer,
+            produceFile = { context.dataStoreFile(DEVICE_DATA_STORE_FILE_NAME)},
+            corruptionHandler = ReplaceFileCorruptionHandler { DeviceDto() },
             scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
         )
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/cache/DeviceCache.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/cache/DeviceCache.kt
@@ -1,0 +1,9 @@
+package com.vci.vectorcamapp.core.domain.cache
+
+import com.vci.vectorcamapp.core.domain.model.Device
+
+interface DeviceCache {
+    suspend fun saveDevice(device: Device, programId: Int)
+    suspend fun getDevice(): Device?
+    suspend fun getProgramId(): Int?
+}


### PR DESCRIPTION
This pull request introduces a new `ProtoDataStore` implementation for persisting a unique device object locally using `kotlinx.serialization`. Rather than relying on a `.proto` schema, the device metadata is stored via a `DeviceDto` data class with custom serializers.

A domain-level `DeviceCache` interface has been defined, along with its implementation, `DeviceCacheImplementation`, which handles the conversion between the domain model and the serialized DTO. The cache persists key fields such as the device ID, model, registration timestamp, and associated program ID.

To support dependency injection, a Hilt module provides the configured `DataStore<DeviceDto>` instance. Logging was added to test and confirm that the device and program ID are correctly stored and retrieved, ensuring reliable state persistence across app sessions. This foundation will support device-level behavior such as tracking, analytics, and session attribution in future features.