### PR TITLE
SOF-260: Display number of incomplete sessions in main screen

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
@@ -63,7 +63,8 @@ fun LandingScreen(
                         title = "View Incomplete Sessions",
                         description = "Resume and complete any unfinished sessions.",
                         icon = painterResource(R.drawable.landing_incomplete_sessions_icon),
-                        onClick = { onAction(LandingAction.ViewIncompleteSessions) })
+                        onClick = { onAction(LandingAction.ViewIncompleteSessions) },
+                        badgeCount = state.incompleteSessionsCount)
 
                     LandingActionTile(
                         title = "View Complete Sessions",

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingState.kt
@@ -9,5 +9,6 @@ data class LandingState(
         name = "",
         country = ""
     ),
-    val showResumeDialog: Boolean = false
+    val showResumeDialog: Boolean = false,
+    val incompleteSessionsCount: Int = 0
 )

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.cache.DeviceCache
 import com.vci.vectorcamapp.core.domain.repository.ProgramRepository
+import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.presentation.CoreViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -23,11 +24,13 @@ class LandingViewModel @Inject constructor(
     private val deviceCache: DeviceCache,
     private val currentSessionCache: CurrentSessionCache,
     private val programRepository: ProgramRepository,
+    private val sessionRepository: SessionRepository,
 ) : CoreViewModel() {
 
     private val _state = MutableStateFlow(LandingState())
     val state: StateFlow<LandingState> = _state.onStart {
         loadLandingDetails()
+        observeIncompleteSessionsCount()
     }.stateIn(
         viewModelScope, SharingStarted.WhileSubscribed(5000L), LandingState()
     )
@@ -94,6 +97,14 @@ class LandingViewModel @Inject constructor(
                 it.copy(
                     enrolledProgram = program, isLoading = false
                 )
+            }
+        }
+    }
+
+    private fun observeIncompleteSessionsCount() {
+        viewModelScope.launch {
+            sessionRepository.observeIncompleteSessions().collect { sessions ->
+                _state.update { it.copy(incompleteSessionsCount = sessions.size) }
             }
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -29,17 +29,18 @@ class LandingViewModel @Inject constructor(
     sessionRepository: SessionRepository,
 ) : CoreViewModel() {
 
-    private val _state = MutableStateFlow(LandingState())
-
     private val _incompleteSessionsCount = sessionRepository.observeIncompleteSessions()
         .map { it.size }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 0)
 
+    private val _state = MutableStateFlow(LandingState())
     val state: StateFlow<LandingState> = combine(
         _state,
         _incompleteSessionsCount
     ) { state, incompleteSessionsCount ->
         state.copy(incompleteSessionsCount = incompleteSessionsCount)
+    }.onStart {
+        loadLandingDetails()
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5000L),
@@ -48,10 +49,6 @@ class LandingViewModel @Inject constructor(
 
     private val _events = Channel<LandingEvent>()
     val events = _events.receiveAsFlow()
-
-    init {
-        loadLandingDetails()
-    }
 
     fun onAction(action: LandingAction) {
         viewModelScope.launch {
@@ -94,12 +91,14 @@ class LandingViewModel @Inject constructor(
             val programId = deviceCache.getProgramId()
             if (programId == null) {
                 _events.send(LandingEvent.NavigateBackToRegistrationScreen)
+                _state.update { it.copy(isLoading = false) }
                 return@launch
             }
 
             val program = programRepository.getProgramById(programId)
             if (program == null) {
                 _events.send(LandingEvent.NavigateBackToRegistrationScreen)
+                _state.update { it.copy(isLoading = false) }
                 return@launch
             }
 

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -42,7 +42,7 @@ class LandingViewModel @Inject constructor(
         state.copy(incompleteSessionsCount = incompleteSessionsCount)
     }.stateIn(
         viewModelScope,
-        SharingStarted.WhileSubscribed(),
+        SharingStarted.WhileSubscribed(5000L),
         LandingState()
     )
 

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -28,15 +30,28 @@ class LandingViewModel @Inject constructor(
 ) : CoreViewModel() {
 
     private val _state = MutableStateFlow(LandingState())
-    val state: StateFlow<LandingState> = _state.onStart {
-        loadLandingDetails()
-        observeIncompleteSessionsCount()
+
+    private val _incompleteSessionsCount = sessionRepository.observeIncompleteSessions()
+        .map { it.size }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), 0)
+
+    val state: StateFlow<LandingState> = combine(
+        _state,
+        _incompleteSessionsCount
+    ) { state, incompleteSessionsCount ->
+        state.copy(incompleteSessionsCount = incompleteSessionsCount)
     }.stateIn(
-        viewModelScope, SharingStarted.WhileSubscribed(5000L), LandingState()
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000L),
+        LandingState()
     )
 
     private val _events = Channel<LandingEvent>()
     val events = _events.receiveAsFlow()
+
+    init {
+        loadLandingDetails()
+    }
 
     fun onAction(action: LandingAction) {
         viewModelScope.launch {
@@ -99,9 +114,7 @@ class LandingViewModel @Inject constructor(
                 )
             }
         }
-    }
 
-    private fun observeIncompleteSessionsCount() {
         viewModelScope.launch {
             sessionRepository.observeIncompleteSessions().collect { sessions ->
                 _state.update { it.copy(incompleteSessionsCount = sessions.size) }
@@ -109,3 +122,4 @@ class LandingViewModel @Inject constructor(
         }
     }
 }
+

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -26,14 +26,14 @@ class LandingViewModel @Inject constructor(
     private val deviceCache: DeviceCache,
     private val currentSessionCache: CurrentSessionCache,
     private val programRepository: ProgramRepository,
-    private val sessionRepository: SessionRepository,
+    sessionRepository: SessionRepository,
 ) : CoreViewModel() {
 
     private val _state = MutableStateFlow(LandingState())
 
     private val _incompleteSessionsCount = sessionRepository.observeIncompleteSessions()
         .map { it.size }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), 0)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), 0)
 
     val state: StateFlow<LandingState> = combine(
         _state,
@@ -42,7 +42,7 @@ class LandingViewModel @Inject constructor(
         state.copy(incompleteSessionsCount = incompleteSessionsCount)
     }.stateIn(
         viewModelScope,
-        SharingStarted.WhileSubscribed(5000L),
+        SharingStarted.WhileSubscribed(),
         LandingState()
     )
 
@@ -112,12 +112,6 @@ class LandingViewModel @Inject constructor(
                 it.copy(
                     enrolledProgram = program, isLoading = false
                 )
-            }
-        }
-
-        viewModelScope.launch {
-            sessionRepository.observeIncompleteSessions().collect { sessions ->
-                _state.update { it.copy(incompleteSessionsCount = sessions.size) }
             }
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/components/LandingActionTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/components/LandingActionTile.kt
@@ -6,11 +6,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -45,33 +45,37 @@ fun LandingActionTile(
                 .fillMaxWidth()
                 .padding(MaterialTheme.dimensions.paddingMedium)
         ) {
-            BadgedBox(
-                badge = {
-                    if (badgeCount > 0) {
-                        Badge(containerColor = MaterialTheme.colors.error) {
-                            Text(
-                                text = badgeCount.toString(),
-                                color = MaterialTheme.colors.buttonText
-                            )
-                        }
-                    }
-                }
-            ) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier
-                        .size(MaterialTheme.dimensions.componentHeightLarge)
-                        .background(
-                            color = MaterialTheme.colors.iconBackground,
-                            shape = RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusMedium)
-                        )
-                ) {
-                    Icon(
-                        painter = icon,
-                        contentDescription = "Action Icon",
-                        tint = MaterialTheme.colors.icon,
-                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeLarge)
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .size(MaterialTheme.dimensions.componentHeightLarge)
+                    .background(
+                        color = MaterialTheme.colors.iconBackground,
+                        shape = RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusMedium)
                     )
+            ) {
+                Icon(
+                    painter = icon,
+                    contentDescription = "Action Icon",
+                    tint = MaterialTheme.colors.icon,
+                    modifier = Modifier.size(MaterialTheme.dimensions.iconSizeLarge)
+                )
+
+                if (badgeCount > 0) {
+                    Badge(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .offset(
+                                x = MaterialTheme.dimensions.paddingExtraSmall,
+                                y = -MaterialTheme.dimensions.paddingExtraSmall
+                            ),
+                        containerColor = MaterialTheme.colors.error
+                    ) {
+                        Text(
+                            text = badgeCount.toString(),
+                            color = MaterialTheme.colors.buttonText
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/components/LandingActionTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/components/LandingActionTile.kt
@@ -9,6 +9,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -22,13 +25,15 @@ import com.vci.vectorcamapp.core.presentation.components.ui.ActionTile
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LandingActionTile(
     title: String,
     description: String,
     icon: Painter,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    badgeCount: Int = 0
 ) {
 
     ActionTile(
@@ -40,21 +45,34 @@ fun LandingActionTile(
                 .fillMaxWidth()
                 .padding(MaterialTheme.dimensions.paddingMedium)
         ) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier
-                    .size(MaterialTheme.dimensions.componentHeightLarge)
-                    .background(
-                        color = MaterialTheme.colors.iconBackground,
-                        shape = RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusMedium)
-                    )
+            BadgedBox(
+                badge = {
+                    if (badgeCount > 0) {
+                        Badge(containerColor = MaterialTheme.colors.error) {
+                            Text(
+                                text = badgeCount.toString(),
+                                color = MaterialTheme.colors.buttonText
+                            )
+                        }
+                    }
+                }
             ) {
-                Icon(
-                    painter = icon,
-                    contentDescription = "Action Icon",
-                    tint = MaterialTheme.colors.icon,
-                    modifier = Modifier.size(MaterialTheme.dimensions.iconSizeLarge)
-                )
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .size(MaterialTheme.dimensions.componentHeightLarge)
+                        .background(
+                            color = MaterialTheme.colors.iconBackground,
+                            shape = RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusMedium)
+                        )
+                ) {
+                    Icon(
+                        painter = icon,
+                        contentDescription = "Action Icon",
+                        tint = MaterialTheme.colors.icon,
+                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeLarge)
+                    )
+                }
             }
 
             Column(

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/components/LandingActionTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/components/LandingActionTile.kt
@@ -25,7 +25,6 @@ import com.vci.vectorcamapp.core.presentation.components.ui.ActionTile
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LandingActionTile(
     title: String,


### PR DESCRIPTION
This PR added the functionality of displaying the number of incomplete session as a badge on landing screen. The code makes sure that the badge won't overlap with other text even if the number is large. Code is tested on a physical device both with the actual imcomplete session count and arbitrary large numbers, in this case 1000.