### PR TITLE
SOF-237: Session does not upload when phone shuts down or dies

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".VectorCamApp"


### PR DESCRIPTION
This PR added a missing permission in the manifest that resulted in the app not being able to listen for the boot completed system event. Now all tasks will automatically resume once the reboot is finished.