### PR TITLE
SOF-272: Fixing display of imaging screen in certain Samsung devices

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -45,7 +45,7 @@ fun CompleteSessionSpecimens(
                         session = session,
                         specimen = specimen,
                         specimenImage = specimenImage,
-                        badgeText = if (totalImages > 1) "${index + 1} of $totalImages" else null,
+                        badgeText = "${index + 1} of $totalImages",
                         modifier = Modifier.width(
                             screenWidthFraction(0.9f)
                         )

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -36,18 +36,21 @@ fun CompleteSessionSpecimens(
             modifier = modifier.fillMaxSize(), horizontalArrangement = Arrangement.Center
         ) {
             items(items = specimensWithImagesAndInferenceResults.asReversed()) { specimenWithSpecimenImagesAndInferenceResults ->
-                Row {
-                    val specimen = specimenWithSpecimenImagesAndInferenceResults.specimen
-                    specimenWithSpecimenImagesAndInferenceResults.specimenImagesAndInferenceResults.map { (specimenImage, _) ->
-                        CompleteSessionSpecimensTile(
-                            session = session,
-                            specimen = specimen,
-                            specimenImage = specimenImage,
-                            modifier = Modifier.width(
-                                screenWidthFraction(0.9f)
-                            )
+                val specimen = specimenWithSpecimenImagesAndInferenceResults.specimen
+                val imageList =
+                    specimenWithSpecimenImagesAndInferenceResults.specimenImagesAndInferenceResults
+                val totalImages = imageList.size
+
+                imageList.mapIndexed { index, (specimenImage, _) ->
+                    CompleteSessionSpecimensTile(
+                        session = session,
+                        specimen = specimen,
+                        specimenImage = specimenImage,
+                        badgeText = if (totalImages > 1) "${index + 1} of $totalImages" else null,
+                        modifier = Modifier.width(
+                            screenWidthFraction(0.9f)
                         )
-                    }
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -76,13 +76,13 @@ fun CompleteSessionSpecimensTile(
             AsyncImage(
                 model = ImageRequest.Builder(context).data(specimenImage.imageUri).build(),
                 contentDescription = "Specimen Image: ${specimen.id}",
-                contentScale = ContentScale.Crop,
+                contentScale = ContentScale.Fit,
                 modifier = Modifier
                     .fillMaxSize()
                     .zoomPanGesture(containerSize)
             )
 
-            if (badgeText != null) {
+            badgeText?.let {
                 Badge(
                     modifier = Modifier
                         .align(Alignment.TopEnd)

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -1,13 +1,18 @@
 package com.vci.vectorcamapp.complete_session.details.presentation.components.specimens
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -41,7 +46,8 @@ fun CompleteSessionSpecimensTile(
     session: Session,
     specimen: Specimen,
     specimenImage: SpecimenImage,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    badgeText: String? = null,
 ) {
 
     val context = LocalContext.current
@@ -49,13 +55,34 @@ fun CompleteSessionSpecimensTile(
         remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
 
     InfoTile(modifier = modifier) {
-        AsyncImage(
-            model = ImageRequest.Builder(context).data(specimenImage.imageUri).build(),
-            contentDescription = "Specimen Image: ${specimen.id}",
-            contentScale = ContentScale.Fit,
-            modifier = Modifier.fillMaxSize()
-        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f / MaterialTheme.dimensions.aspectRatio)
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(context).data(specimenImage.imageUri).build(),
+                contentDescription = "Specimen Image: ${specimen.id}",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
 
+            if (badgeText != null) {
+                Badge(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(MaterialTheme.dimensions.paddingSmall),
+                    containerColor = MaterialTheme.colors.info,
+                    contentColor = MaterialTheme.colors.buttonText
+                ) {
+                    Text(
+                        text = badgeText,
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(MaterialTheme.dimensions.paddingSmall)
+                    )
+                }
+            }
+        }
         Column(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium),
             modifier = Modifier.padding(MaterialTheme.dimensions.paddingLarge)

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -147,32 +147,26 @@ fun CompleteSessionSpecimensTile(
                 style = MaterialTheme.typography.bodySmall
             )
 
-            if (specimenImage.species != null) {
-                Text(
-                    text = "Species: ${specimenImage.species}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colors.textPrimary
-                )
-            }
+            Text(
+                text = if (specimenImage.species != null) "Species: ${specimenImage.species}" else "",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colors.textPrimary
+            )
 
-            if (specimenImage.sex != null) {
-                Text(
-                    text = "Sex: ${specimenImage.sex}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colors.textPrimary
-                )
-            }
-
-            if (specimenImage.abdomenStatus != null) {
-                Text(
-                    text = "Abdomen Status: ${specimenImage.abdomenStatus}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colors.textPrimary
-                )
-            }
+            Text(
+                text = if (specimenImage.sex != null) "Sex: ${specimenImage.sex}" else "",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colors.textPrimary
+            )
 
             Text(
                 text = "Captured At: ${dateTimeFormatter.format(session.createdAt)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colors.textPrimary
+            )
+
+            Text(
+                text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colors.textPrimary
             )

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -160,13 +160,13 @@ fun CompleteSessionSpecimensTile(
             )
 
             Text(
-                text = "Captured At: ${dateTimeFormatter.format(session.createdAt)}",
+                text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colors.textPrimary
             )
 
             Text(
-                text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
+                text = "Captured At: ${dateTimeFormatter.format(session.createdAt)}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colors.textPrimary
             )

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -64,7 +64,7 @@ fun CompleteSessionSpecimensTile(
     InfoTile(modifier = modifier) {
         BoxWithConstraints(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
                 .aspectRatio(1f / MaterialTheme.dimensions.aspectRatio)
                 .clip(RectangleShape)
         ) {
@@ -76,12 +76,11 @@ fun CompleteSessionSpecimensTile(
             AsyncImage(
                 model = ImageRequest.Builder(context).data(specimenImage.imageUri).build(),
                 contentDescription = "Specimen Image: ${specimen.id}",
-                contentScale = ContentScale.Fit,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .fillMaxSize()
                     .zoomPanGesture(containerSize)
             )
-        }
 
             if (badgeText != null) {
                 Badge(
@@ -175,3 +174,4 @@ fun CompleteSessionSpecimensTile(
         }
     }
 }
+

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -147,24 +147,29 @@ fun CompleteSessionSpecimensTile(
                 style = MaterialTheme.typography.bodySmall
             )
 
+            if (specimenImage.species != null) {
+                Text(
+                    text = "Species: ${specimenImage.species}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colors.textPrimary
+                )
+            }
 
-            Text(
-                text = if (specimenImage.species != null) "Species: ${specimenImage.species}" else "",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colors.textPrimary
-            )
+            if (specimenImage.sex != null) {
+                Text(
+                    text = "Sex: ${specimenImage.sex}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colors.textPrimary
+                )
+            }
 
-            Text(
-                text = if (specimenImage.sex != null) "Sex: ${specimenImage.sex}" else "",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colors.textPrimary
-            )
-
-            Text(
-                text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colors.textPrimary
-            )
+            if (specimenImage.abdomenStatus != null) {
+                Text(
+                    text = "Abdomen Status: ${specimenImage.abdomenStatus}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colors.textPrimary
+                )
+            }
 
             Text(
                 text = "Captured At: ${dateTimeFormatter.format(session.createdAt)}",

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/button/ActionButton.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/button/ActionButton.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
@@ -28,7 +29,8 @@ fun ActionButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    iconPainter: Painter? = null
+    iconPainter: Painter? = null,
+    textSize: TextStyle = MaterialTheme.typography.bodyLarge
 ) {
     Button(
         onClick = onClick,
@@ -63,7 +65,7 @@ fun ActionButton(
             Text(
                 text = label,
                 color = MaterialTheme.colors.buttonText,
-                style = MaterialTheme.typography.bodyLarge,
+                style = textSize,
                 fontWeight = FontWeight.Bold
             )
         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.TextButton
 import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.itemsIndexed
 
 @Composable
@@ -116,7 +117,7 @@ fun ImagingScreen(
                     Row(
                         horizontalArrangement = Arrangement.SpaceEvenly,
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.padding(vertical = MaterialTheme.dimensions.paddingMedium).fillMaxWidth()
                     ) {
                         if (page > 0) {
                             Icon(
@@ -165,7 +166,6 @@ fun ImagingScreen(
                                 inferenceResult = inferenceResult,
                                 badgeText = if (imageList.size > 1) "${index + 1} of ${imageList.size}" else null,
                                 modifier = Modifier
-                                    .fillParentMaxHeight()
                                     .fillMaxWidth()
                             )
                         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -62,8 +61,6 @@ import androidx.compose.material3.TextButton
 import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun ImagingScreen(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -164,7 +164,7 @@ fun ImagingScreen(
                                 specimen = state.specimensWithImagesAndInferenceResults[page].specimen,
                                 specimenImage = specimenImage,
                                 inferenceResult = inferenceResult,
-                                badgeText = if (imageList.size > 1) "${index + 1} of ${imageList.size}" else null,
+                                badgeText = "${index + 1} of ${imageList.size}",
                                 modifier = Modifier
                                     .fillMaxWidth()
                             )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -52,6 +52,8 @@ import com.vci.vectorcamapp.imaging.presentation.components.specimen.CapturedSpe
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.lazy.itemsIndexed
 
 @Composable
 fun ImagingScreen(
@@ -141,12 +143,17 @@ fun ImagingScreen(
                                 .size(MaterialTheme.dimensions.iconSizeLarge))
                     }
 
-                    LazyColumn {
-                        items(state.specimensWithImagesAndInferenceResults[page].specimenImagesAndInferenceResults) { (specimenImage, inferenceResult) ->
+                    LazyColumn (modifier = Modifier.fillMaxHeight()) {
+                        val imageList = state.specimensWithImagesAndInferenceResults[page].specimenImagesAndInferenceResults
+                        itemsIndexed(imageList) { index, (specimenImage, inferenceResult) ->
                             CapturedSpecimenTile(
                                 specimen = state.specimensWithImagesAndInferenceResults[page].specimen,
                                 specimenImage = specimenImage,
                                 inferenceResult = inferenceResult,
+                                badgeText = if (imageList.size > 1) "${index + 1} of ${imageList.size}" else null,
+                                modifier = Modifier
+                                    .fillParentMaxHeight()
+                                    .fillMaxWidth()
                             )
                         }
                     }
@@ -168,11 +175,13 @@ fun ImagingScreen(
                         specimenImage = state.currentSpecimenImage,
                         inferenceResult = state.currentInferenceResult,
                         specimenBitmap = specimenBitmap,
-                        onSpecimenIdCorrected = { onAction(ImagingAction.CorrectSpecimenId(it)) })
+                        onSpecimenIdCorrected = { onAction(ImagingAction.CorrectSpecimenId(it)) },
+                        modifier = Modifier.weight(1f)
+                    )
 
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.paddingMedium),
-                        modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.paddingMedium)
+                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.paddingSmall),
+                        modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.paddingSmall)
                     ) {
                         ActionButton(
                             label = "Retake Image",
@@ -182,7 +191,7 @@ fun ImagingScreen(
                         ActionButton(
                             label = "Save To Session",
                             onClick = { onAction(ImagingAction.SaveImageToSession) },
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier.weight(1.1f)
                         )
                     }
                 }
@@ -198,7 +207,7 @@ fun ImagingScreen(
                         modifier = Modifier.padding(
                             start = MaterialTheme.dimensions.paddingMedium,
                             end = MaterialTheme.dimensions.paddingMedium,
-                            top = MaterialTheme.dimensions.paddingLarge
+                            top = MaterialTheme.dimensions.paddingMedium
                         )
                     ) {
                         ActionButton(
@@ -216,7 +225,7 @@ fun ImagingScreen(
                     InfoTile(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(vertical = MaterialTheme.dimensions.paddingMedium)
+                            .padding(vertical = MaterialTheme.dimensions.paddingSmall)
                     ) {
                         Column(
                             verticalArrangement = Arrangement.SpaceEvenly,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -62,6 +62,8 @@ import androidx.compose.material3.TextButton
 import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun ImagingScreen(
@@ -182,7 +184,11 @@ fun ImagingScreen(
                 }
 
                 Column(
-                    verticalArrangement = Arrangement.Center, modifier = modifier.fillMaxSize()
+                    modifier = modifier
+                        .padding(top = MaterialTheme.dimensions.paddingSmall)
+                        .fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     CapturedSpecimenTile(
                         specimen = state.currentSpecimen,
@@ -190,22 +196,28 @@ fun ImagingScreen(
                         inferenceResult = state.currentInferenceResult,
                         specimenBitmap = specimenBitmap,
                         onSpecimenIdCorrected = { onAction(ImagingAction.CorrectSpecimenId(it)) },
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = MaterialTheme.dimensions.paddingSmall)
                     )
 
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.paddingSmall),
-                        modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.paddingSmall)
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = MaterialTheme.dimensions.paddingMedium)
                     ) {
                         ActionButton(
                             label = "Retake Image",
                             onClick = { onAction(ImagingAction.RetakeImage) },
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier.weight(1f),
+                            textSize = MaterialTheme.typography.bodyMedium
                         )
                         ActionButton(
                             label = "Save To Session",
                             onClick = { onAction(ImagingAction.SaveImageToSession) },
-                            modifier = Modifier.weight(1.1f)
+                            modifier = Modifier.weight(1f),
+                            textSize = MaterialTheme.typography.bodyMedium
                         )
                     }
                 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +54,7 @@ fun CapturedSpecimenTile(
     inferenceResult: InferenceResult,
     modifier: Modifier = Modifier,
     specimenBitmap: Bitmap? = null,
+    badgeText: String? = null,
     onSpecimenIdCorrected: ((String) -> Unit)? = null
 ) {
     val context = LocalContext.current
@@ -59,113 +63,146 @@ fun CapturedSpecimenTile(
         remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
 
     InfoTile(modifier = modifier) {
-        BoxWithConstraints(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f / MaterialTheme.dimensions.aspectRatio)
-        ) {
-            val containerSize = IntSize(
-                width = with(density) { maxWidth.roundToPx() },
-                height = with(density) { maxHeight.roundToPx() })
-
-            if (specimenBitmap != null) {
-                Image(
-                    bitmap = specimenBitmap.asImageBitmap(),
-                    contentDescription = specimenImage.localId.toString(),
-                    contentScale = ContentScale.FillBounds,
-                )
-            } else if (specimenImage.imageUri != Uri.EMPTY) {
-                AsyncImage(
-                    model = ImageRequest.Builder(context).data(specimenImage.imageUri).crossfade(true)
-                        .build(), contentDescription = specimenImage.localId.toString(), contentScale = ContentScale.Fit
-                )
-            }
-
-            BoundingBoxOverlay(
-                inferenceResult = inferenceResult, overlaySize = containerSize
-            )
-        }
-
         Column(
-            verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium),
-            modifier = Modifier.padding(MaterialTheme.dimensions.paddingLarge)
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            if (onSpecimenIdCorrected == null) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall),
-                    modifier = Modifier.height(MaterialTheme.dimensions.componentHeightSmall)
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .aspectRatio(1f / MaterialTheme.dimensions.aspectRatio)
+                    .weight(1f, fill = false)
+                    .align(Alignment.CenterHorizontally)
+            ) {
+                BoxWithConstraints(
+                    modifier = Modifier
+                        .aspectRatio(
+                            1f / MaterialTheme.dimensions.aspectRatio,
+                            matchHeightConstraintsFirst = false
+                        )
                 ) {
-                    VerticalDivider(
-                        thickness = MaterialTheme.dimensions.dividerThickness,
-                        color = MaterialTheme.colors.primary,
-                        modifier = Modifier.fillMaxHeight()
-                    )
+                    val containerSize = IntSize(
+                        width = with(density) { maxWidth.roundToPx() },
+                        height = with(density) { maxHeight.roundToPx() })
 
-                    Icon(
-                        painter = painterResource(R.drawable.ic_specimen),
-                        contentDescription = "Mosquito",
-                        tint = MaterialTheme.colors.icon,
-                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeMedium)
-                    )
+                    if (specimenBitmap != null) {
+                        Image(
+                            bitmap = specimenBitmap.asImageBitmap(),
+                            contentDescription = specimenImage.localId.toString(),
+                            contentScale = ContentScale.Fit,
+                        )
+                    } else if (specimenImage.imageUri != Uri.EMPTY) {
+                        AsyncImage(
+                            model = ImageRequest.Builder(context).data(specimenImage.imageUri)
+                                .crossfade(true)
+                                .build(),
+                            contentDescription = specimenImage.localId.toString(),
+                            contentScale = ContentScale.Fit
+                        )
+                    }
 
-                    Text(
-                        text = "Specimen ID: ${specimen.id}",
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = MaterialTheme.colors.textPrimary
+                    BoundingBoxOverlay(
+                        inferenceResult = inferenceResult, overlaySize = containerSize
                     )
                 }
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)) {
-                    TextEntryField(
-                        label = "Specimen ID",
-                        value = specimen.id,
-                        onValueChange = onSpecimenIdCorrected,
-                        singleLine = true,
-                    )
 
-                    InfoPill(
-                        text = "Please ensure that the specimen ID is correct!",
-                        color = MaterialTheme.colors.warning,
-                        iconPainter = painterResource(R.drawable.ic_warning)
-                    )
+                if (badgeText != null) {
+                    Badge(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(MaterialTheme.dimensions.paddingSmall),
+                        containerColor = MaterialTheme.colors.info,
+                        contentColor = MaterialTheme.colors.buttonText
+                    ) {
+                        Text(
+                            text = badgeText,
+                            style = MaterialTheme.typography.labelLarge,
+                            modifier = Modifier.padding(MaterialTheme.dimensions.paddingSmall)
+                        )
+                    }
                 }
             }
 
-            Text(
-                text = if (specimenImage.species != null) "Species: ${specimenImage.species}" else "",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colors.textPrimary
-            )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium),
+                modifier = Modifier.padding(MaterialTheme.dimensions.paddingLarge)
+            ) {
+                if (onSpecimenIdCorrected == null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall),
+                        modifier = Modifier.height(MaterialTheme.dimensions.componentHeightSmall)
+                    ) {
+                        VerticalDivider(
+                            thickness = MaterialTheme.dimensions.dividerThickness,
+                            color = MaterialTheme.colors.primary,
+                            modifier = Modifier.fillMaxHeight()
+                        )
 
-            Text(
-                text = if (specimenImage.sex != null) "Sex: ${specimenImage.sex}" else "",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colors.textPrimary
-            )
+                        Icon(
+                            painter = painterResource(R.drawable.ic_specimen),
+                            contentDescription = "Mosquito",
+                            tint = MaterialTheme.colors.icon,
+                            modifier = Modifier.size(MaterialTheme.dimensions.iconSizeMedium)
+                        )
 
-            Text(
-                text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colors.textPrimary
-            )
-        }
+                        Text(
+                            text = "Specimen ID: ${specimen.id}",
+                            style = MaterialTheme.typography.headlineMedium,
+                            color = MaterialTheme.colors.textPrimary
+                        )
+                    }
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)) {
+                        TextEntryField(
+                            label = "Specimen ID",
+                            value = specimen.id,
+                            onValueChange = onSpecimenIdCorrected,
+                            singleLine = true,
+                        )
 
-        if (onSpecimenIdCorrected == null) {
-            HorizontalDivider(
-                color = MaterialTheme.colors.divider,
-                thickness = MaterialTheme.dimensions.dividerThickness
-            )
+                        InfoPill(
+                            text = "Please ensure that the specimen ID is correct!",
+                            color = MaterialTheme.colors.warning,
+                            iconPainter = painterResource(R.drawable.ic_warning)
+                        )
+                    }
+                }
 
-            Text(
-                text = "Captured At: ${dateTimeFormatter.format(specimenImage.capturedAt)}",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colors.textPrimary,
-                modifier = Modifier.padding(
-                    horizontal = MaterialTheme.dimensions.paddingLarge,
-                    vertical = MaterialTheme.dimensions.paddingMedium
+                Text(
+                    text = if (specimenImage.species != null) "Species: ${specimenImage.species}" else "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colors.textPrimary
                 )
-            )
+
+                Text(
+                    text = if (specimenImage.sex != null) "Sex: ${specimenImage.sex}" else "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colors.textPrimary
+                )
+
+                Text(
+                    text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colors.textPrimary
+                )
+            }
+
+            if (onSpecimenIdCorrected == null) {
+                HorizontalDivider(
+                    color = MaterialTheme.colors.divider,
+                    thickness = MaterialTheme.dimensions.dividerThickness
+                )
+
+                Text(
+                    text = "Captured At: ${dateTimeFormatter.format(specimenImage.capturedAt)}",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colors.textPrimary,
+                    modifier = Modifier.padding(
+                        horizontal = MaterialTheme.dimensions.paddingLarge,
+                        vertical = MaterialTheme.dimensions.paddingMedium
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
@@ -75,16 +75,12 @@ fun CapturedSpecimenTile(
                 modifier = Modifier
                     .padding(horizontal = MaterialTheme.dimensions.paddingLarge)
                     .fillMaxWidth()
-                    .aspectRatio(1f / MaterialTheme.dimensions.aspectRatio)
                     .align(Alignment.CenterHorizontally)
             ) {
                 BoxWithConstraints(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .aspectRatio(
-                            1f / MaterialTheme.dimensions.aspectRatio,
-                            matchHeightConstraintsFirst = false
-                        )
+                        .aspectRatio(1f / MaterialTheme.dimensions.aspectRatio)
                         .clip(RectangleShape)
                 ) {
                     val containerSize = IntSize(
@@ -180,17 +176,23 @@ fun CapturedSpecimenTile(
                     }
                 }
 
-                listOfNotNull(
-                    specimenImage.species?.let { "Species: $it" },
-                    specimenImage.sex?.let { "Sex: $it" },
-                    specimenImage.abdomenStatus?.let { "Abdomen Status: $it" }
-                ).forEach {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colors.textPrimary
-                    )
-                }
+                Text(
+                    text = if (specimenImage.species != null) "Species: ${specimenImage.species}" else "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colors.textPrimary
+                )
+
+                Text(
+                    text = if (specimenImage.sex != null) "Sex: ${specimenImage.sex}" else "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colors.textPrimary
+                )
+
+                Text(
+                    text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colors.textPrimary
+                )
             }
 
             if (onSpecimenIdCorrected == null) {

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -89,29 +88,29 @@ fun CapturedSpecimenTile(
                         height = with(density) { maxHeight.roundToPx() })
 
                     Box(
-                modifier = Modifier
-                    .zoomPanGesture(containerSize)
-            ) {
-                if (specimenBitmap != null) {
-                    Image(
-                        bitmap = specimenBitmap.asImageBitmap(),
-                        contentDescription = specimen.id,
-                        contentScale = ContentScale.FillBounds,
-                    )
-                } else if (specimenImage.imageUri != Uri.EMPTY) {
-                    AsyncImage(
-                        model = ImageRequest.Builder(context).data(specimenImage.imageUri)
-                            .crossfade(true)
-                            .build(),
-                        contentDescription = specimen.id,
-                        contentScale = ContentScale.Fit
-                    )
-                }
+                        modifier = Modifier
+                            .zoomPanGesture(containerSize)
+                    ) {
+                        if (specimenBitmap != null) {
+                            Image(
+                                bitmap = specimenBitmap.asImageBitmap(),
+                                contentDescription = specimen.id,
+                                contentScale = ContentScale.FillBounds,
+                            )
+                        } else if (specimenImage.imageUri != Uri.EMPTY) {
+                            AsyncImage(
+                                model = ImageRequest.Builder(context).data(specimenImage.imageUri)
+                                    .crossfade(true)
+                                    .build(),
+                                contentDescription = specimen.id,
+                                contentScale = ContentScale.Fit
+                            )
+                        }
 
-                BoundingBoxOverlay(
-                    inferenceResult = inferenceResult, overlaySize = containerSize
-                )
-            }
+                        BoundingBoxOverlay(
+                            inferenceResult = inferenceResult, overlaySize = containerSize
+                        )
+                    }
                 }
 
                 if (badgeText != null) {

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,7 +32,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
@@ -66,17 +68,21 @@ fun CapturedSpecimenTile(
 
     InfoTile(modifier = modifier) {
         Column(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .padding(vertical = MaterialTheme.dimensions.paddingLarge)
+                .fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium)
         ) {
             Box(
                 modifier = Modifier
-                    .fillMaxHeight()
+                    .padding(horizontal = MaterialTheme.dimensions.paddingLarge)
+                    .fillMaxWidth()
                     .aspectRatio(1f / MaterialTheme.dimensions.aspectRatio)
-                    .weight(1f, fill = false)
                     .align(Alignment.CenterHorizontally)
             ) {
                 BoxWithConstraints(
                     modifier = Modifier
+                        .fillMaxWidth()
                         .aspectRatio(
                             1f / MaterialTheme.dimensions.aspectRatio,
                             matchHeightConstraintsFirst = false
@@ -85,21 +91,20 @@ fun CapturedSpecimenTile(
                 ) {
                     val containerSize = IntSize(
                         width = with(density) { maxWidth.roundToPx() },
-                        height = with(density) { maxHeight.roundToPx() })
+                        height = with(density) { maxHeight.roundToPx() }
+                    )
 
-                    Box(
-                        modifier = Modifier
-                            .zoomPanGesture(containerSize)
-                    ) {
+                    Box(modifier = Modifier.zoomPanGesture(containerSize)) {
                         if (specimenBitmap != null) {
                             Image(
                                 bitmap = specimenBitmap.asImageBitmap(),
                                 contentDescription = specimen.id,
-                                contentScale = ContentScale.FillBounds,
+                                contentScale = ContentScale.FillBounds
                             )
                         } else if (specimenImage.imageUri != Uri.EMPTY) {
                             AsyncImage(
-                                model = ImageRequest.Builder(context).data(specimenImage.imageUri)
+                                model = ImageRequest.Builder(context)
+                                    .data(specimenImage.imageUri)
                                     .crossfade(true)
                                     .build(),
                                 contentDescription = specimen.id,
@@ -109,13 +114,13 @@ fun CapturedSpecimenTile(
 
                         inferenceResult?.let {
                             BoundingBoxOverlay(
-                                inferenceResult = inferenceResult, overlaySize = containerSize
+                                inferenceResult = it,
+                                overlaySize = containerSize
                             )
                         }
                     }
                 }
-
-                if (badgeText != null) {
+                badgeText?.let {
                     Badge(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
@@ -124,17 +129,17 @@ fun CapturedSpecimenTile(
                         contentColor = MaterialTheme.colors.buttonText
                     ) {
                         Text(
-                            text = badgeText,
+                            text = it,
                             style = MaterialTheme.typography.labelLarge,
-                            modifier = Modifier.padding(MaterialTheme.dimensions.paddingSmall)
+                            modifier = Modifier.padding(MaterialTheme.dimensions.paddingExtraSmall)
                         )
                     }
                 }
             }
 
             Column(
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium),
-                modifier = Modifier.padding(MaterialTheme.dimensions.paddingLarge)
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall),
+                modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.paddingLarge)
             ) {
                 if (onSpecimenIdCorrected == null) {
                     Row(
@@ -167,9 +172,8 @@ fun CapturedSpecimenTile(
                             label = "Specimen ID",
                             value = specimen.id,
                             onValueChange = onSpecimenIdCorrected,
-                            singleLine = true,
+                            singleLine = true
                         )
-
                         InfoPill(
                             text = "Please ensure that the specimen ID is correct!",
                             color = MaterialTheme.colors.warning,
@@ -178,23 +182,17 @@ fun CapturedSpecimenTile(
                     }
                 }
 
-                Text(
-                    text = if (specimenImage.species != null) "Species: ${specimenImage.species}" else "",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colors.textPrimary
-                )
-
-                Text(
-                    text = if (specimenImage.sex != null) "Sex: ${specimenImage.sex}" else "",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colors.textPrimary
-                )
-
-                Text(
-                    text = if (specimenImage.abdomenStatus != null) "Abdomen Status: ${specimenImage.abdomenStatus}" else "",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colors.textPrimary
-                )
+                listOfNotNull(
+                    specimenImage.species?.let { "Species: $it" },
+                    specimenImage.sex?.let { "Sex: $it" },
+                    specimenImage.abdomenStatus?.let { "Abdomen Status: $it" }
+                ).forEach {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colors.textPrimary
+                    )
+                }
             }
 
             if (onSpecimenIdCorrected == null) {
@@ -208,8 +206,9 @@ fun CapturedSpecimenTile(
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colors.textPrimary,
                     modifier = Modifier.padding(
-                        horizontal = MaterialTheme.dimensions.paddingLarge,
-                        vertical = MaterialTheme.dimensions.paddingMedium
+                        start = MaterialTheme.dimensions.paddingLarge,
+                        end = MaterialTheme.dimensions.paddingLarge,
+                        top = MaterialTheme.dimensions.paddingSmall
                     )
                 )
             }


### PR DESCRIPTION
This PR reworks the imaging screen for certain samsung devices that previous have display issues with different resolutions. Now all imaging sub screens should be fixed so that all components display correctly. This PR also adds a badge for x of y style display as a badge for index for multiple images for a specimen. 