### PR TITLE
SOF-261: Bugfix for missing back handler in surveillance form

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormAction.kt
@@ -8,7 +8,7 @@ import com.vci.vectorcamapp.surveillance_form.domain.enums.SentinelSiteOption
 import com.vci.vectorcamapp.surveillance_form.domain.enums.SpecimenConditionOption
 
 sealed interface SurveillanceFormAction {
-    data object SaveSessionProgress: SurveillanceFormAction
+    data object ReturnToLandingScreen: SurveillanceFormAction
     data object SubmitSurveillanceForm: SurveillanceFormAction
     data class EnterCollectorTitle(val text: String) : SurveillanceFormAction
     data class EnterCollectorName(val text: String) : SurveillanceFormAction

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormScreen.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.surveillance_form.presentation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -49,6 +50,10 @@ fun SurveillanceFormScreen(
     onAction: (SurveillanceFormAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    BackHandler {
+        onAction(SurveillanceFormAction.ReturnToLandingScreen)
+    }
+
     ScreenHeader(
         title = "Surveillance Form",
         subtitle = "Fill out the information below",

--- a/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/surveillance_form/presentation/SurveillanceFormViewModel.kt
@@ -63,7 +63,7 @@ class SurveillanceFormViewModel @Inject constructor(
     fun onAction(action: SurveillanceFormAction) {
         viewModelScope.launch {
             when (action) {
-                SurveillanceFormAction.SaveSessionProgress -> {
+                SurveillanceFormAction.ReturnToLandingScreen -> {
                     currentSessionCache.clearSession()
                     _events.send(SurveillanceFormEvent.NavigateBackToLandingScreen)
                 }


### PR DESCRIPTION
This PR fixes an issue where back handler is missing in surveillance form, and thus current session cache is not cleared after pressing back from surveillance form screen, resulting in the popup asking to resume session showing up. This PR also renames an action for surveillance to a better name.