### PR TITLE
SOF-242: Data Collection Mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,7 +36,7 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField("String", "BASE_URL", "\"https://api.vectorcam.org/\"")
+            buildConfigField("String", "BASE_URL", "\"https://test.api.vectorcam.org/\"")
         }
 
         release {

--- a/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/10.json
+++ b/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/10.json
@@ -1,0 +1,593 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "1f08119693f5da9dcd758c65cd0801ad",
+    "entities": [
+      {
+        "tableName": "program",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_program_country",
+            "unique": false,
+            "columnNames": [
+              "country"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_program_country` ON `${TABLE_NAME}` (`country`)"
+          }
+        ]
+      },
+      {
+        "tableName": "site",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `programId` INTEGER NOT NULL, `district` TEXT NOT NULL, `subCounty` TEXT NOT NULL, `parish` TEXT NOT NULL, `sentinelSite` TEXT NOT NULL, `healthCenter` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`programId`) REFERENCES `program`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "programId",
+            "columnName": "programId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subCounty",
+            "columnName": "subCounty",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parish",
+            "columnName": "parish",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentinelSite",
+            "columnName": "sentinelSite",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthCenter",
+            "columnName": "healthCenter",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_site_programId",
+            "unique": false,
+            "columnNames": [
+              "programId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_site_programId` ON `${TABLE_NAME}` (`programId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "program",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "programId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `siteId` INTEGER NOT NULL, `remoteId` INTEGER, `houseNumber` TEXT NOT NULL, `collectorTitle` TEXT NOT NULL, `collectorName` TEXT NOT NULL, `collectionDate` INTEGER NOT NULL, `collectionMethod` TEXT NOT NULL, `specimenCondition` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `completedAt` INTEGER, `submittedAt` INTEGER, `notes` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `type` TEXT NOT NULL, PRIMARY KEY(`localId`), FOREIGN KEY(`siteId`) REFERENCES `site`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "houseNumber",
+            "columnName": "houseNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorTitle",
+            "columnName": "collectorTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorName",
+            "columnName": "collectorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionDate",
+            "columnName": "collectionDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionMethod",
+            "columnName": "collectionMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenCondition",
+            "columnName": "specimenCondition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_session_siteId",
+            "unique": false,
+            "columnNames": [
+              "siteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_siteId` ON `${TABLE_NAME}` (`siteId`)"
+          },
+          {
+            "name": "index_session_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "site",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "siteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, PRIMARY KEY(`id`, `sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen_image",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `specimenId` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `species` TEXT, `sex` TEXT, `abdomenStatus` TEXT, `imageUri` TEXT NOT NULL, `metadataUploadStatus` TEXT NOT NULL, `imageUploadStatus` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL, `submittedAt` INTEGER, PRIMARY KEY(`localId`), FOREIGN KEY(`specimenId`, `sessionId`) REFERENCES `specimen`(`id`, `sessionId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenId",
+            "columnName": "specimenId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "species",
+            "columnName": "species",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sex",
+            "columnName": "sex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatus",
+            "columnName": "abdomenStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUri",
+            "columnName": "imageUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataUploadStatus",
+            "columnName": "metadataUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUploadStatus",
+            "columnName": "imageUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_image_specimenId_sessionId",
+            "unique": false,
+            "columnNames": [
+              "specimenId",
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_image_specimenId_sessionId` ON `${TABLE_NAME}` (`specimenId`, `sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "specimen",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenId",
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id",
+              "sessionId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inference_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`specimenImageId` TEXT NOT NULL, `bboxTopLeftX` REAL NOT NULL, `bboxTopLeftY` REAL NOT NULL, `bboxWidth` REAL NOT NULL, `bboxHeight` REAL NOT NULL, `bboxConfidence` REAL NOT NULL, `bboxClassId` INTEGER NOT NULL, `speciesLogits` TEXT, `sexLogits` TEXT, `abdomenStatusLogits` TEXT, PRIMARY KEY(`specimenImageId`), FOREIGN KEY(`specimenImageId`) REFERENCES `specimen_image`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "specimenImageId",
+            "columnName": "specimenImageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftX",
+            "columnName": "bboxTopLeftX",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftY",
+            "columnName": "bboxTopLeftY",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxWidth",
+            "columnName": "bboxWidth",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxHeight",
+            "columnName": "bboxHeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxConfidence",
+            "columnName": "bboxConfidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxClassId",
+            "columnName": "bboxClassId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speciesLogits",
+            "columnName": "speciesLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sexLogits",
+            "columnName": "sexLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatusLogits",
+            "columnName": "abdomenStatusLogits",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "specimenImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "specimen_image",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenImageId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "surveillance_form",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `numPeopleSleptInHouse` INTEGER NOT NULL, `wasIrsConducted` INTEGER NOT NULL, `monthsSinceIrs` INTEGER, `numLlinsAvailable` INTEGER NOT NULL, `llinType` TEXT, `llinBrand` TEXT, `numPeopleSleptUnderLlin` INTEGER, `submittedAt` INTEGER, PRIMARY KEY(`sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeopleSleptInHouse",
+            "columnName": "numPeopleSleptInHouse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wasIrsConducted",
+            "columnName": "wasIrsConducted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monthsSinceIrs",
+            "columnName": "monthsSinceIrs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "numLlinsAvailable",
+            "columnName": "numLlinsAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "llinType",
+            "columnName": "llinType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "llinBrand",
+            "columnName": "llinBrand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPeopleSleptUnderLlin",
+            "columnName": "numPeopleSleptUnderLlin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1f08119693f5da9dcd758c65cd0801ad')"
+    ]
+  }
+}

--- a/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/9.json
+++ b/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/9.json
@@ -1,0 +1,588 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "a524315f002e50d5155ebaf980167954",
+    "entities": [
+      {
+        "tableName": "program",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_program_country",
+            "unique": false,
+            "columnNames": [
+              "country"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_program_country` ON `${TABLE_NAME}` (`country`)"
+          }
+        ]
+      },
+      {
+        "tableName": "site",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `programId` INTEGER NOT NULL, `district` TEXT NOT NULL, `subCounty` TEXT NOT NULL, `parish` TEXT NOT NULL, `sentinelSite` TEXT NOT NULL, `healthCenter` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`programId`) REFERENCES `program`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "programId",
+            "columnName": "programId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subCounty",
+            "columnName": "subCounty",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parish",
+            "columnName": "parish",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentinelSite",
+            "columnName": "sentinelSite",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthCenter",
+            "columnName": "healthCenter",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_site_programId",
+            "unique": false,
+            "columnNames": [
+              "programId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_site_programId` ON `${TABLE_NAME}` (`programId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "program",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "programId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `siteId` INTEGER NOT NULL, `remoteId` INTEGER, `houseNumber` TEXT NOT NULL, `collectorTitle` TEXT NOT NULL, `collectorName` TEXT NOT NULL, `collectionDate` INTEGER NOT NULL, `collectionMethod` TEXT NOT NULL, `specimenCondition` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `completedAt` INTEGER, `submittedAt` INTEGER, `notes` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `type` TEXT NOT NULL, PRIMARY KEY(`localId`), FOREIGN KEY(`siteId`) REFERENCES `site`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "houseNumber",
+            "columnName": "houseNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorTitle",
+            "columnName": "collectorTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorName",
+            "columnName": "collectorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionDate",
+            "columnName": "collectionDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionMethod",
+            "columnName": "collectionMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenCondition",
+            "columnName": "specimenCondition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_session_siteId",
+            "unique": false,
+            "columnNames": [
+              "siteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_siteId` ON `${TABLE_NAME}` (`siteId`)"
+          },
+          {
+            "name": "index_session_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "site",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "siteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, PRIMARY KEY(`id`, `sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen_image",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `specimenId` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `species` TEXT, `sex` TEXT, `abdomenStatus` TEXT, `imageUri` TEXT NOT NULL, `metadataUploadStatus` TEXT NOT NULL, `imageUploadStatus` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL, `submittedAt` INTEGER, PRIMARY KEY(`localId`), FOREIGN KEY(`specimenId`, `sessionId`) REFERENCES `specimen`(`id`, `sessionId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenId",
+            "columnName": "specimenId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "species",
+            "columnName": "species",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sex",
+            "columnName": "sex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatus",
+            "columnName": "abdomenStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUri",
+            "columnName": "imageUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataUploadStatus",
+            "columnName": "metadataUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUploadStatus",
+            "columnName": "imageUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_image_specimenId_sessionId",
+            "unique": false,
+            "columnNames": [
+              "specimenId",
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_image_specimenId_sessionId` ON `${TABLE_NAME}` (`specimenId`, `sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "specimen",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenId",
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id",
+              "sessionId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inference_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`specimenImageId` TEXT NOT NULL, `bboxTopLeftX` REAL NOT NULL, `bboxTopLeftY` REAL NOT NULL, `bboxWidth` REAL NOT NULL, `bboxHeight` REAL NOT NULL, `bboxConfidence` REAL NOT NULL, `bboxClassId` INTEGER NOT NULL, `speciesLogits` TEXT, `sexLogits` TEXT, `abdomenStatusLogits` TEXT, PRIMARY KEY(`specimenImageId`), FOREIGN KEY(`specimenImageId`) REFERENCES `specimen_image`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "specimenImageId",
+            "columnName": "specimenImageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftX",
+            "columnName": "bboxTopLeftX",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftY",
+            "columnName": "bboxTopLeftY",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxWidth",
+            "columnName": "bboxWidth",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxHeight",
+            "columnName": "bboxHeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxConfidence",
+            "columnName": "bboxConfidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxClassId",
+            "columnName": "bboxClassId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speciesLogits",
+            "columnName": "speciesLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sexLogits",
+            "columnName": "sexLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatusLogits",
+            "columnName": "abdomenStatusLogits",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "specimenImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "specimen_image",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenImageId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "surveillance_form",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `numPeopleSleptInHouse` INTEGER NOT NULL, `wasIrsConducted` INTEGER NOT NULL, `monthsSinceIrs` INTEGER, `numLlinsAvailable` INTEGER NOT NULL, `llinType` TEXT, `llinBrand` TEXT, `numPeopleSleptUnderLlin` INTEGER, `submittedAt` INTEGER, PRIMARY KEY(`sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeopleSleptInHouse",
+            "columnName": "numPeopleSleptInHouse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wasIrsConducted",
+            "columnName": "wasIrsConducted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monthsSinceIrs",
+            "columnName": "monthsSinceIrs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "numLlinsAvailable",
+            "columnName": "numLlinsAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "llinType",
+            "columnName": "llinType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "llinBrand",
+            "columnName": "llinBrand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPeopleSleptUnderLlin",
+            "columnName": "numPeopleSleptUnderLlin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a524315f002e50d5155ebaf980167954')"
+    ]
+  }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/domain/util/CompleteSessionDetailsError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/domain/util/CompleteSessionDetailsError.kt
@@ -5,7 +5,6 @@ import com.vci.vectorcamapp.core.domain.util.Error
 enum class CompleteSessionDetailsError : Error {
     SESSION_NOT_FOUND,
     SITE_NOT_FOUND,
-    SURVEILLANCE_FORM_NOT_FOUND,
     SPECIMENS_NOT_FOUND,
     UNKNOWN_ERROR;
 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
@@ -37,15 +37,6 @@ data class CompleteSessionDetailsState(
         sentinelSite = "",
         healthCenter = ""
     ),
-    val surveillanceForm: SurveillanceForm = SurveillanceForm(
-        numPeopleSleptInHouse = 0,
-        wasIrsConducted = false,
-        monthsSinceIrs = null,
-        numLlinsAvailable = 0,
-        llinType = null,
-        llinBrand = null,
-        numPeopleSleptUnderLlin = null,
-        submittedAt = null
-    ),
+    val surveillanceForm: SurveillanceForm? = null,
     val specimensWithImagesAndInferenceResults: List<SpecimenWithSpecimenImagesAndInferenceResults> = emptyList(),
 )

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
@@ -7,6 +7,7 @@ import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenImageAndInferenceResult
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import java.util.UUID
 
 data class CompleteSessionDetailsState(
@@ -25,7 +26,8 @@ data class CompleteSessionDetailsState(
         submittedAt = null,
         notes = "",
         latitude = null,
-        longitude = null
+        longitude = null,
+        type = SessionType.SURVEILLANCE
     ),
     val site: Site = Site(
         id = -1,

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
@@ -87,11 +87,6 @@ class CompleteSessionDetailsViewModel @Inject constructor(
                 return@launch
             }
 
-            if (surveillanceForm == null) {
-                emitError(CompleteSessionDetailsError.SURVEILLANCE_FORM_NOT_FOUND)
-                return@launch
-            }
-
             _state.update {
                 it.copy(
                     session = session,

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/form/CompleteSessionForm.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/form/CompleteSessionForm.kt
@@ -12,13 +12,14 @@ import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.domain.model.Session
 import com.vci.vectorcamapp.core.domain.model.Site
 import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.core.presentation.components.pill.InfoPill
 import com.vci.vectorcamapp.ui.extensions.colors
 import java.text.SimpleDateFormat
 import java.util.Locale
 
 @Composable
 fun CompleteSessionForm(
-    session: Session, site: Site, surveillanceForm: SurveillanceForm, modifier: Modifier = Modifier
+    session: Session, site: Site, surveillanceForm: SurveillanceForm?, modifier: Modifier = Modifier
 ) {
     val dateTimeFormatter =
         remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
@@ -42,6 +43,8 @@ fun CompleteSessionForm(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colors.textPrimary
                 )
+
+                InfoPill(text = "Session Type: ${session.type}", color = MaterialTheme.colors.info)
             }
 
             CompleteSessionFormTile(
@@ -116,59 +119,61 @@ fun CompleteSessionForm(
                 )
             }
 
-            CompleteSessionFormTile(
-                title = "Surveillance Form",
-                iconPainter = painterResource(R.drawable.ic_clipboard),
-                iconDescription = "Clipboard"
-            ) {
-                Text(
-                    text = "Number of People who Slept in the House: ${surveillanceForm.numPeopleSleptInHouse}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colors.textPrimary
-                )
-
-                Text(
-                    text = "Was Indoor Residual Spray (IRS) Conducted: ${if (surveillanceForm.wasIrsConducted) "Yes" else "No"}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colors.textPrimary
-                )
-
-                surveillanceForm.monthsSinceIrs?.let { monthsSinceIrs ->
+            surveillanceForm?.let {
+                CompleteSessionFormTile(
+                    title = "Surveillance Form",
+                    iconPainter = painterResource(R.drawable.ic_clipboard),
+                    iconDescription = "Clipboard"
+                ) {
                     Text(
-                        text = "Months Since IRS: $monthsSinceIrs",
+                        text = "Number of People who Slept in the House: ${it.numPeopleSleptInHouse}",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colors.textPrimary
                     )
-                }
 
-                Text(
-                    text = "Number of Long Lasting Insecticide-coated Nets (LLINs) Available: ${surveillanceForm.numLlinsAvailable}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colors.textPrimary
-                )
-
-                surveillanceForm.llinType?.let { llinType ->
                     Text(
-                        text = "LLIN Type: $llinType",
+                        text = "Was Indoor Residual Spray (IRS) Conducted: ${if (it.wasIrsConducted) "Yes" else "No"}",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colors.textPrimary
                     )
-                }
 
-                surveillanceForm.llinBrand?.let { llinBrand ->
+                    it.monthsSinceIrs?.let { monthsSinceIrs ->
+                        Text(
+                            text = "Months Since IRS: $monthsSinceIrs",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colors.textPrimary
+                        )
+                    }
+
                     Text(
-                        text = "LLIN Brand: $llinBrand",
+                        text = "Number of Long Lasting Insecticide-coated Nets (LLINs) Available: ${it.numLlinsAvailable}",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colors.textPrimary
                     )
-                }
 
-                surveillanceForm.numPeopleSleptUnderLlin?.let { numPeopleSleptUnderLlin ->
-                    Text(
-                        text = "Number of People who Slept Under LLIN: $numPeopleSleptUnderLlin",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colors.textPrimary
-                    )
+                    it.llinType?.let { llinType ->
+                        Text(
+                            text = "LLIN Type: $llinType",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colors.textPrimary
+                        )
+                    }
+
+                    it.llinBrand?.let { llinBrand ->
+                        Text(
+                            text = "LLIN Brand: $llinBrand",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colors.textPrimary
+                        )
+                    }
+
+                    it.numPeopleSleptUnderLlin?.let { numPeopleSleptUnderLlin ->
+                        Text(
+                            text = "Number of People who Slept Under LLIN: $numPeopleSleptUnderLlin",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colors.textPrimary
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -1,7 +1,6 @@
 package com.vci.vectorcamapp.complete_session.details.presentation.components.specimens
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -125,7 +125,7 @@ fun CompleteSessionSpecimensTile(
             )
 
             Text(
-                text = "Created At: ${dateTimeFormatter.format(session.createdAt)}",
+                text = "Captured At: ${dateTimeFormatter.format(session.createdAt)}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colors.textPrimary
             )

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -72,7 +72,7 @@ fun CompleteSessionListTile(
                     }
                 }
 
-                InfoPill(text = "Session ID: ${session.localId}", color = MaterialTheme.colors.info)
+                InfoPill(text = "Session Type: ${session.type}", color = MaterialTheme.colors.info)
             }
 
             Column(

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/CurrentSessionCacheImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/CurrentSessionCacheImplementation.kt
@@ -27,7 +27,8 @@ class CurrentSessionCacheImplementation @Inject constructor(
                 submittedAt = session.submittedAt,
                 notes = session.notes,
                 latitude = session.latitude,
-                longitude = session.longitude
+                longitude = session.longitude,
+                type = session.type
             )
         }
     }
@@ -51,7 +52,8 @@ class CurrentSessionCacheImplementation @Inject constructor(
                 submittedAt = currentSessionCacheDto.submittedAt,
                 notes = currentSessionCacheDto.notes,
                 latitude = currentSessionCacheDto.latitude,
-                longitude = currentSessionCacheDto.longitude
+                longitude = currentSessionCacheDto.longitude,
+                type = currentSessionCacheDto.type
             )
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/cache/CurrentSessionCacheDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/cache/CurrentSessionCacheDto.kt
@@ -1,6 +1,8 @@
 package com.vci.vectorcamapp.core.data.dto.cache
 
+import com.vci.vectorcamapp.core.data.dto.serializers.SessionTypeSerializer
 import com.vci.vectorcamapp.core.data.dto.serializers.UuidSerializer
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
@@ -22,6 +24,8 @@ data class CurrentSessionCacheDto(
     val notes: String = "",
     val latitude: Float? = null,
     val longitude: Float? = null,
+    @Serializable(with = SessionTypeSerializer::class)
+    val type: SessionType = SessionType.SURVEILLANCE
 ) {
     fun isEmpty() = localId == UUID(0, 0) && createdAt == 0L
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/serializers/SessionTypeSerializer.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/serializers/SessionTypeSerializer.kt
@@ -1,22 +1,22 @@
 package com.vci.vectorcamapp.core.data.dto.serializers
 
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import java.util.UUID
 
-object UuidSerializer : KSerializer<UUID> {
+object SessionTypeSerializer : KSerializer<SessionType> {
     override val descriptor: SerialDescriptor
-        get() = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+        get() = PrimitiveSerialDescriptor("SessionType", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, value: UUID) {
-        encoder.encodeString(value.toString())
+    override fun serialize(encoder: Encoder, value: SessionType) {
+        encoder.encodeString(value.name)
     }
 
-    override fun deserialize(decoder: Decoder): UUID {
-        return UUID.fromString(decoder.decodeString())
+    override fun deserialize(decoder: Decoder): SessionType {
+        return SessionType.valueOf(decoder.decodeString())
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
@@ -4,6 +4,5 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PostSpecimenRequestDto(
-    val specimenId: String = "",
-    val sessionId: Int = -1
+    val specimenId: String = ""
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SpecimenDto(
+    val id: Int? = null,
     val specimenId: String = "",
     val sessionId: Int = -1
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/PostSpecimenImageRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/PostSpecimenImageRequestDto.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PostSpecimenImageRequestDto(
+    val filemd5: String = "",
     val species: String? = null,
     val sex: String? = null,
     val abdomenStatus: String? = null,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/PostSpecimenImageRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/PostSpecimenImageRequestDto.kt
@@ -9,5 +9,5 @@ data class PostSpecimenImageRequestDto(
     val sex: String? = null,
     val abdomenStatus: String? = null,
     val capturedAt: Long = 0L,
-    val inferenceResult: InferenceResultDto = InferenceResultDto()
+    val inferenceResult: InferenceResultDto? = null
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/SpecimenImageDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/SpecimenImageDto.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class SpecimenImageDto(
     val id: Int? = null,
+    val filemd5: String = "",
     val species: String? = null,
     val sex: String? = null,
     val abdomenStatus: String? = null,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/SpecimenImageDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/SpecimenImageDto.kt
@@ -11,5 +11,5 @@ data class SpecimenImageDto(
     val abdomenStatus: String? = null,
     val capturedAt: Long = 0L,
     val submittedAt: Long? = null,
-    val inferenceResult: InferenceResultDto = InferenceResultDto()
+    val inferenceResult: InferenceResultDto? = null
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/InferenceResultMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/InferenceResultMapper.kt
@@ -18,7 +18,7 @@ fun InferenceResultEntity.toDomain() : InferenceResult {
     )
 }
 
-fun InferenceResult.toEntity(specimenImageId: UUID) : InferenceResultEntity {
+fun InferenceResult.toEntity(specimenImageId: String) : InferenceResultEntity {
     return InferenceResultEntity(
         specimenImageId = specimenImageId,
         bboxTopLeftX = this.bboxTopLeftX,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SessionMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SessionMapper.kt
@@ -18,7 +18,8 @@ fun SessionEntity.toDomain(): Session {
         submittedAt = this.submittedAt,
         notes = this.notes,
         latitude = this.latitude,
-        longitude = this.longitude
+        longitude = this.longitude,
+        type = this.type
     )
 }
 
@@ -38,6 +39,7 @@ fun Session.toEntity(siteId: Int): SessionEntity {
         submittedAt = this.submittedAt,
         notes = this.notes,
         latitude = this.latitude,
-        longitude = this.longitude
+        longitude = this.longitude,
+        type = this.type
     )
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
@@ -5,12 +5,16 @@ import com.vci.vectorcamapp.core.domain.model.Specimen
 import java.util.UUID
 
 fun SpecimenEntity.toDomain(): Specimen {
-    return Specimen(id = this.id)
+    return Specimen(
+        id = this.id,
+        remoteId = this.remoteId
+    )
 }
 
 fun Specimen.toEntity(sessionId: UUID): SpecimenEntity {
     return SpecimenEntity(
         id = this.id,
         sessionId = sessionId,
+        remoteId = this.remoteId
     )
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
@@ -1,12 +1,10 @@
 package com.vci.vectorcamapp.core.data.network.api
 
-import com.vci.vectorcamapp.core.data.dto.inference_result.InferenceResultDto
 import com.vci.vectorcamapp.core.data.dto.specimen.PostSpecimenRequestDto
 import com.vci.vectorcamapp.core.data.dto.specimen.PostSpecimenResponseDto
 import com.vci.vectorcamapp.core.data.dto.specimen.SpecimenDto
 import com.vci.vectorcamapp.core.data.network.constructUrl
 import com.vci.vectorcamapp.core.data.network.safeCall
-import com.vci.vectorcamapp.core.domain.model.InferenceResult
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.network.api.SpecimenDataSource
 import com.vci.vectorcamapp.core.domain.util.Result
@@ -27,21 +25,20 @@ class RemoteSpecimenDataSource @Inject constructor(
         specimen: Specimen, sessionId: Int
     ): Result<PostSpecimenResponseDto, NetworkError> {
         return safeCall<PostSpecimenResponseDto> {
-            httpClient.post(constructUrl("specimens")) {
+            httpClient.post(constructUrl("sessions/$sessionId/specimens")) {
                 contentType(ContentType.Application.Json)
                 setBody(
                     PostSpecimenRequestDto(
-                        specimenId = specimen.id,
-                        sessionId = sessionId
+                        specimenId = specimen.id
                     )
                 )
             }
         }
     }
 
-    override suspend fun getSpecimenById(specimenId: String): Result<SpecimenDto, NetworkError> {
+    override suspend fun getSpecimenByIdAndSessionId(specimenId: String, sessionId: Int): Result<SpecimenDto, NetworkError> {
         return safeCall<SpecimenDto> {
-            httpClient.get(constructUrl("specimens/$specimenId")) {
+            httpClient.get(constructUrl("sessions/$sessionId/specimens/$specimenId")) {
                 contentType(ContentType.Application.Json)
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.data.network.api
 
+import android.util.Log
 import com.vci.vectorcamapp.core.data.dto.inference_result.InferenceResultDto
 import com.vci.vectorcamapp.core.data.dto.specimen_image.PostSpecimenImageRequestDto
 import com.vci.vectorcamapp.core.data.dto.specimen_image.PostSpecimenImageResponseDto
@@ -23,10 +24,9 @@ class RemoteSpecimenImageDataSource @Inject constructor(
     private val httpClient: HttpClient
 ) : SpecimenImageDataSource {
     override suspend fun postSpecimenImageMetadata(
-        specimenImage: SpecimenImage,
-        inferenceResult: InferenceResult,
-        specimenId: String
+        specimenImage: SpecimenImage, inferenceResult: InferenceResult?, specimenId: String
     ): Result<PostSpecimenImageResponseDto, NetworkError> {
+        Log.d("postSpecimenImageMetadata", "specimenImage: $specimenImage, inferenceResult: $inferenceResult, specimenId: $specimenId")
         return safeCall<PostSpecimenImageResponseDto> {
             httpClient.post(constructUrl("specimens/${specimenId}/images/data")) {
                 contentType(ContentType.Application.Json)
@@ -36,24 +36,28 @@ class RemoteSpecimenImageDataSource @Inject constructor(
                         sex = specimenImage.sex,
                         abdomenStatus = specimenImage.abdomenStatus,
                         capturedAt = specimenImage.capturedAt,
-                        inferenceResult = InferenceResultDto(
-                            bboxTopLeftX = inferenceResult.bboxTopLeftX,
-                            bboxTopLeftY = inferenceResult.bboxTopLeftY,
-                            bboxWidth = inferenceResult.bboxWidth,
-                            bboxHeight = inferenceResult.bboxHeight,
-                            bboxConfidence = inferenceResult.bboxConfidence,
-                            bboxClassId = inferenceResult.bboxClassId,
-                            speciesLogits = inferenceResult.speciesLogits,
-                            sexLogits = inferenceResult.sexLogits,
-                            abdomenStatusLogits = inferenceResult.abdomenStatusLogits
-                        )
+                        inferenceResult = inferenceResult?.let {
+                            InferenceResultDto(
+                                bboxTopLeftX = it.bboxTopLeftX,
+                                bboxTopLeftY = it.bboxTopLeftY,
+                                bboxWidth = it.bboxWidth,
+                                bboxHeight = it.bboxHeight,
+                                bboxConfidence = it.bboxConfidence,
+                                bboxClassId = it.bboxClassId,
+                                speciesLogits = it.speciesLogits,
+                                sexLogits = it.sexLogits,
+                                abdomenStatusLogits = it.abdomenStatusLogits
+                            )
+                        }
                     )
                 )
             }
         }
     }
 
-    override suspend fun getSpecimenImageMetadata(specimenImageId: Int, specimenId: String): Result<SpecimenImageDto, NetworkError> {
+    override suspend fun getSpecimenImageMetadata(
+        specimenImageId: Int, specimenId: String
+    ): Result<SpecimenImageDto, NetworkError> {
         return safeCall<SpecimenImageDto> {
             httpClient.get(constructUrl("specimens/${specimenId}/images/data/${specimenImageId}")) {
                 contentType(ContentType.Application.Json)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
@@ -24,14 +24,14 @@ class RemoteSpecimenImageDataSource @Inject constructor(
     private val httpClient: HttpClient
 ) : SpecimenImageDataSource {
     override suspend fun postSpecimenImageMetadata(
-        specimenImage: SpecimenImage, inferenceResult: InferenceResult?, specimenId: String
+        specimenImage: SpecimenImage, inferenceResult: InferenceResult?, specimenId: Int
     ): Result<PostSpecimenImageResponseDto, NetworkError> {
-        Log.d("postSpecimenImageMetadata", "specimenImage: $specimenImage, inferenceResult: $inferenceResult, specimenId: $specimenId")
         return safeCall<PostSpecimenImageResponseDto> {
             httpClient.post(constructUrl("specimens/${specimenId}/images/data")) {
                 contentType(ContentType.Application.Json)
                 setBody(
                     PostSpecimenImageRequestDto(
+                        filemd5 = specimenImage.localId,
                         species = specimenImage.species,
                         sex = specimenImage.sex,
                         abdomenStatus = specimenImage.abdomenStatus,
@@ -56,7 +56,7 @@ class RemoteSpecimenImageDataSource @Inject constructor(
     }
 
     override suspend fun getSpecimenImageMetadata(
-        specimenImageId: Int, specimenId: String
+        specimenImageId: String, specimenId: Int
     ): Result<SpecimenImageDto, NetworkError> {
         return safeCall<SpecimenImageDto> {
             httpClient.get(constructUrl("specimens/${specimenId}/images/data/${specimenImageId}")) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/InferenceResultRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/InferenceResultRepositoryImplementation.kt
@@ -7,13 +7,12 @@ import com.vci.vectorcamapp.core.domain.model.InferenceResult
 import com.vci.vectorcamapp.core.domain.repository.InferenceResultRepository
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
-import java.util.UUID
 import javax.inject.Inject
 
 class InferenceResultRepositoryImplementation @Inject constructor(
     private val inferenceResultDao: InferenceResultDao
 ) : InferenceResultRepository {
-    override suspend fun insertInferenceResult(inferenceResult: InferenceResult, specimenImageId: UUID): Result<Unit, RoomDbError> {
+    override suspend fun insertInferenceResult(inferenceResult: InferenceResult, specimenImageId: String): Result<Unit, RoomDbError> {
         return try {
             inferenceResultDao.insertInferenceResult(inferenceResult.toEntity(specimenImageId))
             Result.Success(Unit)
@@ -24,7 +23,7 @@ class InferenceResultRepositoryImplementation @Inject constructor(
         }
     }
 
-    override suspend fun updateInferenceResult(inferenceResult: InferenceResult, specimenImageId: UUID): Result<Unit, RoomDbError> {
+    override suspend fun updateInferenceResult(inferenceResult: InferenceResult, specimenImageId: String): Result<Unit, RoomDbError> {
         return try {
             inferenceResultDao.updateInferenceResult(inferenceResult.toEntity(specimenImageId))
             Result.Success(Unit)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
@@ -55,7 +55,7 @@ class SessionRepositoryImplementation @Inject constructor(
         return relation?.let {
             SessionAndSurveillanceForm(
                 session = it.sessionEntity.toDomain(),
-                surveillanceForm = it.surveillanceFormEntity.toDomain()
+                surveillanceForm = it.surveillanceFormEntity?.toDomain()
             )
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenRepositoryImplementation.kt
@@ -71,7 +71,7 @@ class SpecimenRepositoryImplementation @Inject constructor(
                 specimenImagesAndInferenceResults = specimenImagesAndResults.map { relation ->
                     SpecimenImageAndInferenceResult(
                         specimenImage = relation.specimenImageEntity.toDomain(),
-                        inferenceResult = relation.inferenceResultEntity.toDomain()
+                        inferenceResult = relation.inferenceResultEntity?.toDomain()
                     )
                 })
         }
@@ -95,7 +95,7 @@ class SpecimenRepositoryImplementation @Inject constructor(
                                 specimenImagesAndInferenceResults = specimenImagesAndResults.map { relation ->
                                     SpecimenImageAndInferenceResult(
                                         specimenImage = relation.specimenImageEntity.toDomain(),
-                                        inferenceResult = relation.inferenceResultEntity.toDomain()
+                                        inferenceResult = relation.inferenceResultEntity?.toDomain()
                                     )
                                 })
                         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
@@ -25,7 +25,7 @@ import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
 
 @Database(
     entities = [ProgramEntity::class, SiteEntity::class, SessionEntity::class, SpecimenEntity::class, SpecimenImageEntity::class, InferenceResultEntity::class, SurveillanceFormEntity::class],
-    version = 9,
+    version = 10,
 )
 @TypeConverters(
     UuidConverter::class,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
@@ -4,6 +4,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.vci.vectorcamapp.core.data.room.converters.FloatListConverter
+import com.vci.vectorcamapp.core.data.room.converters.SessionTypeConverter
 import com.vci.vectorcamapp.core.data.room.converters.UploadStatusConverter
 import com.vci.vectorcamapp.core.data.room.converters.UriConverter
 import com.vci.vectorcamapp.core.data.room.converters.UuidConverter
@@ -24,12 +25,13 @@ import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
 
 @Database(
     entities = [ProgramEntity::class, SiteEntity::class, SessionEntity::class, SpecimenEntity::class, SpecimenImageEntity::class, InferenceResultEntity::class, SurveillanceFormEntity::class],
-    version = 8,
+    version = 9,
 )
 @TypeConverters(
     UuidConverter::class,
     UriConverter::class,
     UploadStatusConverter::class,
+    SessionTypeConverter::class,
     FloatListConverter::class
 )
 abstract class VectorCamDatabase : RoomDatabase() {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/converters/SessionTypeConverter.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/converters/SessionTypeConverter.kt
@@ -1,0 +1,12 @@
+package com.vci.vectorcamapp.core.data.room.converters
+
+import androidx.room.TypeConverter
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
+
+class SessionTypeConverter {
+    @TypeConverter
+    fun fromSessionType(value: SessionType?): String? = value?.name
+
+    @TypeConverter
+    fun toSessionType(value: String?): SessionType? = value?.let { SessionType.valueOf(it) }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/converters/UploadStatusConverter.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/converters/UploadStatusConverter.kt
@@ -1,7 +1,7 @@
 package com.vci.vectorcamapp.core.data.room.converters
 
 import androidx.room.TypeConverter
-import com.vci.vectorcamapp.core.domain.model.UploadStatus
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 
 class UploadStatusConverter {
     @TypeConverter

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/InferenceResultEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/InferenceResultEntity.kt
@@ -17,7 +17,7 @@ import java.util.UUID
     ]
 )
 data class InferenceResultEntity(
-    @PrimaryKey val specimenImageId: UUID = UUID(0, 0),
+    @PrimaryKey val specimenImageId: String = "",
     val bboxTopLeftX: Float = 0F,
     val bboxTopLeftY: Float = 0F,
     val bboxWidth: Float = 0F,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SessionEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SessionEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import java.util.UUID
 
 @Entity(
@@ -13,7 +14,7 @@ import java.util.UUID
         childColumns = ["siteId"],
         onDelete = ForeignKey.CASCADE,
         onUpdate = ForeignKey.CASCADE
-    )], indices = [Index("submittedAt"), Index("siteId")]
+    )], indices = [Index("completedAt"), Index("siteId"), Index("type")]
 )
 data class SessionEntity(
     @PrimaryKey val localId: UUID = UUID(0, 0),
@@ -31,4 +32,5 @@ data class SessionEntity(
     val notes: String = "",
     val latitude: Float? = null,
     val longitude: Float? = null,
+    val type: SessionType,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
@@ -17,4 +17,5 @@ import java.util.UUID
 data class SpecimenEntity(
     val id: String = "",
     val sessionId: UUID = UUID(0, 0),
+    val remoteId: Int? = null
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenImageEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenImageEntity.kt
@@ -20,7 +20,7 @@ import java.util.UUID
     ], indices = [Index(value = ["specimenId", "sessionId"])]
 )
 data class SpecimenImageEntity(
-    @PrimaryKey val localId: UUID = UUID(0, 0),
+    @PrimaryKey val localId: String = "",
     val specimenId: String = "",
     val sessionId: UUID = UUID(0, 0),
     val remoteId: Int? = null,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenImageEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenImageEntity.kt
@@ -5,7 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import com.vci.vectorcamapp.core.domain.model.UploadStatus
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import java.util.UUID
 
 @Entity(
@@ -22,7 +22,7 @@ import java.util.UUID
 data class SpecimenImageEntity(
     @PrimaryKey val localId: UUID = UUID(0, 0),
     val specimenId: String = "",
-    val sessionId: UUID,// = UUID(0, 0),
+    val sessionId: UUID = UUID(0, 0),
     val remoteId: Int? = null,
     val species: String? = null,
     val sex: String? = null,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/relations/SessionAndSurveillanceFormRelation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/relations/SessionAndSurveillanceFormRelation.kt
@@ -11,5 +11,5 @@ data class SessionAndSurveillanceFormRelation(
         parentColumn = "localId",
         entityColumn = "sessionId"
     )
-    val surveillanceFormEntity: SurveillanceFormEntity
+    val surveillanceFormEntity: SurveillanceFormEntity?
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/relations/SpecimenImageAndInferenceResultRelation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/relations/SpecimenImageAndInferenceResultRelation.kt
@@ -11,5 +11,5 @@ data class SpecimenImageAndInferenceResultRelation(
         parentColumn = "localId",
         entityColumn = "specimenImageId"
     )
-    val inferenceResultEntity: InferenceResultEntity
+    val inferenceResultEntity: InferenceResultEntity?
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -8,6 +8,7 @@ import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_5_6_ADD
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_6_7_BOUNDING_BOX_TO_INFERENCE_RESULT
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN
+import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS
 
 val ALL_MIGRATIONS = arrayOf(
     MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE,
@@ -17,5 +18,6 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_5_6_ADD_UPLOAD_STATUS_TO_SPECIMEN,
     MIGRATION_6_7_BOUNDING_BOX_TO_INFERENCE_RESULT,
     MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION,
-    MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN
+    MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN,
+    MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -7,6 +7,7 @@ import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_4_5_ADD
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_5_6_ADD_UPLOAD_STATUS_TO_SPECIMEN
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_6_7_BOUNDING_BOX_TO_INFERENCE_RESULT
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION
+import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN
 
 val ALL_MIGRATIONS = arrayOf(
     MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE,
@@ -15,5 +16,6 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_4_5_ADD_SUBMITTED_AT_COLUMNS_TO_SPECIMEN_AND_SURVEILLANCE_FORM_TABLES,
     MIGRATION_5_6_ADD_UPLOAD_STATUS_TO_SPECIMEN,
     MIGRATION_6_7_BOUNDING_BOX_TO_INFERENCE_RESULT,
-    MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION
+    MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION,
+    MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_8_9_AddSessionTypeColumn.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_8_9_AddSessionTypeColumn.kt
@@ -1,0 +1,18 @@
+package com.vci.vectorcamapp.core.data.room.migrations.versions
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN = object : Migration(8, 9) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // Add the new type column with default value
+        db.execSQL("ALTER TABLE `session` ADD COLUMN `type` TEXT NOT NULL DEFAULT 'SURVEILLANCE'")
+
+        // Drop old index on submittedAt
+        db.execSQL("DROP INDEX `index_session_submittedAt`")
+
+        // Create new indices
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_session_completedAt` ON `session` (`completedAt`)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_session_type` ON `session` (`type`)")
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_9_10_RefactorSpecimenImageAndInferenceResultKeys.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_9_10_RefactorSpecimenImageAndInferenceResultKeys.kt
@@ -1,0 +1,53 @@
+package com.vci.vectorcamapp.core.data.room.migrations.versions
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS = object: Migration(9, 10) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // Add remoteId to specimen
+        db.execSQL("ALTER TABLE `specimen` ADD COLUMN `remoteId` INTEGER")
+
+        // Drop and recreate specimen_image table with localId as TEXT
+        db.execSQL("DROP TABLE IF EXISTS `specimen_image`")
+        db.execSQL("""
+            CREATE TABLE `specimen_image` (
+                `localId` TEXT NOT NULL,
+                `specimenId` TEXT NOT NULL,
+                `sessionId` TEXT NOT NULL,
+                `remoteId` INTEGER,
+                `species` TEXT,
+                `sex` TEXT,
+                `abdomenStatus` TEXT,
+                `imageUri` TEXT NOT NULL,
+                `metadataUploadStatus` TEXT NOT NULL,
+                `imageUploadStatus` TEXT NOT NULL,
+                `capturedAt` INTEGER NOT NULL,
+                `submittedAt` INTEGER,
+                PRIMARY KEY(`localId`),
+                FOREIGN KEY(`specimenId`, `sessionId`) REFERENCES `specimen`(`id`, `sessionId`) ON DELETE CASCADE ON UPDATE CASCADE
+            )
+        """.trimIndent())
+
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_specimen_image_specimenId_sessionId` ON `specimen_image` (`specimenId`, `sessionId`)")
+
+        // Drop and recreate inference_result with logits as TEXT (float array)
+        db.execSQL("DROP TABLE IF EXISTS `inference_result`")
+        db.execSQL("""
+            CREATE TABLE `inference_result` (
+                `specimenImageId` TEXT NOT NULL,
+                `bboxTopLeftX` REAL NOT NULL,
+                `bboxTopLeftY` REAL NOT NULL,
+                `bboxWidth` REAL NOT NULL,
+                `bboxHeight` REAL NOT NULL,
+                `bboxConfidence` REAL NOT NULL,
+                `bboxClassId` INTEGER NOT NULL,
+                `speciesLogits` TEXT,
+                `sexLogits` TEXT,
+                `abdomenStatusLogits` TEXT,
+                PRIMARY KEY(`specimenImageId`),
+                FOREIGN KEY(`specimenImageId`) REFERENCES `specimen_image`(`localId`) ON DELETE CASCADE ON UPDATE CASCADE
+            )
+        """.trimIndent())
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -178,7 +178,7 @@ class ImageUploadWorker @AssistedInject constructor(
         val (file, contentType, md5) = try {
             val (prepared, type) = prepareFile(task.image.imageUri, task.specimen.id)
             tempFile = prepared
-            Triple(prepared, type, calculateMD5(prepared))
+            Triple(prepared, type, task.image.localId)
         } catch (e: Exception) {
             if (isStopped) {
                 throw CancellationException("Worker was stopped during file preparation.", e)
@@ -418,18 +418,6 @@ class ImageUploadWorker @AssistedInject constructor(
             this.fingerprint = fingerprint
             this.metadata = metadata
         }
-    }
-
-    private fun calculateMD5(file: File): String {
-        val md = MessageDigest.getInstance("MD5")
-        FileInputStream(file).use { fis ->
-            val buffer = ByteArray(BYTE_ARRAY_SIZE)
-            var read: Int
-            while (fis.read(buffer).also { read = it } != -1) {
-                md.update(buffer, 0, read)
-            }
-        }
-        return md.digest().joinToString("") { "%02x".format(it) }
     }
 
     private suspend fun prepareFile(

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -14,6 +14,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.data.network.constructUrl
+import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
 import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
@@ -54,7 +55,7 @@ class ImageUploadWorker @AssistedInject constructor(
     private val tusClient: TusClient
 ) : CoroutineWorker(context, workerParams) {
 
-    private data class ImageUploadTask(val specimenId: String, val image: SpecimenImage)
+    private data class ImageUploadTask(val specimen: Specimen, val image: SpecimenImage)
 
     companion object {
         const val KEY_SESSION_ID = "session_id"
@@ -115,7 +116,7 @@ class ImageUploadWorker @AssistedInject constructor(
 
         val imagesToUpload = specimensWithImages.flatMap { specimenWithData ->
             specimenWithData.specimenImagesAndInferenceResults.map { imageAndResult ->
-                ImageUploadTask(specimenWithData.specimen.id, imageAndResult.specimenImage)
+                ImageUploadTask(specimenWithData.specimen, imageAndResult.specimenImage)
             }
         }.filter { task ->
             task.image.imageUploadStatus != UploadStatus.COMPLETED
@@ -139,7 +140,7 @@ class ImageUploadWorker @AssistedInject constructor(
                 Log.e("ImageUploadWorker", "Image ${task.image.localId} has a null remoteId. Skipping.")
                 specimenImageRepository.updateSpecimenImage(
                     specimenImage = task.image.copy(imageUploadStatus = UploadStatus.FAILED),
-                    specimenId = task.specimenId,
+                    specimenId = task.specimen.id,
                     sessionId = sessionId
                 )
                 encounteredPermanentFailure = true
@@ -175,7 +176,7 @@ class ImageUploadWorker @AssistedInject constructor(
     ): DomainResult<String, NetworkError> {
         var tempFile: File? = null
         val (file, contentType, md5) = try {
-            val (prepared, type) = prepareFile(task.image.imageUri, task.specimenId)
+            val (prepared, type) = prepareFile(task.image.imageUri, task.specimen.id)
             tempFile = prepared
             Triple(prepared, type, calculateMD5(prepared))
         } catch (e: Exception) {
@@ -185,7 +186,7 @@ class ImageUploadWorker @AssistedInject constructor(
             Log.e("ImageUploadWorker", "Failed to prepare file or calculate MD5 for specimen ${task.image.localId}.", e)
             specimenImageRepository.updateSpecimenImage(
                 specimenImage = task.image.copy(imageUploadStatus = UploadStatus.FAILED),
-                specimenId = task.specimenId,
+                specimenId = task.specimen.id,
                 sessionId = sessionId
             )
             tempFile?.takeIf { it.exists() }?.delete()
@@ -202,8 +203,8 @@ class ImageUploadWorker @AssistedInject constructor(
         val uploadResult: DomainResult<String, NetworkError> = run {
             for (attempt in 1..MAX_RETRIES) {
                 val result: DomainResult<String, NetworkError> = try {
-                    val uniqueFingerprint = "${task.specimenId}-${task.image.localId}-$md5"
-                    val tusPath = "specimens/${task.specimenId}/images/tus"
+                    val uniqueFingerprint = "${task.specimen.remoteId}-${task.image.localId}-$md5"
+                    val tusPath = "specimens/${task.specimen.remoteId}/images/tus"
 
                     tusClient.uploadCreationURL = URL(constructUrl(tusPath))
                     val upload = createTusUpload(file, uniqueFingerprint, metadata)
@@ -213,7 +214,7 @@ class ImageUploadWorker @AssistedInject constructor(
                         val uploaderInstance = tusClient.resumeOrCreateUpload(upload)
                         specimenImageRepository.updateSpecimenImage(
                             specimenImage = task.image.copy(imageUploadStatus = UploadStatus.IN_PROGRESS),
-                            specimenId = task.specimenId,
+                            specimenId = task.specimen.id,
                             sessionId = sessionId
                         )
                         Log.d("ImageUploadWorker", "Connection established for ${task.image.localId}.")
@@ -225,7 +226,7 @@ class ImageUploadWorker @AssistedInject constructor(
                                 Log.i("ImageUploadWorker", "Upload for ${task.image.localId} already exists on server (conflict). Treating as success.")
                                 specimenImageRepository.updateSpecimenImage(
                                     specimenImage = task.image.copy(imageUploadStatus = UploadStatus.COMPLETED),
-                                    specimenId = task.specimenId,
+                                    specimenId = task.specimen.id,
                                     sessionId = sessionId
                                 )
                                 return@run DomainResult.Success(location)
@@ -298,7 +299,7 @@ class ImageUploadWorker @AssistedInject constructor(
         }
         specimenImageRepository.updateSpecimenImage(
             specimenImage = task.image.copy(imageUploadStatus = finalStatus),
-            specimenId = task.specimenId,
+            specimenId = task.specimen.id,
             sessionId = sessionId
         )
         file.delete()

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -15,7 +15,7 @@ import androidx.work.workDataOf
 import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.data.network.constructUrl
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
-import com.vci.vectorcamapp.core.domain.model.UploadStatus
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenImageRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -141,9 +141,8 @@ class MetadataUploadWorker @AssistedInject constructor(
                         syncSpecimenImageAndInferenceResultIfNeeded(
                             specimenImage,
                             inferenceResult,
-                            syncedSpecimen.id,
-                            syncedSession.localId,
-                            syncedSession.remoteId
+                            syncedSpecimen,
+                            syncedSession.localId
                         ).onError { error ->
                             return retryOrFailure(error.toString(context))
                         }
@@ -396,12 +395,11 @@ class MetadataUploadWorker @AssistedInject constructor(
     ): DomainResult<Specimen, NetworkError> {
         return try {
             val localSpecimenDto = SpecimenDto(
-                specimenId = localSpecimen.id, sessionId = syncedRemoteSessionId
+                id = localSpecimen.remoteId, specimenId = localSpecimen.id, sessionId = syncedRemoteSessionId
             )
 
-            // TODO: MIGHT NEED TO CHANGE ONCE BACKEND REQUIRES SESSION ID TO GET A SPECIMEN BY ID
             val remoteSpecimenDto = when (val remoteSpecimenResult =
-                specimenDataSource.getSpecimenById(localSpecimen.id)) {
+                specimenDataSource.getSpecimenByIdAndSessionId(localSpecimen.id, syncedRemoteSessionId)) {
                 is DomainResult.Success -> remoteSpecimenResult.data
                 is DomainResult.Error -> {
                     when (remoteSpecimenResult.error) {
@@ -424,6 +422,7 @@ class MetadataUploadWorker @AssistedInject constructor(
 
             val remoteSpecimen = Specimen(
                 id = remoteSpecimenDto.specimenId,
+                remoteId = remoteSpecimenDto.id
             )
 
             if (remoteSpecimenDto != localSpecimenDto) {
@@ -443,19 +442,19 @@ class MetadataUploadWorker @AssistedInject constructor(
     private suspend fun syncSpecimenImageAndInferenceResultIfNeeded(
         localSpecimenImage: SpecimenImage,
         localInferenceResult: InferenceResult?,
-        syncedSpecimenId: String,
-        syncedLocalSessionId: UUID,
-        syncedRemoteSessionId: Int
+        syncedSpecimen: Specimen,
+        syncedLocalSessionId: UUID
     ): DomainResult<Unit, NetworkError> {
         return try {
             specimenImageRepository.updateSpecimenImage(
                 localSpecimenImage.copy(metadataUploadStatus = UploadStatus.IN_PROGRESS),
-                syncedSpecimenId,
+                syncedSpecimen.id,
                 syncedLocalSessionId
             )
-            // TODO: ADD FRONTEND ID, REMOTE SESSION ID TO DTO WHEN BACKEND MAKES IT AVAILABLE
+
             val localSpecimenImageDto = SpecimenImageDto(
                 id = localSpecimenImage.remoteId,
+                filemd5 = localSpecimenImage.localId,
                 species = localSpecimenImage.species,
                 sex = localSpecimenImage.sex,
                 abdomenStatus = localSpecimenImage.abdomenStatus,
@@ -473,12 +472,16 @@ class MetadataUploadWorker @AssistedInject constructor(
                         sexLogits = it.sexLogits,
                         abdomenStatusLogits = it.abdomenStatusLogits
                     )
-                })
+                }
+            )
 
-            // TODO: Change REMOTE ID when search by frontend ID
+            if (syncedSpecimen.remoteId == null) {
+                return DomainResult.Error(NetworkError.CLIENT_ERROR)
+            }
+
             val remoteSpecimenImageDto = when (val remoteSpecimenImageResult =
                 specimenImageDataSource.getSpecimenImageMetadata(
-                    localSpecimenImage.remoteId ?: -1, syncedSpecimenId
+                    localSpecimenImage.localId, syncedSpecimen.remoteId
                 )) {
                 is DomainResult.Success -> remoteSpecimenImageResult.data
                 is DomainResult.Error -> {
@@ -488,7 +491,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                                 specimenImageDataSource.postSpecimenImageMetadata(
                                     localSpecimenImage,
                                     localInferenceResult,
-                                    syncedSpecimenId // TODO: ADD REMOTE SESSION ID ONCE BACKEND WORKS
+                                    syncedSpecimen.remoteId
                                 )
                             when (postSpecimenImageResult) {
                                 is DomainResult.Success -> {
@@ -499,7 +502,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                                     specimenImageRepository.updateSpecimenImage(
                                         localSpecimenImage.copy(
                                             metadataUploadStatus = UploadStatus.PAUSED
-                                        ), syncedSpecimenId, syncedLocalSessionId
+                                        ), syncedSpecimen.id, syncedLocalSessionId
                                     )
                                     return DomainResult.Error(
                                         postSpecimenImageResult.error
@@ -512,7 +515,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                             specimenImageRepository.updateSpecimenImage(
                                 localSpecimenImage.copy(
                                     metadataUploadStatus = UploadStatus.PAUSED
-                                ), syncedSpecimenId, syncedLocalSessionId
+                                ), syncedSpecimen.id, syncedLocalSessionId
                             )
                             return DomainResult.Error(remoteSpecimenImageResult.error)
                         }
@@ -521,7 +524,7 @@ class MetadataUploadWorker @AssistedInject constructor(
             }
 
             val remoteSpecimenImage = SpecimenImage(
-                localId = localSpecimenImage.localId, // TODO: Change to Remote when backend makes it available
+                localId = remoteSpecimenImageDto.filemd5,
                 remoteId = remoteSpecimenImageDto.id,
                 species = remoteSpecimenImageDto.species,
                 sex = remoteSpecimenImageDto.sex,
@@ -550,7 +553,7 @@ class MetadataUploadWorker @AssistedInject constructor(
             if (remoteSpecimenImageDto != localSpecimenImageDto) {
                 transactionHelper.runAsTransaction {
                     specimenImageRepository.updateSpecimenImage(
-                        remoteSpecimenImage, syncedSpecimenId, syncedLocalSessionId
+                        remoteSpecimenImage, syncedSpecimen.id, syncedLocalSessionId
                     ).onError {
                         return@runAsTransaction DomainResult.Error(NetworkError.CLIENT_ERROR)
                     }
@@ -567,21 +570,21 @@ class MetadataUploadWorker @AssistedInject constructor(
 
             specimenImageRepository.updateSpecimenImage(
                 remoteSpecimenImage.copy(metadataUploadStatus = UploadStatus.COMPLETED),
-                syncedSpecimenId,
+                syncedSpecimen.id,
                 syncedLocalSessionId
             )
             DomainResult.Success(Unit)
         } catch (e: IOException) {
             specimenImageRepository.updateSpecimenImage(
                 localSpecimenImage.copy(metadataUploadStatus = UploadStatus.PAUSED),
-                syncedSpecimenId,
+                syncedSpecimen.id,
                 syncedLocalSessionId
             )
             DomainResult.Error(NetworkError.NO_INTERNET)
         } catch (e: Exception) {
             specimenImageRepository.updateSpecimenImage(
                 localSpecimenImage.copy(metadataUploadStatus = UploadStatus.PAUSED),
-                syncedSpecimenId,
+                syncedSpecimen.id,
                 syncedLocalSessionId
             )
             DomainResult.Error(NetworkError.UNKNOWN_ERROR)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -176,7 +176,7 @@ class MetadataUploadWorker @AssistedInject constructor(
             specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.forEach { (specimenImage, _) ->
                 if (specimenImage.metadataUploadStatus == UploadStatus.IN_PROGRESS) {
                     specimenImageRepository.updateSpecimenImage(
-                        specimenImage.copy(metadataUploadStatus = UploadStatus.PAUSED),
+                        specimenImage.copy(metadataUploadStatus = UploadStatus.FAILED),
                         specimenWithImagesAndInferenceResults.specimen.id,
                         sessionId
                     )
@@ -501,7 +501,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                                 is DomainResult.Error -> {
                                     specimenImageRepository.updateSpecimenImage(
                                         localSpecimenImage.copy(
-                                            metadataUploadStatus = UploadStatus.PAUSED
+                                            metadataUploadStatus = UploadStatus.FAILED
                                         ), syncedSpecimen.id, syncedLocalSessionId
                                     )
                                     return DomainResult.Error(
@@ -514,7 +514,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                         else -> {
                             specimenImageRepository.updateSpecimenImage(
                                 localSpecimenImage.copy(
-                                    metadataUploadStatus = UploadStatus.PAUSED
+                                    metadataUploadStatus = UploadStatus.FAILED
                                 ), syncedSpecimen.id, syncedLocalSessionId
                             )
                             return DomainResult.Error(remoteSpecimenImageResult.error)
@@ -576,14 +576,14 @@ class MetadataUploadWorker @AssistedInject constructor(
             DomainResult.Success(Unit)
         } catch (e: IOException) {
             specimenImageRepository.updateSpecimenImage(
-                localSpecimenImage.copy(metadataUploadStatus = UploadStatus.PAUSED),
+                localSpecimenImage.copy(metadataUploadStatus = UploadStatus.FAILED),
                 syncedSpecimen.id,
                 syncedLocalSessionId
             )
             DomainResult.Error(NetworkError.NO_INTERNET)
         } catch (e: Exception) {
             specimenImageRepository.updateSpecimenImage(
-                localSpecimenImage.copy(metadataUploadStatus = UploadStatus.PAUSED),
+                localSpecimenImage.copy(metadataUploadStatus = UploadStatus.FAILED),
                 syncedSpecimen.id,
                 syncedLocalSessionId
             )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -63,7 +63,6 @@ class MetadataUploadWorker @AssistedInject constructor(
     private val specimenImageDataSource: SpecimenImageDataSource
 ) : CoroutineWorker(context, workerParams) {
 
-    private var retryCount = 0
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
@@ -124,7 +123,8 @@ class MetadataUploadWorker @AssistedInject constructor(
                 specimenRepository.getSpecimenImagesAndInferenceResultsBySession(syncedSession.localId)
             val totalSpecimens = localSpecimensWithImagesAndInferenceResults.size
             localSpecimensWithImagesAndInferenceResults.forEachIndexed { specimenIndex, specimenWithImagesAndInferenceResults ->
-                val totalImages = specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.size
+                val totalImages =
+                    specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.size
                 val syncedSpecimen = when (val syncSpecimenResult = syncSpecimenIfNeeded(
                     specimenWithImagesAndInferenceResults.specimen,
                     syncedSession.localId,
@@ -187,8 +187,7 @@ class MetadataUploadWorker @AssistedInject constructor(
     }
 
     private fun retryOrFailure(message: String): WorkerResult {
-        if (retryCount < MAX_RETRIES) {
-            retryCount++
+        if (runAttemptCount < MAX_RETRIES) {
             showUploadRetryNotification(message)
             return WorkerResult.retry()
         } else {
@@ -443,7 +442,7 @@ class MetadataUploadWorker @AssistedInject constructor(
 
     private suspend fun syncSpecimenImageAndInferenceResultIfNeeded(
         localSpecimenImage: SpecimenImage,
-        localInferenceResult: InferenceResult,
+        localInferenceResult: InferenceResult?,
         syncedSpecimenId: String,
         syncedLocalSessionId: UUID,
         syncedRemoteSessionId: Int
@@ -462,18 +461,19 @@ class MetadataUploadWorker @AssistedInject constructor(
                 abdomenStatus = localSpecimenImage.abdomenStatus,
                 capturedAt = localSpecimenImage.capturedAt,
                 submittedAt = localSpecimenImage.submittedAt,
-                inferenceResult = InferenceResultDto(
-                    bboxTopLeftX = localInferenceResult.bboxTopLeftX,
-                    bboxTopLeftY = localInferenceResult.bboxTopLeftY,
-                    bboxWidth = localInferenceResult.bboxWidth,
-                    bboxHeight = localInferenceResult.bboxHeight,
-                    bboxConfidence = localInferenceResult.bboxConfidence,
-                    bboxClassId = localInferenceResult.bboxClassId,
-                    speciesLogits = localInferenceResult.speciesLogits,
-                    sexLogits = localInferenceResult.sexLogits,
-                    abdomenStatusLogits = localInferenceResult.abdomenStatusLogits
-                )
-            )
+                inferenceResult = localInferenceResult?.let {
+                    InferenceResultDto(
+                        bboxTopLeftX = it.bboxTopLeftX,
+                        bboxTopLeftY = it.bboxTopLeftY,
+                        bboxWidth = it.bboxWidth,
+                        bboxHeight = it.bboxHeight,
+                        bboxConfidence = it.bboxConfidence,
+                        bboxClassId = it.bboxClassId,
+                        speciesLogits = it.speciesLogits,
+                        sexLogits = it.sexLogits,
+                        abdomenStatusLogits = it.abdomenStatusLogits
+                    )
+                })
 
             // TODO: Change REMOTE ID when search by frontend ID
             val remoteSpecimenImageDto = when (val remoteSpecimenImageResult =
@@ -533,17 +533,19 @@ class MetadataUploadWorker @AssistedInject constructor(
                 submittedAt = remoteSpecimenImageDto.submittedAt
             )
 
-            val remoteInferenceResult = InferenceResult(
-                bboxTopLeftX = remoteSpecimenImageDto.inferenceResult.bboxTopLeftX,
-                bboxTopLeftY = remoteSpecimenImageDto.inferenceResult.bboxTopLeftY,
-                bboxWidth = remoteSpecimenImageDto.inferenceResult.bboxWidth,
-                bboxHeight = remoteSpecimenImageDto.inferenceResult.bboxHeight,
-                bboxConfidence = remoteSpecimenImageDto.inferenceResult.bboxConfidence,
-                bboxClassId = remoteSpecimenImageDto.inferenceResult.bboxClassId,
-                speciesLogits = remoteSpecimenImageDto.inferenceResult.speciesLogits,
-                sexLogits = remoteSpecimenImageDto.inferenceResult.sexLogits,
-                abdomenStatusLogits = remoteSpecimenImageDto.inferenceResult.abdomenStatusLogits
-            )
+            val remoteInferenceResult = remoteSpecimenImageDto.inferenceResult?.let {
+                InferenceResult(
+                    bboxTopLeftX = it.bboxTopLeftX,
+                    bboxTopLeftY = it.bboxTopLeftY,
+                    bboxWidth = it.bboxWidth,
+                    bboxHeight = it.bboxHeight,
+                    bboxConfidence = it.bboxConfidence,
+                    bboxClassId = it.bboxClassId,
+                    speciesLogits = it.speciesLogits,
+                    sexLogits = it.sexLogits,
+                    abdomenStatusLogits = it.abdomenStatusLogits
+                )
+            }
 
             if (remoteSpecimenImageDto != localSpecimenImageDto) {
                 transactionHelper.runAsTransaction {
@@ -552,10 +554,13 @@ class MetadataUploadWorker @AssistedInject constructor(
                     ).onError {
                         return@runAsTransaction DomainResult.Error(NetworkError.CLIENT_ERROR)
                     }
-                    inferenceResultRepository.updateInferenceResult(
-                        remoteInferenceResult, remoteSpecimenImage.localId
-                    ).onError {
-                        return@runAsTransaction DomainResult.Error(NetworkError.CLIENT_ERROR)
+
+                    remoteInferenceResult?.let { remoteInferenceResult ->
+                        inferenceResultRepository.updateInferenceResult(
+                            remoteInferenceResult, remoteSpecimenImage.localId
+                        ).onError {
+                            return@runAsTransaction DomainResult.Error(NetworkError.CLIENT_ERROR)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -24,7 +24,7 @@ import com.vci.vectorcamapp.core.domain.model.Session
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
 import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
-import com.vci.vectorcamapp.core.domain.model.UploadStatus
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.network.api.DeviceDataSource
 import com.vci.vectorcamapp.core.domain.network.api.SessionDataSource
 import com.vci.vectorcamapp.core.domain.network.api.SpecimenDataSource
@@ -306,7 +306,8 @@ class MetadataUploadWorker @AssistedInject constructor(
                 submittedAt = remoteSessionDto.submittedAt,
                 notes = remoteSessionDto.notes,
                 latitude = remoteSessionDto.latitude,
-                longitude = remoteSessionDto.longitude
+                longitude = remoteSessionDto.longitude,
+                type = localSession.type
             )
 
             if (localSessionDto != remoteSessionDto) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/NetworkModule.kt
@@ -49,6 +49,7 @@ object NetworkModule {
                     ignoreUnknownKeys = true
                     encodeDefaults = true
                     prettyPrint = false
+                    explicitNulls = false
                 })
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Session.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Session.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.domain.model
 
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import java.util.UUID
 
 data class Session(
@@ -17,4 +18,5 @@ data class Session(
     val notes: String,
     val latitude: Float?,
     val longitude: Float?,
+    val type: SessionType
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
@@ -1,3 +1,6 @@
 package com.vci.vectorcamapp.core.domain.model
 
-data class Specimen(val id: String)
+data class Specimen(
+    val id: String,
+    val remoteId: Int?
+)

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/SpecimenImage.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/SpecimenImage.kt
@@ -5,7 +5,7 @@ import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import java.util.UUID
 
 data class SpecimenImage(
-    val localId: UUID,
+    val localId: String,
     val remoteId: Int?,
     val species: String?,
     val sex: String?,

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/SpecimenImage.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/SpecimenImage.kt
@@ -1,6 +1,7 @@
 package com.vci.vectorcamapp.core.domain.model
 
 import android.net.Uri
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import java.util.UUID
 
 data class SpecimenImage(

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/composites/SessionAndSurveillanceForm.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/composites/SessionAndSurveillanceForm.kt
@@ -5,5 +5,5 @@ import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
 
 data class SessionAndSurveillanceForm(
     val session: Session,
-    val surveillanceForm: SurveillanceForm
+    val surveillanceForm: SurveillanceForm?
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/composites/SpecimenImageAndInferenceResult.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/composites/SpecimenImageAndInferenceResult.kt
@@ -5,5 +5,5 @@ import com.vci.vectorcamapp.core.domain.model.SpecimenImage
 
 data class SpecimenImageAndInferenceResult(
     val specimenImage: SpecimenImage,
-    val inferenceResult: InferenceResult
+    val inferenceResult: InferenceResult?
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/enums/SessionType.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/enums/SessionType.kt
@@ -1,0 +1,6 @@
+package com.vci.vectorcamapp.core.domain.model.enums
+
+enum class SessionType {
+    SURVEILLANCE,
+    DATA_COLLECTION
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/enums/UploadStatus.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/enums/UploadStatus.kt
@@ -1,4 +1,4 @@
-package com.vci.vectorcamapp.core.domain.model
+package com.vci.vectorcamapp.core.domain.model.enums
 
 enum class UploadStatus {
     COMPLETED,

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/enums/UploadStatus.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/enums/UploadStatus.kt
@@ -3,7 +3,6 @@ package com.vci.vectorcamapp.core.domain.model.enums
 enum class UploadStatus {
     COMPLETED,
     IN_PROGRESS,
-    PAUSED,
     NOT_STARTED,
     FAILED
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenDataSource.kt
@@ -10,5 +10,8 @@ interface SpecimenDataSource {
     suspend fun postSpecimen(
         specimen: Specimen, sessionId: Int
     ): Result<PostSpecimenResponseDto, NetworkError>
-    suspend fun getSpecimenById(specimenId: String): Result<SpecimenDto, NetworkError>
+
+    suspend fun getSpecimenByIdAndSessionId(
+        specimenId: String, sessionId: Int
+    ): Result<SpecimenDto, NetworkError>
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenImageDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenImageDataSource.kt
@@ -9,7 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 
 interface SpecimenImageDataSource {
     suspend fun postSpecimenImageMetadata(
-        specimenImage: SpecimenImage, inferenceResult: InferenceResult, specimenId: String
+        specimenImage: SpecimenImage, inferenceResult: InferenceResult?, specimenId: String
     ): Result<PostSpecimenImageResponseDto, NetworkError>
 
     suspend fun getSpecimenImageMetadata(specimenImageId: Int, specimenId: String): Result<SpecimenImageDto, NetworkError>

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenImageDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenImageDataSource.kt
@@ -9,8 +9,8 @@ import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 
 interface SpecimenImageDataSource {
     suspend fun postSpecimenImageMetadata(
-        specimenImage: SpecimenImage, inferenceResult: InferenceResult?, specimenId: String
+        specimenImage: SpecimenImage, inferenceResult: InferenceResult?, specimenId: Int
     ): Result<PostSpecimenImageResponseDto, NetworkError>
 
-    suspend fun getSpecimenImageMetadata(specimenImageId: Int, specimenId: String): Result<SpecimenImageDto, NetworkError>
+    suspend fun getSpecimenImageMetadata(specimenImageId: String, specimenId: Int): Result<SpecimenImageDto, NetworkError>
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/InferenceResultRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/repository/InferenceResultRepository.kt
@@ -3,9 +3,8 @@ package com.vci.vectorcamapp.core.domain.repository
 import com.vci.vectorcamapp.core.domain.model.InferenceResult
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
-import java.util.UUID
 
 interface InferenceResultRepository {
-    suspend fun insertInferenceResult(inferenceResult: InferenceResult, specimenImageId: UUID) : Result<Unit, RoomDbError>
-    suspend fun updateInferenceResult(inferenceResult: InferenceResult, specimenImageId: UUID) : Result<Unit, RoomDbError>
+    suspend fun insertInferenceResult(inferenceResult: InferenceResult, specimenImageId: String) : Result<Unit, RoomDbError>
+    suspend fun updateInferenceResult(inferenceResult: InferenceResult, specimenImageId: String) : Result<Unit, RoomDbError>
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/DatePickerField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/DatePickerField.kt
@@ -25,8 +25,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import com.vci.vectorcamapp.R
+import com.vci.vectorcamapp.core.domain.util.Error
 import com.vci.vectorcamapp.core.presentation.util.error.toString
-import com.vci.vectorcamapp.intake.domain.util.FormValidationError
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 import java.text.SimpleDateFormat
@@ -38,7 +38,7 @@ fun DatePickerField(
     onDateSelected: (Long) -> Unit,
     modifier: Modifier = Modifier,
     label: String? = null,
-    error: FormValidationError? = null
+    error: Error? = null
 ) {
     val context = LocalContext.current
 

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/DropdownField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/DropdownField.kt
@@ -33,8 +33,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import com.vci.vectorcamapp.R
+import com.vci.vectorcamapp.core.domain.util.Error
 import com.vci.vectorcamapp.core.presentation.util.error.toString
-import com.vci.vectorcamapp.intake.domain.util.FormValidationError
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 import com.vci.vectorcamapp.ui.theme.screenHeightFraction
@@ -46,7 +46,7 @@ fun <T> DropdownField(
     onOptionSelected: (T) -> Unit,
     modifier: Modifier = Modifier,
     label: String? = null,
-    error: FormValidationError? = null,
+    error: Error? = null,
     itemContent: @Composable (T) -> Unit,
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
@@ -17,8 +17,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
+import com.vci.vectorcamapp.core.domain.util.Error
 import com.vci.vectorcamapp.core.presentation.util.error.toString
-import com.vci.vectorcamapp.intake.domain.util.FormValidationError
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 
@@ -30,7 +30,7 @@ fun TextEntryField(
     label: String? = null,
     singleLine: Boolean = false,
     keyboardType: KeyboardType = KeyboardType.Text,
-    error: FormValidationError? = null,
+    error: Error? = null,
     placeholder: String? = null
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
@@ -12,6 +12,7 @@ import com.vci.vectorcamapp.main.domain.util.MainError
 import com.vci.vectorcamapp.registration.domain.util.RegistrationError
 import com.vci.vectorcamapp.intake.domain.util.FormValidationError
 import com.vci.vectorcamapp.intake.domain.util.IntakeError
+import com.vci.vectorcamapp.landing.domain.util.LandingError
 
 fun Error.toString(context: Context): String {
     val resId = when (this) {
@@ -74,6 +75,10 @@ fun Error.toString(context: Context): String {
         is RegistrationError -> when (this) {
             RegistrationError.PROGRAM_NOT_FOUND -> R.string.registration_error_program_not_found
             RegistrationError.UNKNOWN_ERROR -> R.string.registration_error_unknown_error
+        }
+
+        is LandingError -> when (this) {
+            LandingError.SESSION_NOT_FOUND -> R.string.landing_error_session_not_found
         }
 
         is IntakeError -> when (this) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
@@ -39,7 +39,6 @@ fun Error.toString(context: Context): String {
         is CompleteSessionDetailsError -> when (this) {
             CompleteSessionDetailsError.SESSION_NOT_FOUND -> R.string.complete_session_error_session_not_found
             CompleteSessionDetailsError.SITE_NOT_FOUND -> R.string.complete_session_error_site_not_found
-            CompleteSessionDetailsError.SURVEILLANCE_FORM_NOT_FOUND -> R.string.complete_session_error_surveillance_form_not_found
             CompleteSessionDetailsError.SPECIMENS_NOT_FOUND -> R.string.complete_session_error_specimens_not_found
             CompleteSessionDetailsError.UNKNOWN_ERROR -> R.string.complete_session_error_unknown_error
         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/CapturedFrameProcessingResult.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/CapturedFrameProcessingResult.kt
@@ -1,0 +1,10 @@
+package com.vci.vectorcamapp.imaging.domain.model
+
+import com.vci.vectorcamapp.core.domain.model.InferenceResult
+
+data class CapturedFrameProcessingResult(
+    val species: String? = null,
+    val sex: String? = null,
+    val abdomenStatus: String? = null,
+    val capturedInferenceResult: InferenceResult? = null
+)

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/LiveFrameProcessingResult.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/LiveFrameProcessingResult.kt
@@ -1,0 +1,8 @@
+package com.vci.vectorcamapp.imaging.domain.model
+
+import com.vci.vectorcamapp.core.domain.model.InferenceResult
+
+data class LiveFrameProcessingResult(
+    val specimenId: String = "",
+    val previewInferenceResults: List<InferenceResult> = emptyList()
+)

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/DataCollectionImagingWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/DataCollectionImagingWorkflow.kt
@@ -1,0 +1,28 @@
+package com.vci.vectorcamapp.imaging.domain.strategy
+
+import android.graphics.Bitmap
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.imaging.domain.model.CapturedFrameProcessingResult
+import com.vci.vectorcamapp.imaging.domain.model.LiveFrameProcessingResult
+import com.vci.vectorcamapp.imaging.domain.repository.InferenceRepository
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
+import javax.inject.Inject
+
+class DataCollectionImagingWorkflow @Inject constructor(
+    private val inferenceRepository: InferenceRepository,
+) : ImagingWorkflow {
+    override suspend fun processLiveFrame(bitmap: Bitmap): LiveFrameProcessingResult {
+        return LiveFrameProcessingResult(
+            specimenId = inferenceRepository.readSpecimenId(bitmap),
+            previewInferenceResults = emptyList()
+        )
+    }
+
+    override suspend fun processCapturedFrame(bitmap: Bitmap): Result<CapturedFrameProcessingResult, ImagingError> {
+        return Result.Success(CapturedFrameProcessingResult())
+    }
+
+    override fun close() {
+        inferenceRepository.closeResources()
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/ImagingWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/ImagingWorkflow.kt
@@ -1,0 +1,13 @@
+package com.vci.vectorcamapp.imaging.domain.strategy
+
+import android.graphics.Bitmap
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.imaging.domain.model.CapturedFrameProcessingResult
+import com.vci.vectorcamapp.imaging.domain.model.LiveFrameProcessingResult
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
+
+interface ImagingWorkflow {
+    suspend fun processLiveFrame(bitmap: Bitmap): LiveFrameProcessingResult
+    suspend fun processCapturedFrame(bitmap: Bitmap): Result<CapturedFrameProcessingResult, ImagingError>
+    fun close()
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/ImagingWorkflowFactory.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/ImagingWorkflowFactory.kt
@@ -1,0 +1,16 @@
+package com.vci.vectorcamapp.imaging.domain.strategy
+
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
+import com.vci.vectorcamapp.imaging.domain.repository.InferenceRepository
+import javax.inject.Inject
+
+class ImagingWorkflowFactory @Inject constructor(
+    private val inferenceRepository: InferenceRepository
+) {
+    fun create(sessionType: SessionType): ImagingWorkflow {
+        return when (sessionType) {
+            SessionType.SURVEILLANCE -> SurveillanceImagingWorkflow(inferenceRepository)
+            SessionType.DATA_COLLECTION -> DataCollectionImagingWorkflow(inferenceRepository)
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/ImagingWorkflowFactory.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/ImagingWorkflowFactory.kt
@@ -2,6 +2,8 @@ package com.vci.vectorcamapp.imaging.domain.strategy
 
 import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import com.vci.vectorcamapp.imaging.domain.repository.InferenceRepository
+import com.vci.vectorcamapp.imaging.domain.strategy.concrete.DataCollectionImagingWorkflow
+import com.vci.vectorcamapp.imaging.domain.strategy.concrete.SurveillanceImagingWorkflow
 import javax.inject.Inject
 
 class ImagingWorkflowFactory @Inject constructor(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/SurveillanceImagingWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/SurveillanceImagingWorkflow.kt
@@ -1,0 +1,115 @@
+package com.vci.vectorcamapp.imaging.domain.strategy
+
+import android.graphics.Bitmap
+import com.vci.vectorcamapp.core.domain.model.InferenceResult
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.imaging.domain.enums.AbdomenStatusLabel
+import com.vci.vectorcamapp.imaging.domain.enums.SexLabel
+import com.vci.vectorcamapp.imaging.domain.enums.SpeciesLabel
+import com.vci.vectorcamapp.imaging.domain.model.CapturedFrameProcessingResult
+import com.vci.vectorcamapp.imaging.domain.model.LiveFrameProcessingResult
+import com.vci.vectorcamapp.imaging.domain.repository.InferenceRepository
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
+import javax.inject.Inject
+
+class SurveillanceImagingWorkflow @Inject constructor(
+    private val inferenceRepository: InferenceRepository
+) : ImagingWorkflow {
+    override suspend fun processLiveFrame(bitmap: Bitmap): LiveFrameProcessingResult {
+        return LiveFrameProcessingResult(
+            specimenId = inferenceRepository.readSpecimenId(bitmap),
+            previewInferenceResults = inferenceRepository.detectSpecimen(bitmap)
+        )
+    }
+
+    override suspend fun processCapturedFrame(bitmap: Bitmap): Result<CapturedFrameProcessingResult, ImagingError> {
+        val captureInferenceResults = inferenceRepository.detectSpecimen(bitmap)
+
+        when (captureInferenceResults.size) {
+            0 -> return Result.Error(ImagingError.NO_SPECIMEN_FOUND)
+            1 -> {
+                val captureInferenceResult = captureInferenceResults.first()
+                val topLeftXFloat =
+                    captureInferenceResult.bboxTopLeftX * bitmap.width
+                val topLeftYFloat =
+                    captureInferenceResult.bboxTopLeftY * bitmap.height
+                val widthFloat = captureInferenceResult.bboxWidth * bitmap.width
+                val heightFloat = captureInferenceResult.bboxHeight * bitmap.height
+
+                val topLeftXAbsolute = topLeftXFloat.toInt()
+                val topLeftYAbsolute = topLeftYFloat.toInt()
+                val widthAbsolute =
+                    (widthFloat + (topLeftXFloat - topLeftXAbsolute)).toInt()
+                val heightAbsolute =
+                    (heightFloat + (topLeftYFloat - topLeftYAbsolute)).toInt()
+
+                val clampedTopLeftX =
+                    topLeftXAbsolute.coerceIn(0, bitmap.width - 1)
+                val clampedTopLeftY =
+                    topLeftYAbsolute.coerceIn(0, bitmap.height - 1)
+                val clampedWidth =
+                    widthAbsolute.coerceIn(1, bitmap.width - clampedTopLeftX)
+                val clampedHeight =
+                    heightAbsolute.coerceIn(1, bitmap.height - clampedTopLeftY)
+
+                if (clampedWidth > 0 && clampedHeight > 0) {
+                    val croppedBitmap = Bitmap.createBitmap(
+                        bitmap,
+                        clampedTopLeftX,
+                        clampedTopLeftY,
+                        clampedWidth,
+                        clampedHeight
+                    )
+
+                    var (speciesLogits, sexLogits, abdomenStatusLogits) = inferenceRepository.classifySpecimen(
+                        croppedBitmap
+                    )
+
+                    val speciesIndex =
+                        speciesLogits?.let { logits -> logits.indexOf(logits.max()) }
+                    var sexIndex =
+                        sexLogits?.let { logits -> logits.indexOf(logits.max()) }
+                    var abdomenStatusIndex =
+                        abdomenStatusLogits?.let { logits -> logits.indexOf(logits.max()) }
+
+                    if (speciesLogits == null || speciesIndex == SpeciesLabel.NON_MOSQUITO.ordinal) {
+                        sexLogits = null
+                        sexIndex = null
+                    }
+                    if (sexLogits == null || sexIndex == SexLabel.MALE.ordinal) {
+                        abdomenStatusLogits = null
+                        abdomenStatusIndex = null
+                    }
+
+                    return Result.Success(
+                        CapturedFrameProcessingResult(
+                            species = speciesIndex?.let { index -> SpeciesLabel.entries[index].label },
+                            sex = sexIndex?.let { index -> SexLabel.entries[index].label },
+                            abdomenStatus = abdomenStatusIndex?.let { index -> AbdomenStatusLabel.entries[index].label },
+                            capturedInferenceResult = InferenceResult(
+                                bboxTopLeftX = captureInferenceResult.bboxTopLeftX,
+                                bboxTopLeftY = captureInferenceResult.bboxTopLeftY,
+                                bboxWidth = captureInferenceResult.bboxWidth,
+                                bboxHeight = captureInferenceResult.bboxHeight,
+                                bboxConfidence = captureInferenceResult.bboxConfidence,
+                                bboxClassId = captureInferenceResult.bboxClassId,
+                                speciesLogits = speciesLogits,
+                                sexLogits = sexLogits,
+                                abdomenStatusLogits = abdomenStatusLogits
+                            )
+                        )
+                    )
+
+                } else {
+                    return Result.Error(ImagingError.PROCESSING_ERROR)
+                }
+            }
+
+            else -> return Result.Error(ImagingError.MULTIPLE_SPECIMENS_FOUND)
+        }
+    }
+
+    override fun close() {
+        inferenceRepository.closeResources()
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/concrete/DataCollectionImagingWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/concrete/DataCollectionImagingWorkflow.kt
@@ -1,10 +1,11 @@
-package com.vci.vectorcamapp.imaging.domain.strategy
+package com.vci.vectorcamapp.imaging.domain.strategy.concrete
 
 import android.graphics.Bitmap
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.imaging.domain.model.CapturedFrameProcessingResult
 import com.vci.vectorcamapp.imaging.domain.model.LiveFrameProcessingResult
 import com.vci.vectorcamapp.imaging.domain.repository.InferenceRepository
+import com.vci.vectorcamapp.imaging.domain.strategy.ImagingWorkflow
 import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 import javax.inject.Inject
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/concrete/SurveillanceImagingWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/concrete/SurveillanceImagingWorkflow.kt
@@ -1,4 +1,4 @@
-package com.vci.vectorcamapp.imaging.domain.strategy
+package com.vci.vectorcamapp.imaging.domain.strategy.concrete
 
 import android.graphics.Bitmap
 import com.vci.vectorcamapp.core.domain.model.InferenceResult
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.imaging.domain.enums.SpeciesLabel
 import com.vci.vectorcamapp.imaging.domain.model.CapturedFrameProcessingResult
 import com.vci.vectorcamapp.imaging.domain.model.LiveFrameProcessingResult
 import com.vci.vectorcamapp.imaging.domain.repository.InferenceRepository
+import com.vci.vectorcamapp.imaging.domain.strategy.ImagingWorkflow
 import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 import javax.inject.Inject
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -257,7 +257,7 @@ fun ImagingScreen(
                                 label = "Capture",
                                 onClick = { onAction(ImagingAction.CaptureImage(controller)) },
                                 iconPainter = painterResource(id = R.drawable.ic_camera),
-                                enabled = !state.isProcessing,
+                                enabled = (!state.isProcessing && state.isCameraReady),
                                 modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.paddingMedium)
                             )
                         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -33,41 +33,4 @@ data class ImagingState(
     val isCameraReady: Boolean = false,
     val showExitDialog: Boolean = false,
     val pendingAction: ImagingAction? = null
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ImagingState
-
-        if (isProcessing != other.isProcessing) return false
-        if (displayOrientation != other.displayOrientation) return false
-        if (isCameraReady != other.isCameraReady) return false
-        if (currentSpecimen != other.currentSpecimen) return false
-        if (currentSpecimenImage != other.currentSpecimenImage) return false
-        if (currentInferenceResult != other.currentInferenceResult) return false
-        if (currentImageBytes != null) {
-            if (other.currentImageBytes == null) return false
-            if (!currentImageBytes.contentEquals(other.currentImageBytes)) return false
-        } else if (other.currentImageBytes != null) return false
-        if (previewInferenceResults != other.previewInferenceResults) return false
-        if (specimensWithImagesAndInferenceResults != other.specimensWithImagesAndInferenceResults) return false
-        if (manualFocusPoint != other.manualFocusPoint) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = isProcessing.hashCode()
-        result = 31 * result + displayOrientation
-        result = 31 * result + isCameraReady.hashCode()
-        result = 31 * result + currentSpecimen.hashCode()
-        result = 31 * result + currentSpecimenImage.hashCode()
-        result = 31 * result + currentInferenceResult.hashCode()
-        result = 31 * result + (currentImageBytes?.contentHashCode() ?: 0)
-        result = 31 * result + previewInferenceResults.hashCode()
-        result = 31 * result + specimensWithImagesAndInferenceResults.hashCode()
-        result = 31 * result + (manualFocusPoint?.hashCode() ?: 0)
-        return result
-    }
-}
+)

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -5,8 +5,7 @@ import androidx.compose.ui.geometry.Offset
 import com.vci.vectorcamapp.core.domain.model.InferenceResult
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
-import com.vci.vectorcamapp.core.domain.model.UploadStatus
-import com.vci.vectorcamapp.core.domain.model.composites.SpecimenImageAndInferenceResult
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
 import java.util.UUID
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -7,13 +7,12 @@ import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
 import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
-import java.util.UUID
 
 data class ImagingState(
     val isProcessing: Boolean = false,
-    val currentSpecimen: Specimen = Specimen(id = ""),
+    val currentSpecimen: Specimen = Specimen(id = "", remoteId = null),
     val currentSpecimenImage: SpecimenImage = SpecimenImage(
-        localId = UUID(0, 0),
+        localId = "",
         remoteId = null,
         species = null,
         sex = null,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -24,21 +24,48 @@ data class ImagingState(
         capturedAt = 0L,
         submittedAt = null
     ),
-    val currentInferenceResult: InferenceResult = InferenceResult(
-        bboxTopLeftX = 0f,
-        bboxTopLeftY = 0f,
-        bboxWidth = 0f,
-        bboxHeight = 0f,
-        bboxConfidence = 0f,
-        bboxClassId = 0,
-        speciesLogits = null,
-        sexLogits = null,
-        abdomenStatusLogits = null
-    ),
+    val currentInferenceResult: InferenceResult? = null,
     val currentImageBytes: ByteArray? = null,
     val previewInferenceResults: List<InferenceResult> = emptyList(),
     val specimensWithImagesAndInferenceResults: List<SpecimenWithSpecimenImagesAndInferenceResults> = emptyList(),
     val displayOrientation: Int = 0,
     val manualFocusPoint: Offset? = null,
     val isCameraReady: Boolean = false
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ImagingState
+
+        if (isProcessing != other.isProcessing) return false
+        if (displayOrientation != other.displayOrientation) return false
+        if (isCameraReady != other.isCameraReady) return false
+        if (currentSpecimen != other.currentSpecimen) return false
+        if (currentSpecimenImage != other.currentSpecimenImage) return false
+        if (currentInferenceResult != other.currentInferenceResult) return false
+        if (currentImageBytes != null) {
+            if (other.currentImageBytes == null) return false
+            if (!currentImageBytes.contentEquals(other.currentImageBytes)) return false
+        } else if (other.currentImageBytes != null) return false
+        if (previewInferenceResults != other.previewInferenceResults) return false
+        if (specimensWithImagesAndInferenceResults != other.specimensWithImagesAndInferenceResults) return false
+        if (manualFocusPoint != other.manualFocusPoint) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = isProcessing.hashCode()
+        result = 31 * result + displayOrientation
+        result = 31 * result + isCameraReady.hashCode()
+        result = 31 * result + currentSpecimen.hashCode()
+        result = 31 * result + currentSpecimenImage.hashCode()
+        result = 31 * result + currentInferenceResult.hashCode()
+        result = 31 * result + (currentImageBytes?.contentHashCode() ?: 0)
+        result = 31 * result + previewInferenceResults.hashCode()
+        result = 31 * result + specimensWithImagesAndInferenceResults.hashCode()
+        result = 31 * result + (manualFocusPoint?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -51,6 +51,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
+import java.security.MessageDigest
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -186,8 +187,7 @@ class ImagingViewModel @Inject constructor(
                     if (success) {
                         val workManager = WorkManager.getInstance(context)
                         val uploadConstraints =
-                            Constraints.Builder()
-                                .setRequiredNetworkType(NetworkType.CONNECTED)
+                            Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED)
                                 .build()
 
                         Log.d("Imaging View Model", currentSession.localId.toString())
@@ -208,9 +208,7 @@ class ImagingViewModel @Inject constructor(
                                 workDataOf(
                                     ImageUploadWorker.KEY_SESSION_ID to currentSession.localId.toString()
                                 )
-                            )
-                                .setConstraints(uploadConstraints)
-                                .setBackoffCriteria(
+                            ).setConstraints(uploadConstraints).setBackoffCriteria(
                                     BackoffPolicy.LINEAR,
                                     WorkRequest.MIN_BACKOFF_MILLIS,
                                     TimeUnit.MILLISECONDS
@@ -293,13 +291,12 @@ class ImagingViewModel @Inject constructor(
                         return@launch
                     }
 
-                    val saveResult =
-                        cameraRepository.saveImage(jpegBytes, filename, currentSession)
+                    val saveResult = cameraRepository.saveImage(jpegBytes, filename, currentSession)
 
                     saveResult.onSuccess { imageUri ->
-                        val specimen = Specimen(id = specimenId)
+                        val specimen = Specimen(id = specimenId, remoteId = null)
                         val specimenImage = SpecimenImage(
-                            localId = UUID.randomUUID(),
+                            localId = calculateMd5(jpegBytes),
                             remoteId = null,
                             species = _state.value.currentSpecimenImage.species,
                             sex = _state.value.currentSpecimenImage.sex,
@@ -315,8 +312,7 @@ class ImagingViewModel @Inject constructor(
                             val inferenceResult = _state.value.currentInferenceResult
 
                             val existingSpecimen = specimenRepository.getSpecimenByIdAndSessionId(
-                                specimenId,
-                                currentSession.localId
+                                specimenId, currentSession.localId
                             )
                             val specimenInsertionResult = if (existingSpecimen == null) {
                                 specimenRepository.insertSpecimen(specimen, currentSession.localId)
@@ -325,15 +321,12 @@ class ImagingViewModel @Inject constructor(
                             }
                             val specimenImageInsertionResult =
                                 specimenImageRepository.insertSpecimenImage(
-                                    specimenImage,
-                                    specimen.id,
-                                    currentSession.localId
+                                    specimenImage, specimen.id, currentSession.localId
                                 )
 
                             val inferenceResultInsertionResult = inferenceResult?.let {
                                 inferenceResultRepository.insertInferenceResult(
-                                    inferenceResult,
-                                    specimenImage.localId
+                                    inferenceResult, specimenImage.localId
                                 )
                             } ?: Result.Success(Unit)
 
@@ -373,7 +366,7 @@ class ImagingViewModel @Inject constructor(
                     id = "",
                 ),
                 currentSpecimenImage = it.currentSpecimenImage.copy(
-                    localId = UUID(0, 0),
+                    localId = "",
                     remoteId = null,
                     species = null,
                     sex = null,
@@ -390,6 +383,12 @@ class ImagingViewModel @Inject constructor(
                 previewInferenceResults = emptyList(),
             )
         }
+    }
+
+    private fun calculateMd5(imageByteArray: ByteArray) : String {
+        val md5 = MessageDigest.getInstance("MD5")
+        val digest = md5.digest(imageByteArray)
+        return digest.joinToString("") { "%02x".format(it) }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.util.Log
 import android.view.OrientationEventListener
 import androidx.compose.material3.SnackbarDuration
 import androidx.lifecycle.viewModelScope
@@ -21,8 +22,8 @@ import com.vci.vectorcamapp.core.data.upload.metadata.MetadataUploadWorker
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
-import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.repository.InferenceResultRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenImageRepository
@@ -31,11 +32,9 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.onError
 import com.vci.vectorcamapp.core.domain.util.onSuccess
 import com.vci.vectorcamapp.core.presentation.CoreViewModel
-import com.vci.vectorcamapp.imaging.domain.enums.AbdomenStatusLabel
-import com.vci.vectorcamapp.imaging.domain.enums.SexLabel
-import com.vci.vectorcamapp.imaging.domain.enums.SpeciesLabel
 import com.vci.vectorcamapp.imaging.domain.repository.CameraRepository
-import com.vci.vectorcamapp.imaging.domain.repository.InferenceRepository
+import com.vci.vectorcamapp.imaging.domain.strategy.ImagingWorkflow
+import com.vci.vectorcamapp.imaging.domain.strategy.ImagingWorkflowFactory
 import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 import com.vci.vectorcamapp.imaging.presentation.extensions.toUprightBitmap
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -64,8 +63,7 @@ class ImagingViewModel @Inject constructor(
     private val specimenRepository: SpecimenRepository,
     private val specimenImageRepository: SpecimenImageRepository,
     private val inferenceResultRepository: InferenceResultRepository,
-    private val cameraRepository: CameraRepository,
-    private val inferenceRepository: InferenceRepository
+    private val cameraRepository: CameraRepository
 ) : CoreViewModel() {
 
     companion object {
@@ -74,6 +72,10 @@ class ImagingViewModel @Inject constructor(
 
     @Inject
     lateinit var transactionHelper: TransactionHelper
+
+    @Inject
+    lateinit var imagingWorkflowFactory: ImagingWorkflowFactory
+    private lateinit var imagingWorkflow: ImagingWorkflow
 
     private val _specimensWithImagesAndInferenceResults: Flow<List<SpecimenWithSpecimenImagesAndInferenceResults>> =
         flow {
@@ -113,7 +115,10 @@ class ImagingViewModel @Inject constructor(
         orientationListener.enable()
 
         viewModelScope.launch {
-            if (currentSessionCache.getSession() == null) {
+            val session = currentSessionCache.getSession()
+            if (session != null) {
+                imagingWorkflow = imagingWorkflowFactory.create(session.type)
+            } else {
                 _events.send(ImagingEvent.NavigateBackToLandingScreen)
                 emitError(ImagingError.NO_ACTIVE_SESSION)
             }
@@ -148,13 +153,12 @@ class ImagingViewModel @Inject constructor(
                         val displayOrientation = _state.value.displayOrientation
                         val bitmap = action.frame.toUprightBitmap(displayOrientation)
 
-                        val specimenId = inferenceRepository.readSpecimenId(bitmap)
-                        val previewInferenceResults = inferenceRepository.detectSpecimen(bitmap)
+                        val liveFrameProcessingResult = imagingWorkflow.processLiveFrame(bitmap)
 
                         _state.update {
                             it.copy(
-                                currentSpecimen = it.currentSpecimen.copy(id = specimenId),
-                                previewInferenceResults = previewInferenceResults
+                                currentSpecimen = it.currentSpecimen.copy(id = liveFrameProcessingResult.specimenId),
+                                previewInferenceResults = liveFrameProcessingResult.previewInferenceResults
                             )
                         }
                     } catch (e: Exception) {
@@ -186,6 +190,7 @@ class ImagingViewModel @Inject constructor(
                                 .setRequiredNetworkType(NetworkType.CONNECTED)
                                 .build()
 
+                        Log.d("Imaging View Model", currentSession.localId.toString())
                         val metadataUploadRequest =
                             OneTimeWorkRequestBuilder<MetadataUploadWorker>().setInputData(
                                 workDataOf(
@@ -213,7 +218,7 @@ class ImagingViewModel @Inject constructor(
 
                         workManager.beginUniqueWork(
                             UPLOAD_WORK_CHAIN_NAME,
-                            ExistingWorkPolicy.APPEND_OR_REPLACE,
+                            ExistingWorkPolicy.REPLACE,
                             metadataUploadRequest
                         ).then(imageUploadRequest).enqueue()
 
@@ -239,100 +244,24 @@ class ImagingViewModel @Inject constructor(
                         val jpegBitmap =
                             BitmapFactory.decodeByteArray(jpegByteArray, 0, jpegByteArray.size)
 
-                        // Avoid issuing error if preview bounding boxes are not yet ready
-                        val captureInferenceResults = inferenceRepository.detectSpecimen(jpegBitmap)
+                        val capturedFrameProcessingResult =
+                            imagingWorkflow.processCapturedFrame(jpegBitmap)
 
-                        when (captureInferenceResults.size) {
-                            0 -> {
-                                emitError(ImagingError.NO_SPECIMEN_FOUND, SnackbarDuration.Short)
-                            }
-
-                            1 -> {
-                                val captureInferenceResult = captureInferenceResults.first()
-                                val topLeftXFloat =
-                                    captureInferenceResult.bboxTopLeftX * bitmap.width
-                                val topLeftYFloat =
-                                    captureInferenceResult.bboxTopLeftY * bitmap.height
-                                val widthFloat = captureInferenceResult.bboxWidth * bitmap.width
-                                val heightFloat = captureInferenceResult.bboxHeight * bitmap.height
-
-                                val topLeftXAbsolute = topLeftXFloat.toInt()
-                                val topLeftYAbsolute = topLeftYFloat.toInt()
-                                val widthAbsolute =
-                                    (widthFloat + (topLeftXFloat - topLeftXAbsolute)).toInt()
-                                val heightAbsolute =
-                                    (heightFloat + (topLeftYFloat - topLeftYAbsolute)).toInt()
-
-                                // Clamp the crop rectangle to stay within bitmap bounds
-                                val clampedTopLeftX =
-                                    topLeftXAbsolute.coerceIn(0, jpegBitmap.width - 1)
-                                val clampedTopLeftY =
-                                    topLeftYAbsolute.coerceIn(0, jpegBitmap.height - 1)
-                                val clampedWidth =
-                                    widthAbsolute.coerceIn(1, jpegBitmap.width - clampedTopLeftX)
-                                val clampedHeight =
-                                    heightAbsolute.coerceIn(1, jpegBitmap.height - clampedTopLeftY)
-
-                                if (clampedWidth > 0 && clampedHeight > 0) {
-                                    val croppedBitmap = Bitmap.createBitmap(
-                                        jpegBitmap,
-                                        clampedTopLeftX,
-                                        clampedTopLeftY,
-                                        clampedWidth,
-                                        clampedHeight
-                                    )
-                                    var (speciesLogits, sexLogits, abdomenStatusLogits) = inferenceRepository.classifySpecimen(
-                                        croppedBitmap
-                                    )
-
-                                    val speciesIndex =
-                                        speciesLogits?.let { logits -> logits.indexOf(logits.max()) }
-                                    var sexIndex =
-                                        sexLogits?.let { logits -> logits.indexOf(logits.max()) }
-                                    var abdomenStatusIndex =
-                                        abdomenStatusLogits?.let { logits -> logits.indexOf(logits.max()) }
-
-                                    if (speciesLogits == null || speciesIndex == SpeciesLabel.NON_MOSQUITO.ordinal) {
-                                        sexLogits = null
-                                        sexIndex = null
-                                    }
-                                    if (sexLogits == null || sexIndex == SexLabel.MALE.ordinal) {
-                                        abdomenStatusLogits = null
-                                        abdomenStatusIndex = null
-                                    }
-
-                                    _state.update {
-                                        it.copy(
-                                            currentSpecimenImage = it.currentSpecimenImage.copy(
-                                                species = speciesIndex?.let { index -> SpeciesLabel.entries[index].label },
-                                                sex = sexIndex?.let { index -> SexLabel.entries[index].label },
-                                                abdomenStatus = abdomenStatusIndex?.let { index -> AbdomenStatusLabel.entries[index].label },
-                                            ),
-                                            currentImageBytes = jpegByteArray,
-                                            currentInferenceResult = it.currentInferenceResult.copy(
-                                                bboxTopLeftX = captureInferenceResult.bboxTopLeftX,
-                                                bboxTopLeftY = captureInferenceResult.bboxTopLeftY,
-                                                bboxWidth = captureInferenceResult.bboxWidth,
-                                                bboxHeight = captureInferenceResult.bboxHeight,
-                                                bboxConfidence = captureInferenceResult.bboxConfidence,
-                                                bboxClassId = captureInferenceResult.bboxClassId,
-                                                speciesLogits = speciesLogits,
-                                                sexLogits = sexLogits,
-                                                abdomenStatusLogits = abdomenStatusLogits
-                                            ),
-                                            previewInferenceResults = emptyList()
-                                        )
-                                    }
-                                } else {
-                                    emitError(ImagingError.PROCESSING_ERROR, SnackbarDuration.Short)
-                                }
-                            }
-
-                            else -> {
-                                emitError(
-                                    ImagingError.MULTIPLE_SPECIMENS_FOUND, SnackbarDuration.Short
+                        capturedFrameProcessingResult.onSuccess { result ->
+                            _state.update {
+                                it.copy(
+                                    currentSpecimenImage = it.currentSpecimenImage.copy(
+                                        species = result.species,
+                                        sex = result.sex,
+                                        abdomenStatus = result.abdomenStatus
+                                    ),
+                                    currentImageBytes = jpegByteArray,
+                                    currentInferenceResult = result.capturedInferenceResult,
+                                    previewInferenceResults = emptyList()
                                 )
                             }
+                        }.onError { error ->
+                            emitError(error, SnackbarDuration.Short)
                         }
                     }.onError { error ->
                         if (error == ImagingError.NO_ACTIVE_SESSION) {
@@ -400,11 +329,13 @@ class ImagingViewModel @Inject constructor(
                                     specimen.id,
                                     currentSession.localId
                                 )
-                            val inferenceResultInsertionResult =
+
+                            val inferenceResultInsertionResult = inferenceResult?.let {
                                 inferenceResultRepository.insertInferenceResult(
                                     inferenceResult,
                                     specimenImage.localId
                                 )
+                            } ?: Result.Success(Unit)
 
                             specimenInsertionResult.onError { error ->
                                 emitError(error)
@@ -453,17 +384,7 @@ class ImagingViewModel @Inject constructor(
                     capturedAt = 0L,
                     submittedAt = null
                 ),
-                currentInferenceResult = it.currentInferenceResult.copy(
-                    bboxTopLeftX = 0f,
-                    bboxTopLeftY = 0f,
-                    bboxWidth = 0f,
-                    bboxHeight = 0f,
-                    bboxConfidence = 0f,
-                    bboxClassId = 0,
-                    speciesLogits = null,
-                    sexLogits = null,
-                    abdomenStatusLogits = null
-                ),
+                currentInferenceResult = null,
                 currentImageBytes = null,
                 isCameraReady = false,
                 previewInferenceResults = emptyList(),
@@ -475,6 +396,6 @@ class ImagingViewModel @Inject constructor(
         super.onCleared()
 
         orientationListener.disable()
-        inferenceRepository.closeResources()
+        imagingWorkflow.close()
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -21,7 +21,7 @@ import com.vci.vectorcamapp.core.data.upload.metadata.MetadataUploadWorker
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
-import com.vci.vectorcamapp.core.domain.model.UploadStatus
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
 import com.vci.vectorcamapp.core.domain.repository.InferenceResultRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/specimen/CapturedSpecimenTile.kt
@@ -48,7 +48,7 @@ import java.util.Locale
 fun CapturedSpecimenTile(
     specimen: Specimen,
     specimenImage: SpecimenImage,
-    inferenceResult: InferenceResult,
+    inferenceResult: InferenceResult?,
     modifier: Modifier = Modifier,
     specimenBitmap: Bitmap? = null,
     onSpecimenIdCorrected: ((String) -> Unit)? = null
@@ -81,9 +81,11 @@ fun CapturedSpecimenTile(
                 )
             }
 
-            BoundingBoxOverlay(
-                inferenceResult = inferenceResult, overlaySize = containerSize
-            )
+            inferenceResult?.let {
+                BoundingBoxOverlay(
+                    inferenceResult = inferenceResult, overlaySize = containerSize
+                )
+            }
         }
 
         Column(

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
@@ -1,6 +1,8 @@
 package com.vci.vectorcamapp.incomplete_session.presentation
 
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
+
 sealed interface IncompleteSessionEvent {
-    data object NavigateToIntakeScreen : IncompleteSessionEvent
+    data class NavigateToIntakeScreen(val sessionType: SessionType) : IncompleteSessionEvent
     data object NavigateToLandingScreen : IncompleteSessionEvent
 }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
@@ -38,10 +38,10 @@ class IncompleteSessionViewModel @Inject constructor(
             when (action) {
                 is IncompleteSessionAction.ResumeSession -> {
                     try {
-                        val relation = sessionRepository.getSessionAndSiteById(action.sessionId)
-                        if (relation != null) {
-                            currentSessionCache.saveSession(relation.session, relation.site.id)
-                            _events.send(IncompleteSessionEvent.NavigateToIntakeScreen)
+                        val sessionAndSite = sessionRepository.getSessionAndSiteById(action.sessionId)
+                        if (sessionAndSite != null) {
+                            currentSessionCache.saveSession(sessionAndSite.session, sessionAndSite.site.id)
+                            _events.send(IncompleteSessionEvent.NavigateToIntakeScreen(sessionAndSite.session.type))
                         } else {
                             emitError(IncompleteSessionError.SESSION_NOT_FOUND)
                         }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -56,7 +56,7 @@ fun IncompleteSessionCard(
 
                 Spacer(Modifier.height(MaterialTheme.dimensions.spacingSmall))
 
-                InfoPill(text = "Session ID: ${session.localId}", color = MaterialTheme.colors.info)
+                InfoPill(text = "Session Type: ${session.type}", color = MaterialTheme.colors.info)
 
                 Spacer(Modifier.height(MaterialTheme.dimensions.spacingSmall))
 

--- a/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/SurveillanceFormWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/SurveillanceFormWorkflow.kt
@@ -1,0 +1,7 @@
+package com.vci.vectorcamapp.intake.domain.strategy
+
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+
+interface SurveillanceFormWorkflow {
+    fun getSurveillanceForm(): SurveillanceForm?
+}

--- a/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/SurveillanceFormWorkflowFactory.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/SurveillanceFormWorkflowFactory.kt
@@ -1,0 +1,15 @@
+package com.vci.vectorcamapp.intake.domain.strategy
+
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
+import com.vci.vectorcamapp.intake.domain.strategy.concrete.SurveillanceFormAbsentWorkflow
+import com.vci.vectorcamapp.intake.domain.strategy.concrete.SurveillanceFormPresentWorkflow
+import javax.inject.Inject
+
+class SurveillanceFormWorkflowFactory @Inject constructor() {
+    fun create(sessionType: SessionType): SurveillanceFormWorkflow {
+        return when (sessionType) {
+            SessionType.SURVEILLANCE -> SurveillanceFormPresentWorkflow()
+            SessionType.DATA_COLLECTION -> SurveillanceFormAbsentWorkflow()
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/concrete/SurveillanceFormAbsentWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/concrete/SurveillanceFormAbsentWorkflow.kt
@@ -1,0 +1,8 @@
+package com.vci.vectorcamapp.intake.domain.strategy.concrete
+
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.intake.domain.strategy.SurveillanceFormWorkflow
+
+class SurveillanceFormAbsentWorkflow : SurveillanceFormWorkflow {
+    override fun getSurveillanceForm(): SurveillanceForm? = null
+}

--- a/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/concrete/SurveillanceFormPresentWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/domain/strategy/concrete/SurveillanceFormPresentWorkflow.kt
@@ -1,0 +1,19 @@
+package com.vci.vectorcamapp.intake.domain.strategy.concrete
+
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.intake.domain.strategy.SurveillanceFormWorkflow
+
+class SurveillanceFormPresentWorkflow : SurveillanceFormWorkflow {
+    override fun getSurveillanceForm(): SurveillanceForm? {
+        return SurveillanceForm(
+            numPeopleSleptInHouse = 0,
+            wasIrsConducted = false,
+            monthsSinceIrs = null,
+            numLlinsAvailable = 0,
+            llinType = null,
+            llinBrand = null,
+            numPeopleSleptUnderLlin = null,
+            submittedAt = null
+        )
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
@@ -56,6 +56,8 @@ fun IntakeScreen(
                 iconPainter = painterResource(R.drawable.ic_info),
                 iconDescription = "General Information Icon"
             ) {
+                InfoPill(text = "Session Type: ${state.session.type.name}", color = MaterialTheme.colors.info)
+
                 TextEntryField(
                     label = "Collector Name",
                     value = state.session.collectorName,

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
@@ -168,14 +168,16 @@ fun IntakeScreen(
                     error = state.intakeErrors.houseNumber
                 )
 
-                TextEntryField(
-                    label = "Number of People Living in the House",
-                    value = if (state.surveillanceForm.numPeopleSleptInHouse == 0) "" else state.surveillanceForm.numPeopleSleptInHouse.toString(),
-                    onValueChange = { onAction(IntakeAction.EnterNumPeopleSleptInHouse(it.filter { character -> character.isDigit() })) },
-                    placeholder = "0",
-                    singleLine = true,
-                    keyboardType = KeyboardType.Number,
-                )
+                state.surveillanceForm?.let { surveillanceForm ->
+                    TextEntryField(
+                        label = "Number of People Living in the House",
+                        value = if (surveillanceForm.numPeopleSleptInHouse == 0) "" else surveillanceForm.numPeopleSleptInHouse.toString(),
+                        onValueChange = { onAction(IntakeAction.EnterNumPeopleSleptInHouse(it.filter { character -> character.isDigit() })) },
+                        placeholder = "0",
+                        singleLine = true,
+                        keyboardType = KeyboardType.Number,
+                    )
+                }
 
                 when {
                     state.session.latitude != null && state.session.longitude != null -> {
@@ -239,93 +241,95 @@ fun IntakeScreen(
             }
         }
 
-        item {
-            IntakeTile(
-                title = "Surveillance Form",
-                iconPainter = painterResource(id = R.drawable.ic_clipboard),
-                iconDescription = "Surveillance Form Icon"
-            ) {
-                ToggleField(
-                    label = "Was IRS conducted in this household?",
-                    checked = state.surveillanceForm.wasIrsConducted,
-                    onCheckedChange = {
-                        onAction(
-                            IntakeAction.ToggleIrsConducted(
-                                it
+        state.surveillanceForm?.let { surveillanceForm ->
+            item {
+                IntakeTile(
+                    title = "Surveillance Form",
+                    iconPainter = painterResource(id = R.drawable.ic_clipboard),
+                    iconDescription = "Surveillance Form Icon"
+                ) {
+                    ToggleField(
+                        label = "Was IRS conducted in this household?",
+                        checked = surveillanceForm.wasIrsConducted,
+                        onCheckedChange = {
+                            onAction(
+                                IntakeAction.ToggleIrsConducted(
+                                    it
+                                )
                             )
-                        )
-                    })
+                        })
 
-                if (state.surveillanceForm.wasIrsConducted) {
-                    TextEntryField(
-                        label = "Months Since IRS",
-                        value = state.surveillanceForm.monthsSinceIrs?.let { if (it == 0) "" else it.toString() }
-                            .orEmpty(),
-                        onValueChange = {
-                            onAction(IntakeAction.EnterMonthsSinceIrs(it.filter { character -> character.isDigit() }))
-                        },
-                        placeholder = "0",
-                        singleLine = true,
-                        keyboardType = KeyboardType.Number,
-                    )
-                }
-
-                TextEntryField(
-                    label = "Number of LLINs Available",
-                    value = if (state.surveillanceForm.numLlinsAvailable == 0) "" else state.surveillanceForm.numLlinsAvailable.toString(),
-                    onValueChange = { onAction(IntakeAction.EnterNumLlinsAvailable(it.filter { character -> character.isDigit() })) },
-                    placeholder = "0",
-                    singleLine = true,
-                    keyboardType = KeyboardType.Number
-                )
-
-                state.surveillanceForm.llinType?.let { current ->
-                    DropdownField(
-                        label = "LLIN Type",
-                        options = IntakeDropdownOptions.LlinTypeOption.entries,
-                        selectedOption = IntakeDropdownOptions.LlinTypeOption.entries.firstOrNull { it.label == current },
-                        onOptionSelected = {
-                            onAction(IntakeAction.SelectLlinType(it))
-                        },
-                        error = state.intakeErrors.llinType,
-                    ) { llinType ->
-                        Text(
-                            text = llinType.label,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colors.textPrimary
+                    if (surveillanceForm.wasIrsConducted) {
+                        TextEntryField(
+                            label = "Months Since IRS",
+                            value = surveillanceForm.monthsSinceIrs?.let { if (it == 0) "" else it.toString() }
+                                .orEmpty(),
+                            onValueChange = {
+                                onAction(IntakeAction.EnterMonthsSinceIrs(it.filter { character -> character.isDigit() }))
+                            },
+                            placeholder = "0",
+                            singleLine = true,
+                            keyboardType = KeyboardType.Number,
                         )
                     }
-                }
 
-                state.surveillanceForm.llinBrand?.let { current ->
-                    DropdownField(
-                        label = "LLIN Brand",
-                        options = IntakeDropdownOptions.LlinBrandOption.entries,
-                        selectedOption = IntakeDropdownOptions.LlinBrandOption.entries.firstOrNull { it.label == current },
-                        onOptionSelected = {
-                            onAction(IntakeAction.SelectLlinBrand(it))
-                        },
-                        error = state.intakeErrors.llinBrand,
-                    ) { llinBrand ->
-                        Text(
-                            text = llinBrand.label,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colors.textPrimary
-                        )
-                    }
-                }
-
-                state.surveillanceForm.numPeopleSleptUnderLlin?.let { current ->
                     TextEntryField(
-                        label = "Number of People who Slept Under LLIN",
-                        value = if (current == 0) "" else current.toString(),
-                        onValueChange = {
-                            onAction(IntakeAction.EnterNumPeopleSleptUnderLlin(it.filter { character -> character.isDigit() }))
-                        },
+                        label = "Number of LLINs Available",
+                        value = if (surveillanceForm.numLlinsAvailable == 0) "" else surveillanceForm.numLlinsAvailable.toString(),
+                        onValueChange = { onAction(IntakeAction.EnterNumLlinsAvailable(it.filter { character -> character.isDigit() })) },
                         placeholder = "0",
                         singleLine = true,
                         keyboardType = KeyboardType.Number
                     )
+
+                    surveillanceForm.llinType?.let { current ->
+                        DropdownField(
+                            label = "LLIN Type",
+                            options = IntakeDropdownOptions.LlinTypeOption.entries,
+                            selectedOption = IntakeDropdownOptions.LlinTypeOption.entries.firstOrNull { it.label == current },
+                            onOptionSelected = {
+                                onAction(IntakeAction.SelectLlinType(it))
+                            },
+                            error = state.intakeErrors.llinType,
+                        ) { llinType ->
+                            Text(
+                                text = llinType.label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colors.textPrimary
+                            )
+                        }
+                    }
+
+                    surveillanceForm.llinBrand?.let { current ->
+                        DropdownField(
+                            label = "LLIN Brand",
+                            options = IntakeDropdownOptions.LlinBrandOption.entries,
+                            selectedOption = IntakeDropdownOptions.LlinBrandOption.entries.firstOrNull { it.label == current },
+                            onOptionSelected = {
+                                onAction(IntakeAction.SelectLlinBrand(it))
+                            },
+                            error = state.intakeErrors.llinBrand,
+                        ) { llinBrand ->
+                            Text(
+                                text = llinBrand.label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colors.textPrimary
+                            )
+                        }
+                    }
+
+                    surveillanceForm.numPeopleSleptUnderLlin?.let { current ->
+                        TextEntryField(
+                            label = "Number of People who Slept Under LLIN",
+                            value = if (current == 0) "" else current.toString(),
+                            onValueChange = {
+                                onAction(IntakeAction.EnterNumPeopleSleptUnderLlin(it.filter { character -> character.isDigit() }))
+                            },
+                            placeholder = "0",
+                            singleLine = true,
+                            keyboardType = KeyboardType.Number
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeState.kt
@@ -3,6 +3,7 @@ package com.vci.vectorcamapp.intake.presentation
 import com.vci.vectorcamapp.core.domain.model.Session
 import com.vci.vectorcamapp.core.domain.model.Site
 import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import com.vci.vectorcamapp.intake.presentation.model.IntakeErrors
 import com.vci.vectorcamapp.intake.domain.util.IntakeError
 
@@ -26,9 +27,10 @@ data class IntakeState(
         createdAt = System.currentTimeMillis(),
         completedAt = null,
         submittedAt = null,
+        notes = "",
         latitude = null,
         longitude = null,
-        notes = ""
+        type = SessionType.SURVEILLANCE
     ),
     val surveillanceForm: SurveillanceForm = SurveillanceForm(
         numPeopleSleptInHouse = 0,

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeState.kt
@@ -32,16 +32,7 @@ data class IntakeState(
         longitude = null,
         type = SessionType.SURVEILLANCE
     ),
-    val surveillanceForm: SurveillanceForm = SurveillanceForm(
-        numPeopleSleptInHouse = 0,
-        wasIrsConducted = false,
-        monthsSinceIrs = null,
-        numLlinsAvailable = 0,
-        llinType = null,
-        llinBrand = null,
-        numPeopleSleptUnderLlin = null,
-        submittedAt = null
-    ),
+    val surveillanceForm: SurveillanceForm? = null,
     val intakeErrors: IntakeErrors = IntakeErrors(
         collectorTitle = null,
         collectorName = null,

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -1,10 +1,12 @@
 package com.vci.vectorcamapp.intake.presentation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.data.room.TransactionHelper
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.cache.DeviceCache
 import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SiteRepository
 import com.vci.vectorcamapp.core.domain.repository.SurveillanceFormRepository
@@ -32,6 +34,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class IntakeViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
     private val validationUseCases: ValidationUseCases,
     private val deviceCache: DeviceCache,
     private val currentSessionCache: CurrentSessionCache,
@@ -398,7 +401,10 @@ class IntakeViewModel @Inject constructor(
             _state.update {
                 it.copy(
                     isLoading = false,
-                    session = currentSession ?: it.session,
+                    session = currentSession ?: it.session.copy(
+                        type = savedStateHandle.get<SessionType>("sessionType")
+                            ?: SessionType.SURVEILLANCE
+                    ),
                     surveillanceForm = savedForm ?: it.surveillanceForm,
                     allSitesInProgram = allSites,
                     selectedDistrict = district,
@@ -430,8 +436,7 @@ class IntakeViewModel @Inject constructor(
                         session = it.session.copy(
                             latitude = location.latitude.toFloat(),
                             longitude = location.longitude.toFloat(),
-                        ),
-                        locationError = null
+                        ), locationError = null
                     )
                 }
             }.onError { error ->

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -16,6 +16,8 @@ import com.vci.vectorcamapp.core.domain.util.onError
 import com.vci.vectorcamapp.core.domain.util.onSuccess
 import com.vci.vectorcamapp.core.presentation.CoreViewModel
 import com.vci.vectorcamapp.intake.domain.repository.LocationRepository
+import com.vci.vectorcamapp.intake.domain.strategy.SurveillanceFormWorkflow
+import com.vci.vectorcamapp.intake.domain.strategy.SurveillanceFormWorkflowFactory
 import com.vci.vectorcamapp.intake.domain.use_cases.ValidationUseCases
 import com.vci.vectorcamapp.intake.domain.util.IntakeError
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -51,6 +53,10 @@ class IntakeViewModel @Inject constructor(
     @Inject
     lateinit var transactionHelper: TransactionHelper
 
+    @Inject
+    lateinit var surveillanceFormWorkflowFactory: SurveillanceFormWorkflowFactory
+    private lateinit var surveillanceFormWorkflow: SurveillanceFormWorkflow
+
     private val _state = MutableStateFlow(IntakeState())
     val state: StateFlow<IntakeState> = _state.onStart {
         loadFormDetails()
@@ -84,9 +90,9 @@ class IntakeViewModel @Inject constructor(
                     val houseNumberResult =
                         validationUseCases.validateHouseNumber(session.houseNumber)
                     val llinTypeResult =
-                        surveillanceForm.llinType?.let { validationUseCases.validateLlinType(it) }
+                        surveillanceForm?.llinType?.let { validationUseCases.validateLlinType(it) }
                     val llinBrandResult =
-                        surveillanceForm.llinBrand?.let { validationUseCases.validateLlinBrand(it) }
+                        surveillanceForm?.llinBrand?.let { validationUseCases.validateLlinBrand(it) }
                     val collectionDateResult =
                         validationUseCases.validateCollectionDate(session.collectionDate)
                     val collectionMethodResult =
@@ -141,10 +147,12 @@ class IntakeViewModel @Inject constructor(
                                 return@runAsTransaction false
                             }
 
-                            val surveillanceFormResult =
+                            val surveillanceFormResult = surveillanceForm?.let {
                                 surveillanceFormRepository.upsertSurveillanceForm(
                                     surveillanceForm, session.localId
                                 )
+                            } ?: Result.Success(Unit)
+
                             surveillanceFormResult.onError { error ->
                                 emitError(error)
                                 return@runAsTransaction false
@@ -211,7 +219,7 @@ class IntakeViewModel @Inject constructor(
                     numPeopleSleptInHouse?.let { count ->
                         _state.update {
                             it.copy(
-                                surveillanceForm = it.surveillanceForm.copy(
+                                surveillanceForm = it.surveillanceForm?.copy(
                                     numPeopleSleptInHouse = count
                                 )
                             )
@@ -223,7 +231,7 @@ class IntakeViewModel @Inject constructor(
                     val wasIrsConducted = action.isChecked
                     _state.update {
                         it.copy(
-                            surveillanceForm = it.surveillanceForm.copy(
+                            surveillanceForm = it.surveillanceForm?.copy(
                                 wasIrsConducted = wasIrsConducted,
                                 monthsSinceIrs = if (wasIrsConducted) 0 else null
                             )
@@ -237,7 +245,7 @@ class IntakeViewModel @Inject constructor(
                     monthsSinceIrs?.let { count ->
                         _state.update {
                             it.copy(
-                                surveillanceForm = it.surveillanceForm.copy(
+                                surveillanceForm = it.surveillanceForm?.copy(
                                     monthsSinceIrs = count
                                 )
                             )
@@ -251,7 +259,7 @@ class IntakeViewModel @Inject constructor(
                     numLlinsAvailable?.let { count ->
                         _state.update {
                             it.copy(
-                                surveillanceForm = it.surveillanceForm.copy(
+                                surveillanceForm = it.surveillanceForm?.copy(
                                     numLlinsAvailable = count
                                 )
                             )
@@ -259,7 +267,7 @@ class IntakeViewModel @Inject constructor(
                         if (numLlinsAvailable == 0) {
                             _state.update {
                                 it.copy(
-                                    surveillanceForm = it.surveillanceForm.copy(
+                                    surveillanceForm = it.surveillanceForm?.copy(
                                         llinType = null,
                                         llinBrand = null,
                                         numPeopleSleptUnderLlin = null
@@ -269,7 +277,7 @@ class IntakeViewModel @Inject constructor(
                         } else {
                             _state.update {
                                 it.copy(
-                                    surveillanceForm = it.surveillanceForm.copy(
+                                    surveillanceForm = it.surveillanceForm?.copy(
                                         llinType = "", llinBrand = "", numPeopleSleptUnderLlin = 0
                                     )
                                 )
@@ -281,7 +289,7 @@ class IntakeViewModel @Inject constructor(
                 is IntakeAction.SelectLlinType -> {
                     _state.update {
                         it.copy(
-                            surveillanceForm = it.surveillanceForm.copy(
+                            surveillanceForm = it.surveillanceForm?.copy(
                                 llinType = action.option.label
                             )
                         )
@@ -291,7 +299,7 @@ class IntakeViewModel @Inject constructor(
                 is IntakeAction.SelectLlinBrand -> {
                     _state.update {
                         it.copy(
-                            surveillanceForm = it.surveillanceForm.copy(
+                            surveillanceForm = it.surveillanceForm?.copy(
                                 llinBrand = action.option.label
                             )
                         )
@@ -304,7 +312,7 @@ class IntakeViewModel @Inject constructor(
                     numPeopleSleptUnderLlin?.let { count ->
                         _state.update {
                             it.copy(
-                                surveillanceForm = it.surveillanceForm.copy(
+                                surveillanceForm = it.surveillanceForm?.copy(
                                     numPeopleSleptUnderLlin = count
                                 )
                             )
@@ -398,14 +406,17 @@ class IntakeViewModel @Inject constructor(
                 }
             }
 
+            val effectiveSession = currentSession ?: _state.value.session.copy(
+                type = savedStateHandle.get<SessionType>("sessionType")
+                    ?: SessionType.SURVEILLANCE
+            )
+            surveillanceFormWorkflow = surveillanceFormWorkflowFactory.create(effectiveSession.type)
+
             _state.update {
                 it.copy(
                     isLoading = false,
-                    session = currentSession ?: it.session.copy(
-                        type = savedStateHandle.get<SessionType>("sessionType")
-                            ?: SessionType.SURVEILLANCE
-                    ),
-                    surveillanceForm = savedForm ?: it.surveillanceForm,
+                    session = effectiveSession,
+                    surveillanceForm = savedForm ?: surveillanceFormWorkflow.getSurveillanceForm(),
                     allSitesInProgram = allSites,
                     selectedDistrict = district,
                     selectedSentinelSite = sentinelSite

--- a/app/src/main/java/com/vci/vectorcamapp/landing/domain/util/LandingError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/domain/util/LandingError.kt
@@ -1,0 +1,7 @@
+package com.vci.vectorcamapp.landing.domain.util
+
+import com.vci.vectorcamapp.core.domain.util.Error
+
+enum class LandingError : Error {
+    SESSION_NOT_FOUND
+}

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingAction.kt
@@ -1,7 +1,8 @@
 package com.vci.vectorcamapp.landing.presentation
 
 sealed interface LandingAction {
-    data object StartNewSession : LandingAction
+    data object StartNewSurveillanceSession : LandingAction
+    data object StartNewDataCollectionSession : LandingAction
     data object ViewIncompleteSessions : LandingAction
     data object ViewCompleteSessions : LandingAction
     data object ResumeSession : LandingAction

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingEvent.kt
@@ -1,7 +1,9 @@
 package com.vci.vectorcamapp.landing.presentation
 
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
+
 sealed interface LandingEvent {
-    data object NavigateToNewSessionScreen: LandingEvent
+    data class NavigateToIntakeScreen(val sessionType: SessionType): LandingEvent
     data object NavigateToIncompleteSessionsScreen: LandingEvent
     data object NavigateToCompleteSessionsScreen: LandingEvent
     data object NavigateBackToRegistrationScreen: LandingEvent

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
@@ -49,13 +49,13 @@ fun LandingScreen(
                         title = "Start New Session",
                         description = "Begin a new household visit and capture mosquito images.",
                         icon = painterResource(R.drawable.ic_specimen),
-                        onClick = { onAction(LandingAction.StartNewSession) })
+                        onClick = { onAction(LandingAction.StartNewSurveillanceSession) })
 
                     LandingActionTile(
                         title = "Data Collection Mode",
                         description = "Capture and upload mosquito images without filling forms.",
                         icon = painterResource(R.drawable.ic_database),
-                        onClick = { Log.d("LandingScreen", "Data Collection Mode") })
+                        onClick = { onAction(LandingAction.StartNewDataCollectionSession) })
                 }
 
                 LandingSection(title = "Library") {

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
@@ -46,7 +46,7 @@ fun LandingScreen(
 
                 LandingSection(title = "Imaging") {
                     LandingActionTile(
-                        title = "Start New Session",
+                        title = "New Surveillance Session",
                         description = "Begin a new household visit and capture mosquito images.",
                         icon = painterResource(R.drawable.ic_specimen),
                         onClick = { onAction(LandingAction.StartNewSurveillanceSession) })

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingViewModel.kt
@@ -1,12 +1,13 @@
 package com.vci.vectorcamapp.landing.presentation
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.domain.cache.CurrentSessionCache
 import com.vci.vectorcamapp.core.domain.cache.DeviceCache
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import com.vci.vectorcamapp.core.domain.repository.ProgramRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.presentation.CoreViewModel
+import com.vci.vectorcamapp.landing.domain.util.LandingError
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -53,8 +54,12 @@ class LandingViewModel @Inject constructor(
     fun onAction(action: LandingAction) {
         viewModelScope.launch {
             when (action) {
-                LandingAction.StartNewSession -> {
-                    _events.send(LandingEvent.NavigateToNewSessionScreen)
+                LandingAction.StartNewSurveillanceSession -> {
+                    _events.send(LandingEvent.NavigateToIntakeScreen(SessionType.SURVEILLANCE))
+                }
+
+                LandingAction.StartNewDataCollectionSession -> {
+                    _events.send(LandingEvent.NavigateToIntakeScreen(SessionType.DATA_COLLECTION))
                 }
 
                 LandingAction.ViewIncompleteSessions -> {
@@ -66,8 +71,14 @@ class LandingViewModel @Inject constructor(
                 }
 
                 LandingAction.ResumeSession -> {
+                    val session = currentSessionCache.getSession()
+                    if (session == null) {
+                        emitError(LandingError.SESSION_NOT_FOUND)
+                        return@launch
+                    }
+
                     _state.update { it.copy(showResumeDialog = false) }
-                    _events.send(LandingEvent.NavigateToNewSessionScreen)
+                    _events.send(LandingEvent.NavigateToIntakeScreen(session.type))
                 }
 
                 LandingAction.DismissResumePrompt -> {

--- a/app/src/main/java/com/vci/vectorcamapp/navigation/Destination.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/navigation/Destination.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.navigation
 
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import kotlinx.serialization.Serializable
 
 sealed interface Destination {
@@ -10,7 +11,7 @@ sealed interface Destination {
     data object Landing : Destination
 
     @Serializable
-    data object Intake : Destination
+    data class Intake(val sessionType: SessionType) : Destination
 
     @Serializable
     data object Imaging : Destination

--- a/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
@@ -70,8 +70,8 @@ fun NavGraph(startDestination: Destination) {
 
             ObserveAsEvents(events = viewModel.events) { event ->
                 when (event) {
-                    LandingEvent.NavigateToNewSessionScreen -> navController.navigate(
-                        Destination.Intake
+                    is LandingEvent.NavigateToIntakeScreen -> navController.navigate(
+                        Destination.Intake(event.sessionType)
                     )
 
                     LandingEvent.NavigateToIncompleteSessionsScreen -> navController.navigate(
@@ -165,8 +165,8 @@ fun NavGraph(startDestination: Destination) {
 
             ObserveAsEvents(events = viewModel.events) { event ->
                 when (event) {
-                    IncompleteSessionEvent.NavigateToIntakeScreen ->
-                        navController.navigate(Destination.Intake)
+                    is IncompleteSessionEvent.NavigateToIntakeScreen ->
+                        navController.navigate(Destination.Intake(event.sessionType))
                     IncompleteSessionEvent.NavigateToLandingScreen -> navController.popBackStack()
                 }
             }

--- a/app/src/main/java/com/vci/vectorcamapp/ui/extensions/UploadStatusExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/ui/extensions/UploadStatusExtensions.kt
@@ -13,7 +13,6 @@ fun UploadStatus.color(): Color = when (this) {
     UploadStatus.IN_PROGRESS -> MaterialTheme.colors.warning
     UploadStatus.COMPLETED -> MaterialTheme.colors.successConfirm
     UploadStatus.FAILED -> MaterialTheme.colors.error
-    UploadStatus.PAUSED -> MaterialTheme.colors.error
 }
 
 fun UploadStatus.displayText(context: Context): String {
@@ -22,7 +21,6 @@ fun UploadStatus.displayText(context: Context): String {
         UploadStatus.IN_PROGRESS -> R.string.upload_status_in_progress
         UploadStatus.NOT_STARTED -> R.string.upload_status_not_started
         UploadStatus.FAILED -> R.string.upload_status_retry
-        UploadStatus.PAUSED -> R.string.upload_status_paused
     }
     return context.getString(resId)
 }

--- a/app/src/main/java/com/vci/vectorcamapp/ui/extensions/UploadStatusExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/ui/extensions/UploadStatusExtensions.kt
@@ -5,7 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.vci.vectorcamapp.R
-import com.vci.vectorcamapp.core.domain.model.UploadStatus
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 
 @Composable
 fun UploadStatus.color(): Color = when (this) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,9 @@
     <!-- Main error: Unknown error -->
     <string name="main_error_unknown_error">An unknown error occurred. Please try again or contact support if the issue persists.</string>
 
+    <!-- Landing error: Session not found -->
+    <string name="landing_error_session_not_found">Unable to find a saved session. Please start a new one.</string>
+
     <!-- Intake error: Site fetch failed -->
     <string name="intake_error_site_not_found">Site not found for selected district and sentinel site.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,9 +163,6 @@
     <!-- Complete session error: Site not found -->
     <string name="complete_session_error_site_not_found">Could not load site details. Please try again.</string>
 
-    <!-- Complete session error: Surveillance form not found -->
-    <string name="complete_session_error_surveillance_form_not_found">Could not load surveillance form details. Please try again.</string>
-
     <!-- Complete session error: Specimens not found -->
     <string name="complete_session_error_specimens_not_found">Could not load specimens. Please try again.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,9 +175,6 @@
     <!-- Image Upload Status: Upload in progress -->
     <string name="upload_status_in_progress">In Progress</string>
 
-    <!-- Image Upload Status: Upload paused -->
-    <string name="upload_status_paused">Paused</string>
-
     <!-- Image Upload Status: Upload not started -->
     <string name="upload_status_not_started">Not Started</string>
 


### PR DESCRIPTION
This PR introduces support for Data Collection Mode in VectorCam, enabling sessions where the surveillance form is not required. Unlike Surveillance Mode, which mandates form input, Data Collection Mode bypasses form collection entirely — based not just on session type but on broader program-level logic. This is especially useful for RCT arms or special deployments. To maintain modularity and flexibility, we extended the Strategy + Factory pattern already used in the imaging layer. A new SurveillanceFormWorkflow abstraction now governs form behavior, and the IntakeViewModel uses the factory to determine whether a form should be displayed, removing the need for additional booleans in UI state.

In parallel, we refined the ImagingWorkflow architecture to support Data Collection Mode more cleanly. Previously, all workflows assumed form capture as a prerequisite. With this update, we added new ImagingWorkflow variants that account for the absence of a form — for example, skipping form validation steps, image tagging logic, or metadata handling that previously depended on form inputs. This ensures consistent separation of session-specific behavior while maintaining the existing ViewModel contract.

We also made several changes to the local Room database schema. SpecimenEntity now includes a nullable remoteId field to track server-assigned IDs, and both SpecimenImageEntity and InferenceResultEntity now use String IDs instead of UUID, simplifying backend sync and improving consistency. Related foreign keys and indices were updated, and new type converters for UUID and FloatArray were added to support this transition. The migration (MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS) is destructive but safe given the current user base. On the networking side, we’ve configured kotlinx.serialization to use explicitNulls = false so that inference results are omitted entirely from the payload when not present, rather than sending "inferenceResult": null" — ensuring backend compatibility and cleaner requests.