### PR TITLE
SOF-216: Fix discrepancy between Live camera inference and image picker.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/CameraRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/CameraRepository.kt
@@ -1,6 +1,5 @@
 package com.vci.vectorcamapp.imaging.domain.repository
 
-import android.graphics.Bitmap
 import android.net.Uri
 import androidx.camera.core.ImageProxy
 import androidx.camera.view.LifecycleCameraController
@@ -10,6 +9,6 @@ import com.vci.vectorcamapp.core.domain.util.Result
 
 interface CameraRepository {
     suspend fun captureImage(controller: LifecycleCameraController) : Result<ImageProxy, ImagingError>
-    suspend fun saveImage(bitmap: Bitmap, filename: String, currentSession: Session) : Result<Uri, ImagingError>
+    suspend fun saveImage(jpegBytes: ByteArray, filename: String, currentSession: Session) : Result<Uri, ImagingError>
     suspend fun deleteSavedImage(uri: Uri)
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.imaging.presentation
 
+import android.graphics.BitmapFactory
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
@@ -62,12 +63,16 @@ fun ImagingScreen(
                 )
             }
 
-            (state.currentImage != null && state.captureBoundingBox != null) -> {
+            (state.currentImageBytes != null && state.captureBoundingBox != null) -> {
+                val specimenBitmap = remember(state.currentImageBytes) {
+                    BitmapFactory.decodeByteArray(state.currentImageBytes, 0, state.currentImageBytes.size)
+                }
+
                 CapturedSpecimenOverlay(
                     specimen = state.currentSpecimen,
                     boundingBox = state.captureBoundingBox,
                     modifier = modifier,
-                    specimenBitmap = state.currentImage,
+                    specimenBitmap = specimenBitmap,
                     onSpecimenIdCorrected = { onAction(ImagingAction.CorrectSpecimenId(it)) },
                     onRetakeImage = { onAction(ImagingAction.RetakeImage) },
                     onSaveImageToSession = { onAction(ImagingAction.SaveImageToSession) }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -21,7 +21,6 @@ data class ImagingState(
         capturedAt = 0L,
         submittedAt = null
     ),
-    val currentImage: Bitmap? = null,
     val currentImageBytes: ByteArray? = null,
     val captureBoundingBox: BoundingBox? = null,
     val previewBoundingBoxes: List<BoundingBox> = emptyList(),

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -22,6 +22,7 @@ data class ImagingState(
         submittedAt = null
     ),
     val currentImage: Bitmap? = null,
+    val currentImageBytes: ByteArray? = null,
     val captureBoundingBox: BoundingBox? = null,
     val previewBoundingBoxes: List<BoundingBox> = emptyList(),
     val capturedSpecimensAndBoundingBoxes: List<SpecimenAndBoundingBox> = emptyList(),

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -238,13 +238,15 @@ class ImagingViewModel @Inject constructor(
 
                             1 -> {
                                 val boundingBox = boundingBoxesList[0]
-                                val topLeftXAbsolute =
-                                    (boundingBox.topLeftX * jpegBitmap.width).toInt()
-                                val topLeftYAbsolute =
-                                    (boundingBox.topLeftY * jpegBitmap.height).toInt()
-                                val widthAbsolute = (boundingBox.width * jpegBitmap.width).toInt()
-                                val heightAbsolute =
-                                    (boundingBox.height * jpegBitmap.height).toInt()
+                                val topLeftXFloat = boundingBox.topLeftX * bitmap.width
+                                val topLeftYFloat = boundingBox.topLeftY * bitmap.height
+                                val widthFloat = boundingBox.width * bitmap.width
+                                val heightFloat = boundingBox.height * bitmap.height
+
+                                val topLeftXAbsolute = topLeftXFloat.toInt()
+                                val topLeftYAbsolute = topLeftYFloat.toInt()
+                                val widthAbsolute = (widthFloat + (topLeftXFloat - topLeftXAbsolute)).toInt()
+                                val heightAbsolute = (heightFloat + (topLeftYFloat - topLeftYAbsolute)).toInt()
 
                                 val croppedBitmap = Bitmap.createBitmap(
                                     jpegBitmap,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -225,8 +225,6 @@ class ImagingViewModel @Inject constructor(
                         val jpegStream = ByteArrayOutputStream()
                         bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
                         val jpegByteArray = jpegStream.toByteArray()
-
-                        // Create bitmap from JPEG bytes for ML processing
                         val jpegBitmap =
                             BitmapFactory.decodeByteArray(jpegByteArray, 0, jpegByteArray.size)
 
@@ -266,7 +264,6 @@ class ImagingViewModel @Inject constructor(
                                             sex = sex?.label,
                                             abdomenStatus = abdomenStatus?.label,
                                         ),
-                                        currentImage = jpegBitmap,
                                         currentImageBytes = jpegByteArray,
                                         captureBoundingBox = boundingBox,
                                         previewBoundingBoxes = emptyList()
@@ -365,7 +362,6 @@ class ImagingViewModel @Inject constructor(
                 currentSpecimen = it.currentSpecimen.copy(
                     id = "", species = null, sex = null, abdomenStatus = null
                 ),
-                currentImage = null,
                 currentImageBytes = null,
                 captureBoundingBox = null,
                 previewBoundingBoxes = emptyList(),

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/gallery/CapturedSpecimenOverlay.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/gallery/CapturedSpecimenOverlay.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
@@ -29,6 +30,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -52,7 +54,7 @@ fun CapturedSpecimenOverlay(
     onSaveImageToSession: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    var overlaySize by remember { mutableStateOf(IntSize.Zero) }
+    val density = LocalDensity.current
 
     val aspectRatio = 4f / 3f
 
@@ -64,12 +66,16 @@ fun CapturedSpecimenOverlay(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            Box(
+            BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(1f / aspectRatio)
-                    .onSizeChanged { overlaySize = it }
             ) {
+                val containerSize = IntSize(
+                    width = with(density) { maxWidth.roundToPx() },
+                    height = with(density) { maxHeight.roundToPx() }
+                )
+
                 if (specimenBitmap != null) {
                     Image(
                         bitmap = specimenBitmap.asImageBitmap(),
@@ -88,7 +94,7 @@ fun CapturedSpecimenOverlay(
                 }
 
                 BoundingBoxOverlay(
-                    boundingBox = boundingBox, overlaySize = overlaySize, modifier = Modifier.fillMaxSize()
+                    boundingBox = boundingBox, overlaySize = containerSize, modifier = Modifier.fillMaxSize()
                 )
             }
         }


### PR DESCRIPTION
This PR addresses a critical issue where the ML model was processing different image data than what was being saved to device storage, causing SHA-256 checksum mismatches between inference and saved files.
Root Cause: The application was compressing captured images to JPEG format twice - once during the CaptureImage action for ML processing, and again during the SaveImageToSession action for file storage. Even with identical quality settings 100%, JPEG compression is non-deterministic and can produce different byte sequences in different contexts, leading to different checksums for what should be identical images.
Solution: Implemented a single-compression approach where the bitmap is compressed to JPEG bytes only once during capture. These exact bytes are then used for both ML inference by decoding back to bitmap and file storage by writing directly to disk. This ensures that the ML model processes the exact same image data that gets saved to the camera roll.
Key Changes:
- Added currentImageBytes field to ImagingState to store the canonical JPEG representation
- Removed duplicate currentImage bitmap storage to eliminate memory redundancy
- Created saveImageBytes() method in CameraRepository to write bytes directly to storage
- Updated UI layer to decode bytes to bitmap on-demand using remember() for performance
- Modified CaptureImage action to compress once and use those bytes for all subsequent operations
This fix guarantees that inference results are based on the exact same image data that users see saved in their photo gallery, eliminating any potential discrepancies between processing and storage.