### PR TITLE
SOF-183: Fixed bounding box UI updates issue after imaging button is clicked

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -62,10 +62,10 @@ fun ImagingScreen(
                 )
             }
 
-            (state.currentImage != null && state.currentBoundingBoxUi != null) -> {
+            (state.currentImage != null && state.captureBoundingBoxUi != null) -> {
                 CapturedSpecimenOverlay(
                     specimen = state.currentSpecimen,
-                    boundingBoxUi = state.currentBoundingBoxUi,
+                    boundingBoxUi = state.captureBoundingBoxUi,
                     modifier = modifier,
                     specimenBitmap = state.currentImage,
                     onSpecimenIdCorrected = { onAction(ImagingAction.CorrectSpecimenId(it)) },

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -77,7 +77,7 @@ fun ImagingScreen(
             else -> {
                 LiveCameraPreviewPage(
                     controller = controller,
-                    boundingBoxUi = state.currentBoundingBoxUi,
+                    boundingBoxUi = state.previewBoundingBoxUi,
                     onImageCaptured = { onAction(ImagingAction.CaptureImage(controller)) },
                     onSaveSessionProgress = { onAction(ImagingAction.SaveSessionProgress) },
                     onSubmitSession = { onAction(ImagingAction.SubmitSession) },

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -17,7 +17,7 @@ data class ImagingState(
         capturedAt = 0L,
     ),
     val currentImage: Bitmap? = null,
-    val currentBoundingBoxUi: BoundingBoxUi? = null,
+    val captureBoundingBoxUi: BoundingBoxUi? = null,
     val previewBoundingBoxUi: BoundingBoxUi? = null,
     val capturedSpecimensAndBoundingBoxesUi: List<SpecimenAndBoundingBoxUi> = emptyList()
 )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -18,5 +18,6 @@ data class ImagingState(
     ),
     val currentImage: Bitmap? = null,
     val currentBoundingBoxUi: BoundingBoxUi? = null,
+    val previewBoundingBoxUi: BoundingBoxUi? = null,
     val capturedSpecimensAndBoundingBoxesUi: List<SpecimenAndBoundingBoxUi> = emptyList()
 )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -131,9 +131,10 @@ class ImagingViewModel @Inject constructor(
                         _state.update {
                             it.copy(
                                 currentSpecimen = it.currentSpecimen.copy(id = specimenId),
-                                currentBoundingBoxUi = boundingBox?.let { boundingBox ->
-                                    inferenceRepository.convertToBoundingBoxUi(boundingBox)
-                                })
+                                previewBoundingBoxUi = boundingBox?.let { box ->
+                                    inferenceRepository.convertToBoundingBoxUi(box)
+                                }
+                            )
                         }
                     } catch (e: Exception) {
                         Log.e("ViewModel", "Image processing setup failed: ${e.message}")
@@ -210,7 +211,10 @@ class ImagingViewModel @Inject constructor(
                                         species = species.label,
                                         sex = sex?.label,
                                         abdomenStatus = abdomenStatus?.label,
-                                    ), currentImage = bitmap
+                                    ),
+                                    currentImage = bitmap,
+                                    currentBoundingBoxUi = it.previewBoundingBoxUi,
+                                    previewBoundingBoxUi = null
                                 )
                             }
                         } else {
@@ -301,6 +305,7 @@ class ImagingViewModel @Inject constructor(
                 ),
                 currentImage = null,
                 currentBoundingBoxUi = null,
+                previewBoundingBoxUi = null,
             )
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -131,8 +131,10 @@ class ImagingViewModel @Inject constructor(
                         _state.update {
                             it.copy(
                                 currentSpecimen = it.currentSpecimen.copy(id = specimenId),
-                                previewBoundingBoxUi = boundingBox?.let { box ->
-                                    inferenceRepository.convertToBoundingBoxUi(box)
+                                previewBoundingBoxUi = if (it.captureBoundingBoxUi == null && boundingBox != null) {
+                                    inferenceRepository.convertToBoundingBoxUi(boundingBox)
+                                } else {
+                                    it.previewBoundingBoxUi
                                 }
                             )
                         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -213,7 +213,7 @@ class ImagingViewModel @Inject constructor(
                                         abdomenStatus = abdomenStatus?.label,
                                     ),
                                     currentImage = bitmap,
-                                    currentBoundingBoxUi = it.previewBoundingBoxUi,
+                                    captureBoundingBoxUi = it.previewBoundingBoxUi,
                                     previewBoundingBoxUi = null
                                 )
                             }
@@ -263,7 +263,7 @@ class ImagingViewModel @Inject constructor(
 
                         val success = transactionHelper.runAsTransaction {
                             val boundingBoxUi =
-                                _state.value.currentBoundingBoxUi ?: return@runAsTransaction false
+                                _state.value.captureBoundingBoxUi ?: return@runAsTransaction false
                             val boundingBox = inferenceRepository.convertToBoundingBox(
                                 boundingBoxUi
                             )
@@ -304,7 +304,7 @@ class ImagingViewModel @Inject constructor(
                     id = "", species = null, sex = null, abdomenStatus = null
                 ),
                 currentImage = null,
-                currentBoundingBoxUi = null,
+                captureBoundingBoxUi = null,
                 previewBoundingBoxUi = null,
             )
         }


### PR DESCRIPTION
This pull request fixes an issue on the Imaging screen where the bounding box appears in the wrong position if the phone is rotated immediately after the imaging button is clicked. To resolve this issue, I added a previewBoundingBoxUi property in the ImagingState. This separates the bounding box used for the live preview from the one associated with the actual capture. To improve clarity, I also renamed the original currentBoundingBoxUi to captureBoundingBoxUi. The code was tested on a physical device.