### PR TITLE
SOF-219: Set up Ktor boilerplate code for constructing API requests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
     // Dagger Hilt Dependencies
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
     ksp(libs.hilt.android.compiler)
 
     // TensorFlow Lite Library

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,11 +23,17 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "BASE_URL", "\"https://api.vectorcam.org/\"")
+        }
+
         release {
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
+            
+            buildConfigField("String", "BASE_URL", "\"https://api.vectorcam.org/\"")
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
         <service
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
-            android:exported="false" />
+            tools:node="merge" />
 
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -37,6 +38,17 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             android:exported="false" />
+
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
 
     </application>
 

--- a/app/src/main/java/com/vci/vectorcamapp/VectorCamApp.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/VectorCamApp.kt
@@ -1,7 +1,19 @@
 package com.vci.vectorcamapp
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class VectorCamApp : Application()
+class VectorCamApp : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
@@ -1,0 +1,22 @@
+package com.vci.vectorcamapp.core.data.dto.session
+
+import com.vci.vectorcamapp.core.data.dto.serializers.UuidSerializer
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+data class PostSessionRequestDto(
+    @Serializable(with = UuidSerializer::class)
+    val frontendId: UUID = UUID(0, 0),
+    val houseNumber: String = "",
+    val collectorTitle: String = "",
+    val collectorName: String = "",
+    val collectionDate: Long = 0L,
+    val collectionMethod: String = "",
+    val specimenCondition: String = "",
+    val createdAt: Long = 0L,
+    val completedAt: Long = 0L,
+    val notes: String = "",
+    val siteId: Int = -1,
+    val deviceId: Int = -1,
+)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionResponseDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionResponseDto.kt
@@ -1,0 +1,9 @@
+package com.vci.vectorcamapp.core.data.dto.session
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PostSessionResponseDto(
+    val message: String = "",
+    val session: SessionResponseDto = SessionResponseDto(),
+)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionResponseDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionResponseDto.kt
@@ -1,0 +1,24 @@
+package com.vci.vectorcamapp.core.data.dto.session
+
+import com.vci.vectorcamapp.core.data.dto.serializers.UuidSerializer
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+data class SessionResponseDto(
+    val sessionId: Int = -1,
+    @Serializable(with = UuidSerializer::class)
+    val frontendId: UUID = UUID(0, 0),
+    val houseNumber: String = "",
+    val collectorTitle: String = "",
+    val collectorName: String = "",
+    val collectionDate: Long = 0L,
+    val collectionMethod: String = "",
+    val specimenCondition: String = "",
+    val createdAt: Long = 0L,
+    val completedAt: Long = 0L,
+    val submittedAt: Long = 0L,
+    val notes: String = "",
+    val siteId: Int = -1,
+    val deviceId: Int = -1,
+)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
@@ -1,0 +1,47 @@
+package com.vci.vectorcamapp.core.data.network.api
+
+import com.vci.vectorcamapp.core.data.dto.session.PostSessionRequestDto
+import com.vci.vectorcamapp.core.data.dto.session.PostSessionResponseDto
+import com.vci.vectorcamapp.core.data.network.constructUrl
+import com.vci.vectorcamapp.core.data.network.safeCall
+import com.vci.vectorcamapp.core.domain.model.Session
+import com.vci.vectorcamapp.core.domain.network.api.SessionDataSource
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.network.NetworkError
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import javax.inject.Inject
+
+class RemoteSessionDataSource @Inject constructor(
+    private val httpClient: HttpClient
+) : SessionDataSource {
+
+    override suspend fun postSession(session: Session, siteId: Int, deviceId: Int): Result<PostSessionResponseDto, NetworkError> {
+        if (session.completedAt == null) {
+            return Result.Error(NetworkError.SESSION_NOT_COMPLETED)
+        }
+
+        return safeCall<PostSessionResponseDto> {
+            httpClient.post(constructUrl("sessions")) {
+                contentType(ContentType.Application.Json)
+                setBody(PostSessionRequestDto(
+                    frontendId = session.localId,
+                    houseNumber = session.houseNumber,
+                    collectorTitle = session.collectorTitle,
+                    collectorName = session.collectorName,
+                    collectionDate = session.collectionDate,
+                    collectionMethod = session.collectionMethod,
+                    specimenCondition = session.specimenCondition,
+                    createdAt = session.createdAt,
+                    completedAt = session.completedAt,
+                    notes = session.notes,
+                    siteId = siteId,
+                    deviceId = deviceId,
+                ))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/constructUrl.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/constructUrl.kt
@@ -1,16 +1,11 @@
 package com.vci.vectorcamapp.core.data.network
 
-/* TODO: After getting a base URL from the API, do the following:
-*   1. Add BASE_URL to the Gradle BuildConfig for the release and debug build types. Make sure BASE_URL has a trailing /.
-*   2. Under buildFeatures, set buildConfig to true
-*   3. Replace BASE_URL with BuildConfig.BASE_URL
-*/
-const val BASE_URL = "" // Placeholder Variable
+import com.vci.vectorcamapp.BuildConfig
 
 fun constructUrl(url: String): String {
     return when {
-        url.contains(BASE_URL) -> url
-        url.startsWith("/") -> BASE_URL + url.drop(1)
-        else -> BASE_URL + url
+        url.contains(BuildConfig.BASE_URL) -> url
+        url.startsWith("/") -> BuildConfig.BASE_URL + url.drop(1)
+        else -> BuildConfig.BASE_URL + url
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/safeCall.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/safeCall.kt
@@ -6,6 +6,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.util.network.UnresolvedAddressException
 import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.SerializationException
+import java.net.UnknownHostException
 import kotlin.coroutines.coroutineContext
 
 suspend inline fun <reified T> safeCall(
@@ -14,6 +15,8 @@ suspend inline fun <reified T> safeCall(
     val response = try {
         execute()
     } catch (e: UnresolvedAddressException) {
+        return Result.Error(NetworkError.NO_INTERNET)
+    } catch (e: UnknownHostException) {
         return Result.Error(NetworkError.NO_INTERNET)
     } catch (e: SerializationException) {
         return Result.Error(NetworkError.SERIALIZATION)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
@@ -26,6 +26,10 @@ class SessionRepositoryImplementation @Inject constructor(
         }
     }
 
+    override suspend fun getSessionById(sessionId: UUID): Session? {
+        return sessionDao.getSessionById(sessionId)?.toDomain()
+    }
+
     override suspend fun deleteSession(session: Session, siteId: Int): Boolean {
         return sessionDao.deleteSession(session.toEntity(siteId)) > 0
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SessionDao.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/dao/SessionDao.kt
@@ -17,6 +17,9 @@ interface SessionDao {
     @Upsert
     suspend fun upsertSession(session: SessionEntity): Long
 
+    @Query("SELECT * FROM session WHERE localId = :sessionId")
+    suspend fun getSessionById(sessionId: UUID): SessionEntity?
+
     @Delete
     suspend fun deleteSession(session: SessionEntity): Int
 

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -29,7 +29,7 @@ class ImageUploadWorker @AssistedInject constructor(
 
         setForegroundAsync(createForegroundInfo())
 
-        val sessionId = inputData.getString("sessionId") ?: return Result.retry()
+        val sessionId = inputData.getString("session_id") ?: return Result.retry()
 
         try {
             for (i in 1..TOTAL_IMAGES) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -6,15 +6,19 @@ import android.content.Context
 import android.content.pm.ServiceInfo
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.vci.vectorcamapp.R
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.delay
 
-class ImageUploadWorker(
-    private val context: Context,
-    workerParams: WorkerParameters,
+@HiltWorker
+class ImageUploadWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
 ) : CoroutineWorker(context, workerParams) {
 
     private val notificationManager: NotificationManager =
@@ -23,15 +27,17 @@ class ImageUploadWorker(
     override suspend fun doWork(): Result {
         createNotificationChannel()
 
-        setForeground(createForegroundInfo())
+        setForegroundAsync(createForegroundInfo())
+
+        val sessionId = inputData.getString("sessionId") ?: return Result.retry()
 
         try {
             for (i in 1..TOTAL_IMAGES) {
                 // Simulate image upload
                 delay(1000)
+                Log.d("UploadWorker", "Uploading image $sessionId")
                 updateNotification(i)
             }
-
         } catch (e: Exception) {
             Log.d("UploadWorker", "Error during upload: ${e.message}")
             return Result.retry()

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -24,12 +24,11 @@ class ImageUploadWorker @AssistedInject constructor(
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    override suspend fun getForegroundInfo(): ForegroundInfo {
-        createNotificationChannel()
-        return createForegroundInfo()
-    }
-
     override suspend fun doWork(): Result {
+        createNotificationChannel()
+
+        setForeground(createForegroundInfo())
+
         val sessionId = inputData.getString("session_id") ?: return Result.retry()
 
         try {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -24,11 +24,12 @@ class ImageUploadWorker @AssistedInject constructor(
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    override suspend fun doWork(): Result {
+    override suspend fun getForegroundInfo(): ForegroundInfo {
         createNotificationChannel()
+        return createForegroundInfo()
+    }
 
-        setForegroundAsync(createForegroundInfo())
-
+    override suspend fun doWork(): Result {
         val sessionId = inputData.getString("session_id") ?: return Result.retry()
 
         try {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -6,17 +6,27 @@ import android.content.Context
 import android.content.pm.ServiceInfo
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.vci.vectorcamapp.R
+import com.vci.vectorcamapp.core.domain.network.api.SessionDataSource
+import com.vci.vectorcamapp.core.domain.repository.SessionRepository
+import com.vci.vectorcamapp.core.domain.util.onError
+import com.vci.vectorcamapp.core.domain.util.onSuccess
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.delay
+import java.util.UUID
 
-class MetadataUploadWorker(
-    private val context: Context,
-    workerParams: WorkerParameters,
-) : CoroutineWorker(context, workerParams
-) {
+@HiltWorker
+class MetadataUploadWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val sessionRepository: SessionRepository,
+    private val sessionDataSource: SessionDataSource,
+) : CoroutineWorker(context, workerParams) {
 
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -24,9 +34,24 @@ class MetadataUploadWorker(
     override suspend fun doWork(): Result {
         createNotificationChannel()
 
-        setForeground(createForegroundInfo())
+        setForegroundAsync(createForegroundInfo())
+
+        val session = inputData.getString("session_id")?.let { UUID.fromString(it) }
+            ?.let { sessionRepository.getSessionById(it) } ?: return Result.retry()
+        val siteId = inputData.getInt("site_id", -1)
+        val deviceId = inputData.getInt("device_id", -1)
+
+        if (siteId == -1 || deviceId == -1) return Result.retry()
 
         try {
+            // TODO: UPLOAD DEVICE FOR REGISTRATION IF POSSIBLE
+            // TODO: THIS IS JUST A TEST EXECUTION OF AN ENDPOINT. THIS ENTIRE ALGORITHM SHOULD BE REWRITTEN.
+            sessionDataSource.postSession(session, siteId, deviceId).onSuccess {
+                Log.d("UploadWorker", "Session uploaded successfully")
+            }.onError {
+                Log.d("UploadWorker", "Error during upload: $it")
+            }
+
             for (i in 1..TOTAL_DATAPOINTS) {
                 // Simulate metadata upload
                 delay(1000)
@@ -51,8 +76,7 @@ class MetadataUploadWorker(
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle("Session Metadata Upload in Progress")
             .setContentText("Uploading datapoint 0 of $TOTAL_DATAPOINTS")
-            .setProgress(TOTAL_DATAPOINTS, 0, false)
-            .setSmallIcon(R.drawable.ic_upload)
+            .setProgress(TOTAL_DATAPOINTS, 0, false).setSmallIcon(R.drawable.ic_upload)
             .setOngoing(true).build()
 
         return ForegroundInfo(
@@ -64,8 +88,7 @@ class MetadataUploadWorker(
         val updatedNotification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle("Session Metadata Upload in Progress")
             .setContentText("Uploading datapoint $counter of $TOTAL_DATAPOINTS")
-            .setProgress(TOTAL_DATAPOINTS, counter, false)
-            .setSmallIcon(R.drawable.ic_upload)
+            .setProgress(TOTAL_DATAPOINTS, counter, false).setSmallIcon(R.drawable.ic_upload)
             .setOngoing(true).build()
 
         notificationManager.notify(NOTIFICATION_ID, updatedNotification)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -31,11 +31,12 @@ class MetadataUploadWorker @AssistedInject constructor(
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    override suspend fun doWork(): Result {
+    override suspend fun getForegroundInfo(): ForegroundInfo {
         createNotificationChannel()
+        return createForegroundInfo()
+    }
 
-        setForegroundAsync(createForegroundInfo())
-
+    override suspend fun doWork(): Result {
         val session = inputData.getString("session_id")?.let { UUID.fromString(it) }
             ?.let { sessionRepository.getSessionById(it) } ?: return Result.retry()
         val siteId = inputData.getInt("site_id", -1)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -31,12 +31,11 @@ class MetadataUploadWorker @AssistedInject constructor(
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-    override suspend fun getForegroundInfo(): ForegroundInfo {
-        createNotificationChannel()
-        return createForegroundInfo()
-    }
-
     override suspend fun doWork(): Result {
+        createNotificationChannel()
+
+        setForeground(createForegroundInfo())
+
         val session = inputData.getString("session_id")?.let { UUID.fromString(it) }
             ?.let { sessionRepository.getSessionById(it) } ?: return Result.retry()
         val siteId = inputData.getInt("site_id", -1)
@@ -56,6 +55,7 @@ class MetadataUploadWorker @AssistedInject constructor(
             for (i in 1..TOTAL_DATAPOINTS) {
                 // Simulate metadata upload
                 delay(1000)
+                Log.d("UploadWorker", i.toString())
                 updateNotification(i)
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/CacheModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/CacheModule.kt
@@ -1,12 +1,13 @@
 package com.vci.vectorcamapp.core.di
 
+import android.os.Build
 import android.util.Log
 import com.vci.vectorcamapp.BuildConfig
 import com.vci.vectorcamapp.core.data.cache.CurrentSessionCacheImplementation
 import com.vci.vectorcamapp.core.data.cache.DeviceCacheImplementation
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.cache.DeviceCache
-import dagger.Binds
+import com.vci.vectorcamapp.core.domain.model.Device
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -57,6 +58,17 @@ object CacheModule {
     fun provideDeviceCache(
         impl: DeviceCacheImplementation
     ): DeviceCache {
+        if (BuildConfig.DEBUG) {
+            CoroutineScope(Dispatchers.IO).launch {
+                impl.saveDevice(
+                    Device(
+                        id = 1,
+                        model = Build.MANUFACTURER + " " + Build.MODEL,
+                        registeredAt = System.currentTimeMillis(),
+                    ), programId = 2
+                )
+            }
+        }
         return impl
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/DataSourceModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/DataSourceModule.kt
@@ -1,0 +1,20 @@
+package com.vci.vectorcamapp.core.di
+
+import com.vci.vectorcamapp.core.data.network.api.RemoteSessionDataSource
+import com.vci.vectorcamapp.core.domain.network.api.SessionDataSource
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSessionDataSource(
+        remoteSessionDataSource: RemoteSessionDataSource
+    ): SessionDataSource
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/NetworkModule.kt
@@ -1,22 +1,28 @@
-package com.vci.vectorcamapp.core.data.network
+package com.vci.vectorcamapp.core.di
 
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.ANDROID
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import javax.inject.Singleton
 
-object HttpClientFactory {
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
 
-    fun create(engine: HttpClientEngine): HttpClient {
-        return HttpClient(engine) {
+    @Provides
+    @Singleton
+    fun provideHttpClient(): HttpClient {
+        return HttpClient(Android) {
             install(Logging) {
                 level = LogLevel.ALL
                 logger = Logger.ANDROID
@@ -24,10 +30,9 @@ object HttpClientFactory {
             install(ContentNegotiation) {
                 json(json = Json {
                     ignoreUnknownKeys = true
+                    encodeDefaults = true
+                    prettyPrint = false
                 })
-            }
-            defaultRequest {
-                contentType(ContentType.Application.Json)
             }
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
@@ -45,11 +45,12 @@ object RoomDatabaseModule {
             if (BuildConfig.DEBUG) {
                 CoroutineScope(Dispatchers.IO).launch {
                     Log.w("VectorCamDatabase", "Clearing all tables (DEBUG only)")
-//                    clearAllTables()
+                    clearAllTables()
 
                     val seededPrograms = listOf(
-                        ProgramEntity(id = 1, name = "Uganda Surveillance Program", country = "Uganda"),
-                        ProgramEntity(id = 2, name = "Kenya Research Study", country = "Kenya")
+                        ProgramEntity(id = 1, name = "Test Program", country = "Singapore"),
+                        ProgramEntity(id = 2, name = "Uganda Ministry of Health", country = "Uganda"),
+                        ProgramEntity(id = 3, name = "Jhpiego", country = "India")
                     )
 
                     programDao.insertAll(seededPrograms)
@@ -57,39 +58,39 @@ object RoomDatabaseModule {
                     val seededSites = listOf(
                         SiteEntity(
                             id = 1,
-                            programId = 1,
+                            programId = 2,
                             district = "Mayuge",
-                            subCounty = "county1",
-                            parish = "Bukatube",
-                            sentinelSite = "Bukasero",
+                            subCounty = "County1",
+                            parish = "Parish1",
+                            sentinelSite = "Bukatube",
                             healthCenter = "Health Center 1"
                         ),
                         SiteEntity(
                             id = 2,
-                            programId = 1,
+                            programId = 2,
                             district = "Mayuge",
-                            subCounty = "county2",
-                            parish = "Malongo",
+                            subCounty = "County2",
+                            parish = "Parish2",
                             sentinelSite = "Namadhi",
                             healthCenter = "Health Center 2"
                         ),
                         SiteEntity(
                             id = 3,
-                            programId = 1,
+                            programId = 2,
                             district = "Adjumani",
-                            subCounty = "county3",
-                            parish = "Ofua",
-                            sentinelSite = "Ofua Site",
+                            subCounty = "County3",
+                            parish = "Parish3",
+                            sentinelSite = "Ofua",
                             healthCenter = "Health Center 3"
                         ),
                         SiteEntity(
                             id = 4,
-                            programId = 2,
-                            district = "Kisumu",
-                            subCounty = "Central",
-                            parish = "Market",
-                            sentinelSite = "Site B",
-                            healthCenter = "Health Center 2"
+                            programId = 3,
+                            district = "Ahmedabad",
+                            subCounty = "County4",
+                            parish = "Parish4",
+                            sentinelSite = "Vastrapur",
+                            healthCenter = "Health Center 4"
                         )
                     )
 

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
@@ -57,7 +57,7 @@ object RoomDatabaseModule {
 
                     val seededSites = listOf(
                         SiteEntity(
-                            id = 1,
+                            id = 2,
                             programId = 2,
                             district = "Mayuge",
                             subCounty = "County1",
@@ -66,7 +66,7 @@ object RoomDatabaseModule {
                             healthCenter = "Health Center 1"
                         ),
                         SiteEntity(
-                            id = 2,
+                            id = 3,
                             programId = 2,
                             district = "Mayuge",
                             subCounty = "County2",
@@ -75,7 +75,7 @@ object RoomDatabaseModule {
                             healthCenter = "Health Center 2"
                         ),
                         SiteEntity(
-                            id = 3,
+                            id = 4,
                             programId = 2,
                             district = "Adjumani",
                             subCounty = "County3",
@@ -84,7 +84,7 @@ object RoomDatabaseModule {
                             healthCenter = "Health Center 3"
                         ),
                         SiteEntity(
-                            id = 4,
+                            id = 5,
                             programId = 3,
                             district = "Ahmedabad",
                             subCounty = "County4",

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SessionDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SessionDataSource.kt
@@ -1,0 +1,10 @@
+package com.vci.vectorcamapp.core.domain.network.api
+
+import com.vci.vectorcamapp.core.data.dto.session.PostSessionResponseDto
+import com.vci.vectorcamapp.core.domain.model.Session
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.core.domain.util.network.NetworkError
+
+interface SessionDataSource {
+    suspend fun postSession(session: Session, siteId: Int, deviceId: Int): Result<PostSessionResponseDto, NetworkError>
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SessionRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/SessionRepository.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 
 interface SessionRepository {
     suspend fun upsertSession(session: Session, siteId: Int): Result<Unit, RoomDbError>
+    suspend fun getSessionById(sessionId: UUID): Session?
     suspend fun deleteSession(session: Session, siteId: Int): Boolean
     suspend fun markSessionAsComplete(sessionId: UUID): Boolean
     fun observeCompleteSessions(): Flow<List<Session>>

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/util/network/NetworkError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/util/network/NetworkError.kt
@@ -3,5 +3,14 @@ package com.vci.vectorcamapp.core.domain.util.network
 import com.vci.vectorcamapp.core.domain.util.Error
 
 enum class NetworkError : Error {
-    REQUEST_TIMEOUT, TOO_MANY_REQUESTS, NO_INTERNET, SERVER_ERROR, SERIALIZATION, UNKNOWN,
+    // Generic Errors
+    REQUEST_TIMEOUT,
+    TOO_MANY_REQUESTS,
+    NO_INTERNET,
+    SERVER_ERROR,
+    SERIALIZATION,
+    UNKNOWN,
+
+    // Endpoint-Specific Errors
+    SESSION_NOT_COMPLETED
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/network/NetworkErrorToString.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/network/NetworkErrorToString.kt
@@ -12,6 +12,8 @@ fun NetworkError.toString(context: Context): String {
         NetworkError.SERVER_ERROR -> R.string.network_error_server_error
         NetworkError.SERIALIZATION -> R.string.network_error_serialization
         NetworkError.UNKNOWN -> R.string.network_error_unknown
+
+        NetworkError.SESSION_NOT_COMPLETED -> R.string.network_error_session_not_completed
     }
     return context.getString(resId)
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -179,7 +179,6 @@ class ImagingViewModel @Inject constructor(
                                 WorkRequest.MIN_BACKOFF_MILLIS,
                                 TimeUnit.MILLISECONDS,
                             )
-                            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                             .build()
 
                         val imageUploadRequest = OneTimeWorkRequestBuilder<ImageUploadWorker>()
@@ -190,7 +189,6 @@ class ImagingViewModel @Inject constructor(
                                 WorkRequest.MIN_BACKOFF_MILLIS,
                                 TimeUnit.MILLISECONDS,
                             )
-                            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                             .build()
 
                         WorkManager.getInstance(context).beginUniqueWork(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -9,12 +9,15 @@ import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
+import androidx.work.workDataOf
 import com.vci.vectorcamapp.core.data.room.TransactionHelper
 import com.vci.vectorcamapp.core.data.upload.image.ImageUploadWorker
 import com.vci.vectorcamapp.core.data.upload.metadata.MetadataUploadWorker
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
+import com.vci.vectorcamapp.core.domain.cache.DeviceCache
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.repository.BoundingBoxRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
@@ -50,6 +53,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ImagingViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
+    private val deviceCache: DeviceCache,
     private val currentSessionCache: CurrentSessionCache,
     private val sessionRepository: SessionRepository,
     private val specimenRepository: SpecimenRepository,
@@ -148,36 +152,45 @@ class ImagingViewModel @Inject constructor(
                 }
 
                 ImagingAction.SubmitSession -> {
+                    val device = deviceCache.getDevice()
                     val currentSession = currentSessionCache.getSession()
-                    if (currentSession == null) {
+                    val currentSessionSiteId = currentSessionCache.getSiteId()
+
+                    if (device == null || currentSession == null || currentSessionSiteId == null) {
                         _events.send(ImagingEvent.NavigateBackToLandingScreen)
                         return@launch
                     }
+
                     val success = sessionRepository.markSessionAsComplete(currentSession.localId)
                     if (success) {
-                        currentSessionCache.clearSession()
-                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
-
                         val uploadConstraints = Constraints.Builder()
                             .setRequiredNetworkType(NetworkType.CONNECTED)
                             .build()
 
                         val metadataUploadRequest = OneTimeWorkRequestBuilder<MetadataUploadWorker>()
+                            .setInputData(workDataOf(
+                                "session_id" to currentSession.localId.toString(),
+                                "site_id" to currentSessionSiteId,
+                                "device_id" to device.id
+                            ))
                             .setConstraints(uploadConstraints)
                             .setBackoffCriteria(
                                 BackoffPolicy.LINEAR,
                                 WorkRequest.MIN_BACKOFF_MILLIS,
                                 TimeUnit.MILLISECONDS,
                             )
+                            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                             .build()
 
                         val imageUploadRequest = OneTimeWorkRequestBuilder<ImageUploadWorker>()
+                            .setInputData(workDataOf("session_id" to currentSession.localId.toString()))
                             .setConstraints(uploadConstraints)
                             .setBackoffCriteria(
                                 BackoffPolicy.LINEAR,
                                 WorkRequest.MIN_BACKOFF_MILLIS,
                                 TimeUnit.MILLISECONDS,
                             )
+                            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                             .build()
 
                         WorkManager.getInstance(context).beginUniqueWork(
@@ -185,6 +198,9 @@ class ImagingViewModel @Inject constructor(
                             ExistingWorkPolicy.REPLACE,
                             metadataUploadRequest
                         ).then(imageUploadRequest).enqueue()
+
+                        currentSessionCache.clearSession()
+                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
                     }
                 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormViewModel.kt
@@ -352,7 +352,7 @@ class SurveillanceFormViewModel @Inject constructor(
                     isLoading = true
                 )
             }
-            val allSitesInProgram = siteRepository.getAllSitesByProgramId(1)
+            val allSitesInProgram = siteRepository.getAllSitesByProgramId(2)
             _state.update {
                 it.copy(
                     allSitesInProgram = allSitesInProgram

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,9 @@
     <!-- Network error: Unknown error -->
     <string name="network_error_unknown">An unknown error occurred. Please try again or contact support if the issue persists.</string>
 
+    <!-- Network error: Session not completed-->
+    <string name="network_error_session_not_completed">This session hasn\'t been marked as complete yet.</string>
+
     <!-- Form validation error: Blank collector title -->
     <string name="form_validation_error_blank_collector_title">Collector title is required.</string>
 
@@ -96,4 +99,5 @@
 
     <!-- RoomDb error: Unknown error -->
     <string name="roomdb_error_unknown_error">An unknown error occurred while saving data. Please contact support if this issue persists.</string>
+
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ coilCompose = "3.1.0"
 datastore = "1.1.5"
 hiltAndroid = "2.51.1"
 hiltNavigationCompose = "1.2.0"
+hiltWork = "1.2.0"
 kotlin = "2.0.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"
@@ -35,7 +36,9 @@ androidx-camera-video = { module = "androidx.camera:camera-video", version.ref =
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "cameraCoreVersion" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltWork" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "hiltWork" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-navigation-dynamic-features-fragment = { module = "androidx.navigation:navigation-dynamic-features-fragment", version.ref = "navigationCompose" }
 androidx-navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigationCompose" }


### PR DESCRIPTION
This PR introduces the boilerplate setup for making API requests using Ktor in the VectorCam app. The goal is to establish a clean and reusable networking foundation that will support communication with the backend services going forward.

The implementation includes the creation of a centralized HttpClient object, which configures the Ktor client with content negotiation (using kotlinx.serialization), request logging, and default headers. This setup ensures all requests share a consistent configuration and are ready for JSON-based communication with the server.

As part of this setup, a sample postSession endpoint has also been implemented. This provides a working reference for how other endpoints can be structured, including data mapping, request formatting, and response handling using Kotlin serialization and coroutine-based execution.

The current focus is to validate the client structure and confirm communication with the backend is working as expected. In future PRs, we’ll expand this by adding endpoints for metadata, specimen, and chunked image uploads, along with any necessary error handling and retry logic.

The setup was tested manually by running the app in a development environment and invoking the postSession endpoint with mock session data. Logcat was used to verify that the request payload was correctly formed and that the server responded as expected. On the backend side, the received session data was confirmed to be valid by inspecting logs and database entries. Additional testing should include simulating network failures to confirm retry behavior, checking that invalid or incomplete payloads are handled gracefully, and verifying that exceptions in the Ktor layer are correctly surfaced to the UI or logged for debugging. 