### PR TITLE
SOF-151: Allow users to tap on any incomplete session to reopen it and continue capturing data.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionAction.kt
@@ -1,0 +1,7 @@
+package com.vci.vectorcamapp.incomplete_session.presentation
+
+import java.util.UUID
+
+sealed interface IncompleteSessionAction {
+    data class ResumeSession(val sessionId: UUID) : IncompleteSessionAction
+}

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
@@ -1,0 +1,5 @@
+package com.vci.vectorcamapp.incomplete_session.presentation
+
+sealed interface IncompleteSessionEvent {
+    object NavigateToSurveillanceForm : IncompleteSessionEvent
+}

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
@@ -1,5 +1,5 @@
 package com.vci.vectorcamapp.incomplete_session.presentation
 
 sealed interface IncompleteSessionEvent {
-    object NavigateToSurveillanceForm : IncompleteSessionEvent
+    data object NavigateToSurveillanceForm : IncompleteSessionEvent
 }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -9,10 +9,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.vci.vectorcamapp.incomplete_session.presentation.components.IncompleteSessionCard
+import java.util.UUID
 
 @Composable
 fun IncompleteSessionScreen(
     state: IncompleteSessionState,
+    onResumeSession: (UUID) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -22,7 +24,10 @@ fun IncompleteSessionScreen(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         items(items = state.sessions.asReversed(), key = { it.localId }) { session ->
-            IncompleteSessionCard(session = session, modifier = modifier)
+            IncompleteSessionCard(session = session,
+                onClick = { onResumeSession(session.localId) },
+                modifier = modifier
+            )
         }
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @Composable
 fun IncompleteSessionScreen(
     state: IncompleteSessionState,
-    onResumeSession: (UUID) -> Unit,
+    onAction: (IncompleteSessionAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -25,7 +25,7 @@ fun IncompleteSessionScreen(
     ) {
         items(items = state.sessions.asReversed(), key = { it.localId }) { session ->
             IncompleteSessionCard(session = session,
-                onClick = { onResumeSession(session.localId) },
+                onClick = { onAction(IncompleteSessionAction.ResumeSession(session.localId)) },
                 modifier = modifier
             )
         }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
@@ -2,17 +2,22 @@ package com.vci.vectorcamapp.incomplete_session.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class IncompleteSessionViewModel @Inject constructor(
-    sessionRepository: SessionRepository
+    private val sessionRepository: SessionRepository,
+    private val currentSessionCache: CurrentSessionCache
 ) : ViewModel() {
 
     private val _incompleteSessions = sessionRepository.observeIncompleteSessions()
@@ -23,4 +28,24 @@ class IncompleteSessionViewModel @Inject constructor(
             sessions = incompleteSessions
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), IncompleteSessionState())
+
+    private val _events = Channel<IncompleteSessionEvent>()
+    val events = _events.receiveAsFlow()
+
+    fun onAction(action: IncompleteSessionAction) {
+        viewModelScope.launch {
+            when (action) {
+                is IncompleteSessionAction.ResumeSession -> {
+                    val relation = sessionRepository.getSessionAndSiteById(action.sessionId)
+                    if (relation != null) {
+                        currentSessionCache.saveSession(
+                            relation.session,
+                            relation.site.id
+                        )
+                        _events.send(IncompleteSessionEvent.NavigateToSurveillanceForm)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.incomplete_session.presentation.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,13 +20,16 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 @Composable
-fun IncompleteSessionCard(session: Session, modifier: Modifier = Modifier) {
+fun IncompleteSessionCard(session: Session, onClick: () -> Unit, modifier: Modifier = Modifier) {
 
     val dateTimeFormatter = remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
     val formattedDateTime = dateTimeFormatter.format(session.createdAt)
 
     Card(
-        modifier = modifier.fillMaxWidth().wrapContentHeight(),
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .clickable(onClick = onClick),
         shape = MaterialTheme.shapes.medium,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant

--- a/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
@@ -39,6 +39,8 @@ import com.vci.vectorcamapp.complete_session.list.presentation.CompleteSessionLi
 import com.vci.vectorcamapp.complete_session.specimens.presentation.CompleteSessionSpecimensAction
 import com.vci.vectorcamapp.complete_session.specimens.presentation.CompleteSessionSpecimensScreen
 import com.vci.vectorcamapp.complete_session.specimens.presentation.CompleteSessionSpecimensViewModel
+import com.vci.vectorcamapp.incomplete_session.presentation.IncompleteSessionAction
+import com.vci.vectorcamapp.incomplete_session.presentation.IncompleteSessionEvent
 import com.vci.vectorcamapp.incomplete_session.presentation.IncompleteSessionScreen
 import com.vci.vectorcamapp.incomplete_session.presentation.IncompleteSessionViewModel
 import com.vci.vectorcamapp.registration.presentation.RegistrationEvent
@@ -179,21 +181,20 @@ fun NavGraph(startDestination: Destination) {
         composable<Destination.IncompleteSession> {
             val viewModel = hiltViewModel<IncompleteSessionViewModel>()
             val state by viewModel.state.collectAsStateWithLifecycle()
-
-            Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                IncompleteSessionScreen(
-                    state = state,
-                    modifier = Modifier.padding(innerPadding)
-                )
+            ObserveAsEvents(events = viewModel.events) { event ->
+                when (event) {
+                    IncompleteSessionEvent.NavigateToSurveillanceForm ->
+                        navController.navigate(Destination.SurveillanceForm)
+                }
             }
-        }
-        composable<Destination.IncompleteSession> {
-            val viewModel = hiltViewModel<IncompleteSessionViewModel>()
-            val state by viewModel.state.collectAsStateWithLifecycle()
-
             Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                 IncompleteSessionScreen(
                     state = state,
+                    onResumeSession = { sessionId ->
+                        viewModel.onAction(
+                            IncompleteSessionAction.ResumeSession(sessionId)
+                        )
+                    },
                     modifier = Modifier.padding(innerPadding)
                 )
             }

--- a/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
@@ -76,7 +76,7 @@ fun NavGraph(startDestination: Destination) {
             }
 
             Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                RegistrationScreen(
+                 RegistrationScreen(
                     state = state,
                     onAction = viewModel::onAction,
                     modifier = Modifier.padding(innerPadding)
@@ -190,11 +190,7 @@ fun NavGraph(startDestination: Destination) {
             Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                 IncompleteSessionScreen(
                     state = state,
-                    onResumeSession = { sessionId ->
-                        viewModel.onAction(
-                            IncompleteSessionAction.ResumeSession(sessionId)
-                        )
-                    },
+                    onAction = viewModel::onAction,
                     modifier = Modifier.padding(innerPadding)
                 )
             }


### PR DESCRIPTION
This pull request introduced functionalities that allows users to continue an existing incomplete session. When in the incomplete session screen, user would be able to click on an session, upon clicking that session will be loaded into the current session cache, user will then be directed to the surveillance form screen, where the resume session logic will pick up this session from the cache and load information into the form. 

Also removed duplicate code for incomplete session in NavGraph.