### PR TITLE
SOF-271: Confirmation Alerts before session submission

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
@@ -16,7 +16,7 @@ sealed interface ImagingAction {
     data object CancelManualFocus : ImagingAction
     data object ShowExitDialog : ImagingAction
     data object DismissExitDialog : ImagingAction
-    data class SetPendingAction(val action: ImagingAction) : ImagingAction
+    data class SelectPendingAction(val pendingAction: ImagingAction) : ImagingAction
     data object ClearPendingAction : ImagingAction
     data object ConfirmPendingAction : ImagingAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
@@ -14,4 +14,9 @@ sealed interface ImagingAction {
     data object RetakeImage : ImagingAction
     data class ManualFocusAt(val offset: Offset) : ImagingAction
     data object CancelManualFocus : ImagingAction
+    data object ShowExitDialog : ImagingAction
+    data object DismissExitDialog : ImagingAction
+    data class SetPendingAction(val action: ImagingAction) : ImagingAction
+    data object ClearPendingAction : ImagingAction
+    data object ConfirmPendingAction : ImagingAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -56,9 +56,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.TextButton
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.unit.dp
 import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 
 @Composable
@@ -236,7 +233,7 @@ fun ImagingScreen(
                         }, confirmButton = {
                             if (state.pendingAction == null) {
                                 OutlinedButton(
-                                    onClick = { onAction(ImagingAction.SetPendingAction(ImagingAction.SubmitSession)) },
+                                    onClick = { onAction(ImagingAction.SelectPendingAction(ImagingAction.SubmitSession)) },
                                     border = BorderStroke(MaterialTheme.dimensions.borderThicknessThick, MaterialTheme.colors.successConfirm)
                                 ) {
                                     Icon(
@@ -271,7 +268,7 @@ fun ImagingScreen(
                         }, dismissButton = {
                             if (state.pendingAction == null) {
                                 OutlinedButton(
-                                    onClick = { onAction(ImagingAction.SetPendingAction(ImagingAction.SaveSessionProgress)) },
+                                    onClick = { onAction(ImagingAction.SelectPendingAction(ImagingAction.SaveSessionProgress)) },
                                     border = BorderStroke(MaterialTheme.dimensions.borderThicknessThick, MaterialTheme.colors.info)
                                 ) {
                                     Icon(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -11,11 +11,13 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
@@ -49,6 +51,14 @@ import com.vci.vectorcamapp.imaging.presentation.components.camera.LiveCameraPre
 import com.vci.vectorcamapp.imaging.presentation.components.specimen.CapturedSpecimenTile
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.dp
 import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 
 @Composable
@@ -194,15 +204,99 @@ fun ImagingScreen(
                         )
                     ) {
                         ActionButton(
-                            label = "Save and Exit",
-                            onClick = { onAction(ImagingAction.SaveSessionProgress) },
-                            modifier = Modifier.weight(1f)
+                            label = "Exit",
+                            onClick = { onAction(ImagingAction.ShowExitDialog) },
+                            modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.paddingMedium)
                         )
-                        ActionButton(
-                            label = "Submit",
-                            onClick = { onAction(ImagingAction.SubmitSession) },
-                            modifier = Modifier.weight(1f)
-                        )
+                    }
+
+                    if (state.showExitDialog) {
+                        AlertDialog(onDismissRequest = {
+                            onAction(ImagingAction.DismissExitDialog)
+                        }, title = {
+                            Text(
+                                text = if (state.pendingAction == null) "Exit session?" else "Confirm Action",
+                                style = MaterialTheme.typography.headlineMedium,
+                                color = MaterialTheme.colors.textPrimary
+                            )
+                        }, text = {
+                            val dialogText = when (state.pendingAction) {
+                                null -> "Would you like to save this session for later or submit it now?"
+                                is ImagingAction.SaveSessionProgress -> "Are you sure you want to save the session and exit?"
+                                is ImagingAction.SubmitSession -> "Are you sure you want to submit the session?"
+                                else -> ""
+                            }
+                            if (dialogText.isNotEmpty()) {
+                                Text(
+                                    text = dialogText,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colors.textSecondary
+                                )
+                            }
+                        }, confirmButton = {
+                            if (state.pendingAction == null) {
+                                OutlinedButton(
+                                    onClick = { onAction(ImagingAction.SetPendingAction(ImagingAction.SubmitSession)) },
+                                    border = BorderStroke(MaterialTheme.dimensions.borderThicknessThick, MaterialTheme.colors.successConfirm)
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_cloud_upload),
+                                        contentDescription = "Submit Icon",
+                                        tint = MaterialTheme.colors.successConfirm,
+                                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+                                    )
+                                    Spacer(Modifier.size(MaterialTheme.dimensions.paddingSmall))
+                                    Text(
+                                        text = "Submit",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.successConfirm
+                                    )
+                                }
+                            } else {
+                                Button(
+                                    onClick = {
+                                        onAction(ImagingAction.ConfirmPendingAction)
+                                    },
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colors.successConfirm
+                                    )
+                                ) {
+                                    Text(
+                                        text = "Yes, Confirm",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.buttonText
+                                    )
+                                }
+                            }
+                        }, dismissButton = {
+                            if (state.pendingAction == null) {
+                                OutlinedButton(
+                                    onClick = { onAction(ImagingAction.SetPendingAction(ImagingAction.SaveSessionProgress)) },
+                                    border = BorderStroke(MaterialTheme.dimensions.borderThicknessThick, MaterialTheme.colors.info)
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_save),
+                                        contentDescription = "Save Icon",
+                                        tint = MaterialTheme.colors.info,
+                                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+                                    )
+                                    Spacer(Modifier.size(MaterialTheme.dimensions.paddingSmall))
+                                    Text(
+                                        "Save",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.info
+                                    )
+                                }
+                            } else {
+                                TextButton(onClick = { onAction(ImagingAction.ClearPendingAction) }) {
+                                    Text(
+                                        "Back",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.error
+                                    )
+                                }
+                            }
+                        })
                     }
 
                     InfoTile(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -258,7 +258,7 @@ fun ImagingScreen(
                                         onAction(ImagingAction.ConfirmPendingAction)
                                     },
                                     colors = ButtonDefaults.buttonColors(
-                                        containerColor = MaterialTheme.colors.successConfirm
+                                        containerColor = MaterialTheme.colors.error
                                     )
                                 ) {
                                     Text(
@@ -292,7 +292,7 @@ fun ImagingScreen(
                                     Text(
                                         "Back",
                                         style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colors.error
+                                        color = MaterialTheme.colors.textPrimary
                                     )
                                 }
                             }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -36,5 +36,7 @@ data class ImagingState(
     val capturedSpecimensAndInferenceResults: List<SpecimenAndInferenceResult> = emptyList(),
     val displayOrientation: Int = 0,
     val manualFocusPoint: Offset? = null,
-    val isCameraReady: Boolean = false
+    val isCameraReady: Boolean = false,
+    val showExitDialog: Boolean = false,
+    val pendingAction: ImagingAction? = null
 )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -127,6 +127,28 @@ class ImagingViewModel @Inject constructor(
     fun onAction(action: ImagingAction) {
         viewModelScope.launch {
             when (action) {
+                ImagingAction.ShowExitDialog -> {
+                    _state.update { it.copy(showExitDialog = true) }
+                }
+
+                ImagingAction.DismissExitDialog -> {
+                    _state.update { it.copy(showExitDialog = false, pendingAction = null) }
+                }
+
+                is ImagingAction.SetPendingAction -> {
+                    _state.update { it.copy(pendingAction = action.action) }
+                }
+
+                ImagingAction.ClearPendingAction -> {
+                    _state.update { it.copy(pendingAction = null) }
+                }
+
+                ImagingAction.ConfirmPendingAction -> {
+                    val actionToConfirm = _state.value.pendingAction
+                    _state.update { it.copy(showExitDialog = false, pendingAction = null) }
+                    actionToConfirm?.let { onAction(it) }
+                }
+
                 is ImagingAction.ManualFocusAt -> {
                     _state.update { it.copy(manualFocusPoint = action.offset) }
                 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -135,8 +135,8 @@ class ImagingViewModel @Inject constructor(
                     _state.update { it.copy(showExitDialog = false, pendingAction = null) }
                 }
 
-                is ImagingAction.SetPendingAction -> {
-                    _state.update { it.copy(pendingAction = action.action) }
+                is ImagingAction.SelectPendingAction -> {
+                    _state.update { it.copy(pendingAction = action.pendingAction) }
                 }
 
                 ImagingAction.ClearPendingAction -> {


### PR DESCRIPTION
This PR implemented a confirmation dialogue for exiting from imaging screen. After the user clicks on the exit button, user will be prompted with a AlertDialog to choose whether to save the session or submit the session. After the user clicks on either option, a second dialog will appear to confirm with the user whether the selected action is intended. 