### PR TITLE
SOF-246: Fix the UI of the surveillance form to remove default integer values

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
@@ -159,12 +159,11 @@ fun SurveillanceFormScreen(
 
                 TextEntryField(
                     label = "Number of House Occupants",
-                    value = state.surveillanceForm.numPeopleSleptInHouse.toString(),
+                    value = if (state.surveillanceForm.numPeopleSleptInHouse == 0) "" else state.surveillanceForm.numPeopleSleptInHouse.toString(),
                     onValueChange = {
-                        onAction(SurveillanceFormAction.EnterNumPeopleSleptInHouse(
-                            sanitizeNumericInput(it, state.surveillanceForm.numPeopleSleptInHouse)
-                        ))
+                        onAction(SurveillanceFormAction.EnterNumPeopleSleptInHouse(it.filter { c -> c.isDigit() }))
                     },
+                    placeholder = "0",
                     singleLine = true,
                     keyboardType = KeyboardType.Number,
                 )
@@ -233,12 +232,11 @@ fun SurveillanceFormScreen(
             SectionCard(sectionTitle = "Surveillance Form") {
                 TextEntryField(
                     label = "Number of LLINs Available",
-                    value = state.surveillanceForm.numLlinsAvailable.toString(),
+                    value = if (state.surveillanceForm.numLlinsAvailable == 0) "" else state.surveillanceForm.numLlinsAvailable.toString(),
                     onValueChange = {
-                        onAction(SurveillanceFormAction.EnterNumLlinsAvailable(
-                            sanitizeNumericInput(it, state.surveillanceForm.numLlinsAvailable)
-                        ))
+                        onAction(SurveillanceFormAction.EnterNumLlinsAvailable(it.filter { c -> c.isDigit() }))
                     },
+                    placeholder = "0",
                     singleLine = true,
                     keyboardType = KeyboardType.Number
                 )
@@ -273,12 +271,11 @@ fun SurveillanceFormScreen(
                 state.surveillanceForm.numPeopleSleptUnderLlin?.let { current ->
                     TextEntryField(
                         label = "Number of People who Slept Under LLIN",
-                        value = current.toString(),
+                        value = if (current == 0) "" else current.toString(),
                         onValueChange = {
-                            onAction(SurveillanceFormAction.EnterNumPeopleSleptUnderLlin(
-                                sanitizeNumericInput(it, state.surveillanceForm.numPeopleSleptUnderLlin)
-                            ))
+                            onAction(SurveillanceFormAction.EnterNumPeopleSleptUnderLlin(it.filter { c -> c.isDigit() }))
                         },
+                        placeholder = "0",
                         singleLine = true,
                         keyboardType = KeyboardType.Number
                     )
@@ -301,12 +298,11 @@ fun SurveillanceFormScreen(
                 if (state.surveillanceForm.wasIrsConducted) {
                     TextEntryField(
                         label = "Months Since IRS",
-                        value = state.surveillanceForm.monthsSinceIrs?.toString().orEmpty(),
+                        value = state.surveillanceForm.monthsSinceIrs?.let { if (it == 0) "" else it.toString() }.orEmpty(),
                         onValueChange = {
-                            onAction(SurveillanceFormAction.EnterMonthsSinceIrs(
-                                sanitizeNumericInput(it, state.surveillanceForm.monthsSinceIrs)
-                            ))
+                            onAction(SurveillanceFormAction.EnterMonthsSinceIrs(it.filter { c -> c.isDigit() }))
                         },
+                        placeholder = "0",
                         singleLine = true,
                         keyboardType = KeyboardType.Number,
                     )

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
@@ -161,7 +161,9 @@ fun SurveillanceFormScreen(
                     label = "Number of House Occupants",
                     value = state.surveillanceForm.numPeopleSleptInHouse.toString(),
                     onValueChange = {
-                        onAction(SurveillanceFormAction.EnterNumPeopleSleptInHouse(it))
+                        onAction(SurveillanceFormAction.EnterNumPeopleSleptInHouse(
+                            sanitizeNumericInput(it, state.surveillanceForm.numPeopleSleptInHouse)
+                        ))
                     },
                     singleLine = true,
                     keyboardType = KeyboardType.Number,
@@ -233,11 +235,9 @@ fun SurveillanceFormScreen(
                     label = "Number of LLINs Available",
                     value = state.surveillanceForm.numLlinsAvailable.toString(),
                     onValueChange = {
-                        onAction(
-                            SurveillanceFormAction.EnterNumLlinsAvailable(
-                                it
-                            )
-                        )
+                        onAction(SurveillanceFormAction.EnterNumLlinsAvailable(
+                            sanitizeNumericInput(it, state.surveillanceForm.numLlinsAvailable)
+                        ))
                     },
                     singleLine = true,
                     keyboardType = KeyboardType.Number
@@ -275,7 +275,9 @@ fun SurveillanceFormScreen(
                         label = "Number of People who Slept Under LLIN",
                         value = current.toString(),
                         onValueChange = {
-                            onAction(SurveillanceFormAction.EnterNumPeopleSleptUnderLlin(it))
+                            onAction(SurveillanceFormAction.EnterNumPeopleSleptUnderLlin(
+                                sanitizeNumericInput(it, state.surveillanceForm.numPeopleSleptUnderLlin)
+                            ))
                         },
                         singleLine = true,
                         keyboardType = KeyboardType.Number
@@ -301,11 +303,9 @@ fun SurveillanceFormScreen(
                         label = "Months Since IRS",
                         value = state.surveillanceForm.monthsSinceIrs?.toString().orEmpty(),
                         onValueChange = {
-                            onAction(
-                                SurveillanceFormAction.EnterMonthsSinceIrs(
-                                    it
-                                )
-                            )
+                            onAction(SurveillanceFormAction.EnterMonthsSinceIrs(
+                                sanitizeNumericInput(it, state.surveillanceForm.monthsSinceIrs)
+                            ))
                         },
                         singleLine = true,
                         keyboardType = KeyboardType.Number,
@@ -372,5 +372,14 @@ fun SurveillanceFormScreenPreview() {
                 modifier = Modifier.padding(innerPadding)
             )
         }
+    }
+}
+
+private fun sanitizeNumericInput(newValue: String, oldValue: Int?): String {
+    val digits = newValue.filter { it.isDigit() }
+    return if (oldValue == 0 && digits.length > 1) {
+        digits.replace("0", "")
+    } else {
+        digits
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
@@ -370,12 +370,3 @@ fun SurveillanceFormScreenPreview() {
         }
     }
 }
-
-private fun sanitizeNumericInput(newValue: String, oldValue: Int?): String {
-    val digits = newValue.filter { it.isDigit() }
-    return if (oldValue == 0 && digits.length > 1) {
-        digits.replace("0", "")
-    } else {
-        digits
-    }
-}

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
@@ -161,7 +161,7 @@ fun SurveillanceFormScreen(
                     label = "Number of House Occupants",
                     value = if (state.surveillanceForm.numPeopleSleptInHouse == 0) "" else state.surveillanceForm.numPeopleSleptInHouse.toString(),
                     onValueChange = {
-                        onAction(SurveillanceFormAction.EnterNumPeopleSleptInHouse(it.filter { c -> c.isDigit() }))
+                        onAction(SurveillanceFormAction.EnterNumPeopleSleptInHouse(it.filter { character -> character.isDigit() }))
                     },
                     placeholder = "0",
                     singleLine = true,
@@ -234,7 +234,7 @@ fun SurveillanceFormScreen(
                     label = "Number of LLINs Available",
                     value = if (state.surveillanceForm.numLlinsAvailable == 0) "" else state.surveillanceForm.numLlinsAvailable.toString(),
                     onValueChange = {
-                        onAction(SurveillanceFormAction.EnterNumLlinsAvailable(it.filter { c -> c.isDigit() }))
+                        onAction(SurveillanceFormAction.EnterNumLlinsAvailable(it.filter { character -> character.isDigit() }))
                     },
                     placeholder = "0",
                     singleLine = true,
@@ -273,7 +273,7 @@ fun SurveillanceFormScreen(
                         label = "Number of People who Slept Under LLIN",
                         value = if (current == 0) "" else current.toString(),
                         onValueChange = {
-                            onAction(SurveillanceFormAction.EnterNumPeopleSleptUnderLlin(it.filter { c -> c.isDigit() }))
+                            onAction(SurveillanceFormAction.EnterNumPeopleSleptUnderLlin(it.filter { character -> character.isDigit() }))
                         },
                         placeholder = "0",
                         singleLine = true,
@@ -300,7 +300,7 @@ fun SurveillanceFormScreen(
                         label = "Months Since IRS",
                         value = state.surveillanceForm.monthsSinceIrs?.let { if (it == 0) "" else it.toString() }.orEmpty(),
                         onValueChange = {
-                            onAction(SurveillanceFormAction.EnterMonthsSinceIrs(it.filter { c -> c.isDigit() }))
+                            onAction(SurveillanceFormAction.EnterMonthsSinceIrs(it.filter { character -> character.isDigit() }))
                         },
                         placeholder = "0",
                         singleLine = true,

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/components/TextEntryField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/components/TextEntryField.kt
@@ -23,7 +23,8 @@ fun TextEntryField(
     modifier: Modifier = Modifier,
     singleLine: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
-    error: FormValidationError? = null
+    error: FormValidationError? = null,
+    placeholder: String? = null
 ) {
     val context = LocalContext.current
 
@@ -42,6 +43,11 @@ fun TextEntryField(
             isError = error != null,
             singleLine = singleLine,
             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            placeholder = {
+                if (placeholder != null) {
+                    Text(text = placeholder)
+                }
+            },
             modifier = Modifier.fillMaxWidth()
         )
 


### PR DESCRIPTION
This PR introduced sanitization for numeric inputs in surveillance form. The inputs used to be taken as integers, so the default 0 would persist and inputs such as adding X to before or after the 0 will become X0 or 0X. Now, the initial 0 would work as a placeholder and any input would override it. There was also an issue with 2 inputs at the same time when the field is 0, where only one input would register. This issue have been resolved.