### PR TITLE
SOF-265: Disable capture button when isCapturing 

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -90,7 +90,8 @@ fun ImagingScreen(
                     onSubmitSession = { onAction(ImagingAction.SubmitSession) },
                     manualFocusPoint = state.manualFocusPoint,
                     onAction = onAction,
-                    modifier = modifier
+                    modifier = modifier,
+                    captureEnabled = !state.isCapturing
                 )
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -91,7 +91,7 @@ fun ImagingScreen(
                     manualFocusPoint = state.manualFocusPoint,
                     onAction = onAction,
                     modifier = modifier,
-                    captureEnabled = !state.isCapturing
+                    captureEnabled = !state.isProcessing
                 )
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -1,6 +1,5 @@
 package com.vci.vectorcamapp.imaging.presentation
 
-import android.graphics.Bitmap
 import android.net.Uri
 import androidx.compose.ui.geometry.Offset
 import com.vci.vectorcamapp.core.domain.model.BoundingBox
@@ -9,7 +8,7 @@ import com.vci.vectorcamapp.core.domain.model.UploadStatus
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenAndBoundingBox
 
 data class ImagingState(
-    val isCapturing: Boolean = false,
+    val isProcessing: Boolean = false,
     val currentSpecimen: Specimen = Specimen(
         id = "",
         species = null,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -213,9 +213,8 @@ class ImagingViewModel @Inject constructor(
                 }
 
                 is ImagingAction.CaptureImage -> {
-                    _state.update { it.copy(isCapturing = true) }
+                    _state.update { it.copy(isProcessing = true) }
                     val captureResult = cameraRepository.captureImage(action.controller)
-                    _state.update { it.copy(isCapturing = false) }
 
                     captureResult.onSuccess { image ->
                         val displayOrientation = _state.value.displayOrientation
@@ -285,6 +284,7 @@ class ImagingViewModel @Inject constructor(
                         }
                         emitError(error)
                     }
+                    _state.update { it.copy(isProcessing = false) }
                 }
 
                 ImagingAction.RetakeImage -> {

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreviewPage.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreviewPage.kt
@@ -52,7 +52,8 @@ fun LiveCameraPreviewPage(
     onSaveSessionProgress: () -> Unit,
     onSubmitSession: () -> Unit,
     onAction: (ImagingAction) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    captureEnabled: Boolean = true
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -118,7 +119,6 @@ fun LiveCameraPreviewPage(
                         }
                     }
             ) {
-
                 manualFocusPoint?.let { focusPoint ->
                     if (containerSize != IntSize.Zero) {
                         val (offsetX, offsetY) = cameraManager.calculateFocusRingOffset(
@@ -177,6 +177,7 @@ fun LiveCameraPreviewPage(
 
         IconButton(
             onClick = onImageCaptured,
+            enabled = captureEnabled, // <-- disable when not enabled
             modifier = Modifier
                 .padding(bottom = 48.dp)
                 .size(64.dp)

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreviewPage.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreviewPage.kt
@@ -175,21 +175,22 @@ fun LiveCameraPreviewPage(
             )
         }
 
-        IconButton(
-            onClick = onImageCaptured,
-            enabled = captureEnabled,
-            modifier = Modifier
-                .padding(bottom = 48.dp)
-                .size(64.dp)
-                .background(MaterialTheme.colorScheme.primary, CircleShape)
-                .align(Alignment.BottomCenter)
-        ) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_camera),
-                contentDescription = "Capture Image",
-                modifier = Modifier.size(32.dp),
-                tint = MaterialTheme.colorScheme.onPrimary
-            )
+        if (captureEnabled) {
+            IconButton(
+                onClick = onImageCaptured,
+                modifier = Modifier
+                    .padding(bottom = 48.dp)
+                    .size(64.dp)
+                    .background(MaterialTheme.colorScheme.primary, CircleShape)
+                    .align(Alignment.BottomCenter)
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_camera),
+                    contentDescription = "Capture Image",
+                    modifier = Modifier.size(32.dp),
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreviewPage.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreviewPage.kt
@@ -177,7 +177,7 @@ fun LiveCameraPreviewPage(
 
         IconButton(
             onClick = onImageCaptured,
-            enabled = captureEnabled, // <-- disable when not enabled
+            enabled = captureEnabled,
             modifier = Modifier
                 .padding(bottom = 48.dp)
                 .size(64.dp)


### PR DESCRIPTION
This pull request disables the `IconButton` in `LiveCameraPreviewPage` when `isCapturing` is `true`. A boolean parameter `captureEnabled`, which is set to `!state.isCapturing`, is passed from the `ImagingScreen` to the `LiveCameraPreviewPage`.

The code was only tested on the Samsung A15, so more testing on the Motorola is necessary.