### PR TITLE
SOF-278: Add back buttons to all screens

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsAction.kt
@@ -3,5 +3,6 @@ package com.vci.vectorcamapp.complete_session.details.presentation
 import com.vci.vectorcamapp.complete_session.details.presentation.enums.CompleteSessionDetailsTab
 
 sealed interface CompleteSessionDetailsAction {
+    data object ReturnToCompleteSessionListScreen : CompleteSessionDetailsAction
     data class ChangeSelectedTab(val selectedTab: CompleteSessionDetailsTab) : CompleteSessionDetailsAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsEvent.kt
@@ -1,0 +1,5 @@
+package com.vci.vectorcamapp.complete_session.details.presentation
+
+sealed interface CompleteSessionDetailsEvent {
+    data object NavigateBackToCompleteSessionListScreen: CompleteSessionDetailsEvent
+}

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
@@ -1,16 +1,24 @@
 package com.vci.vectorcamapp.complete_session.details.presentation
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.complete_session.details.presentation.components.SegmentedTabBar
 import com.vci.vectorcamapp.complete_session.details.presentation.components.form.CompleteSessionForm
 import com.vci.vectorcamapp.complete_session.details.presentation.components.specimens.CompleteSessionSpecimens
 import com.vci.vectorcamapp.complete_session.details.presentation.enums.CompleteSessionDetailsTab
 import com.vci.vectorcamapp.core.presentation.components.header.ScreenHeader
+import com.vci.vectorcamapp.ui.extensions.colors
+import com.vci.vectorcamapp.ui.extensions.dimensions
 import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 
 @Composable
@@ -23,6 +31,17 @@ fun CompleteSessionDetailsScreen(
     ScreenHeader(
         title = "Session Information",
         subtitle = "ID: ${state.session.localId}",
+        leadingIcon = {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_left),
+                contentDescription = "Back Button",
+                tint = MaterialTheme.colors.icon,
+                modifier = Modifier
+                    .size(MaterialTheme.dimensions.iconSizeMedium)
+                    .clickable {
+                        onAction(CompleteSessionDetailsAction.ReturnToCompleteSessionListScreen)
+                    })
+        },
         modifier = modifier
     ) {
         item {
@@ -43,7 +62,9 @@ fun CompleteSessionDetailsScreen(
                 )
 
                 CompleteSessionDetailsTab.SESSION_SPECIMENS -> CompleteSessionSpecimens(
-                    session = state.session, specimensWithImagesAndInferenceResults = state.specimensWithImagesAndInferenceResults, modifier = modifier
+                    session = state.session,
+                    specimensWithImagesAndInferenceResults = state.specimensWithImagesAndInferenceResults,
+                    modifier = modifier
                 )
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
@@ -7,7 +7,9 @@ import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenIma
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
 import com.vci.vectorcamapp.core.presentation.CoreViewModel
+import com.vci.vectorcamapp.intake.presentation.IntakeEvent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -15,6 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -51,9 +54,16 @@ class CompleteSessionDetailsViewModel @Inject constructor(
         loadCompleteSessionDetails()
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), CompleteSessionDetailsState())
 
+    private val _events = Channel<CompleteSessionDetailsEvent>()
+    val events = _events.receiveAsFlow()
+
     fun onAction(action: CompleteSessionDetailsAction) {
         viewModelScope.launch {
             when (action) {
+                CompleteSessionDetailsAction.ReturnToCompleteSessionListScreen -> {
+                    _events.send(CompleteSessionDetailsEvent.NavigateBackToCompleteSessionListScreen)
+                }
+
                 is CompleteSessionDetailsAction.ChangeSelectedTab -> {
                     _state.update { it.copy(selectedTab = action.selectedTab) }
                 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListAction.kt
@@ -3,6 +3,7 @@ package com.vci.vectorcamapp.complete_session.list.presentation
 import java.util.UUID
 
 sealed interface CompleteSessionListAction {
+    data object ReturnToLandingScreen : CompleteSessionListAction
     data class ViewCompleteSessionDetails(val sessionId: UUID) : CompleteSessionListAction
     data object UploadAllPendingSessions : CompleteSessionListAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListEvent.kt
@@ -3,5 +3,6 @@ package com.vci.vectorcamapp.complete_session.list.presentation
 import java.util.UUID
 
 sealed interface CompleteSessionListEvent {
+    data object NavigateBackToLandingScreen : CompleteSessionListEvent
     data class NavigateToCompleteSessionDetails(val sessionId: UUID) : CompleteSessionListEvent
 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.complete_session.list.presentation
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -31,6 +32,17 @@ fun CompleteSessionListScreen(
         ScreenHeader(
             title = "Complete Sessions",
             subtitle = "Click on a session to view more details",
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(R.drawable.ic_arrow_left),
+                    contentDescription = "Back Button",
+                    tint = MaterialTheme.colors.icon,
+                    modifier = Modifier
+                        .size(MaterialTheme.dimensions.iconSizeMedium)
+                        .clickable {
+                            onAction(CompleteSessionListAction.ReturnToLandingScreen)
+                        })
+            },
             modifier = modifier
         ) {
             items(

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListViewModel.kt
@@ -40,15 +40,17 @@ class CompleteSessionListViewModel @Inject constructor(
     val events = _events.receiveAsFlow()
 
     fun onAction(action: CompleteSessionListAction) {
-        when (action) {
-            is CompleteSessionListAction.ViewCompleteSessionDetails -> {
-                viewModelScope.launch {
+        viewModelScope.launch {
+            when (action) {
+                CompleteSessionListAction.ReturnToLandingScreen -> {
+                    _events.send(CompleteSessionListEvent.NavigateBackToLandingScreen)
+                }
+
+                is CompleteSessionListAction.ViewCompleteSessionDetails -> {
                     _events.send(CompleteSessionListEvent.NavigateToCompleteSessionDetails(action.sessionId))
                 }
-            }
 
-            is CompleteSessionListAction.UploadAllPendingSessions -> {
-                viewModelScope.launch {
+                is CompleteSessionListAction.UploadAllPendingSessions -> {
                     val completeSessionsAndSites =
                         sessionRepository.observeCompleteSessionsAndSites().first()
                     for (sessionAndSite in completeSessionsAndSites) {

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionEvent.kt
@@ -4,5 +4,5 @@ import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 
 sealed interface IncompleteSessionEvent {
     data class NavigateToIntakeScreen(val sessionType: SessionType) : IncompleteSessionEvent
-    data object NavigateToLandingScreen : IncompleteSessionEvent
+    data object NavigateBackToLandingScreen : IncompleteSessionEvent
 }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -1,10 +1,18 @@
 package com.vci.vectorcamapp.incomplete_session.presentation
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.presentation.components.header.ScreenHeader
 import com.vci.vectorcamapp.incomplete_session.presentation.components.IncompleteSessionCard
+import com.vci.vectorcamapp.ui.extensions.colors
+import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
 fun IncompleteSessionScreen(
@@ -15,6 +23,17 @@ fun IncompleteSessionScreen(
     ScreenHeader(
         title = "Incomplete Sessions",
         subtitle = "Click on a session to resume",
+        leadingIcon = {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_left),
+                contentDescription = "Back Button",
+                tint = MaterialTheme.colors.icon,
+                modifier = Modifier
+                    .size(MaterialTheme.dimensions.iconSizeMedium)
+                    .clickable {
+                        onAction(IncompleteSessionAction.ReturnToLandingScreen)
+                    })
+        },
         modifier = modifier
     ) {
         items(

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
@@ -51,7 +51,7 @@ class IncompleteSessionViewModel @Inject constructor(
                 }
 
                 is IncompleteSessionAction.ReturnToLandingScreen -> {
-                    _events.send(IncompleteSessionEvent.NavigateToLandingScreen)
+                    _events.send(IncompleteSessionEvent.NavigateBackToLandingScreen)
                 }
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
@@ -1,6 +1,7 @@
 package com.vci.vectorcamapp.intake.presentation
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,7 +9,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -48,6 +51,18 @@ fun IntakeScreen(
     ScreenHeader(
         title = "Session Intake",
         subtitle = "Please fill out the information below",
+        leadingIcon = {
+            Icon(
+                painter = painterResource(R.drawable.ic_arrow_left),
+                contentDescription = "Back Button",
+                tint = MaterialTheme.colors.icon,
+                modifier = Modifier
+                    .size(MaterialTheme.dimensions.iconSizeMedium)
+                    .clickable {
+                        onAction(IntakeAction.ReturnToLandingScreen)
+                    }
+            )
+        },
         modifier = modifier
     ) {
         item {
@@ -56,7 +71,10 @@ fun IntakeScreen(
                 iconPainter = painterResource(R.drawable.ic_info),
                 iconDescription = "General Information Icon"
             ) {
-                InfoPill(text = "Session Type: ${state.session.type.name}", color = MaterialTheme.colors.info)
+                InfoPill(
+                    text = "Session Type: ${state.session.type.name}",
+                    color = MaterialTheme.colors.info
+                )
 
                 TextEntryField(
                     label = "Collector Name",

--- a/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/navigation/NavGraph.kt
@@ -1,6 +1,5 @@
 package com.vci.vectorcamapp.navigation
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -12,6 +11,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.vci.vectorcamapp.animation.presentation.LoadingAnimation
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsEvent
 import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsScreen
 import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsViewModel
 import com.vci.vectorcamapp.complete_session.list.presentation.CompleteSessionListEvent
@@ -171,9 +171,10 @@ fun NavGraph(startDestination: Destination) {
 
             ObserveAsEvents(events = viewModel.events) { event ->
                 when (event) {
+                    IncompleteSessionEvent.NavigateBackToLandingScreen -> navController.popBackStack()
+
                     is IncompleteSessionEvent.NavigateToIntakeScreen ->
                         navController.navigate(Destination.Intake(event.sessionType))
-                    IncompleteSessionEvent.NavigateToLandingScreen -> navController.popBackStack()
                 }
             }
 
@@ -192,6 +193,8 @@ fun NavGraph(startDestination: Destination) {
 
             ObserveAsEvents(events = viewModel.events) { event ->
                 when (event) {
+                    CompleteSessionListEvent.NavigateBackToLandingScreen -> navController.popBackStack()
+
                     is CompleteSessionListEvent.NavigateToCompleteSessionDetails -> navController.navigate(
                         Destination.CompleteSessionDetails(event.sessionId.toString())
                     )
@@ -210,6 +213,12 @@ fun NavGraph(startDestination: Destination) {
         composable<Destination.CompleteSessionDetails> {
             val viewModel = hiltViewModel<CompleteSessionDetailsViewModel>()
             val state by viewModel.state.collectAsStateWithLifecycle()
+
+            ObserveAsEvents(events = viewModel.events) { event ->
+                when (event) {
+                    CompleteSessionDetailsEvent.NavigateBackToCompleteSessionListScreen -> navController.popBackStack()
+                }
+            }
 
             BaseScaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                 CompleteSessionDetailsScreen(


### PR DESCRIPTION
This PR enhances navigation UX by implementing back button support in the ScreenHeader component and updating screens throughout the app. The ScreenHeader component now utilizes its leadingIcon parameter to display back buttons, providing users with clear visual navigation cues in the header area alongside the title and subtitle.
The changes include updating multiple screens across the app flow - from registration and landing screens to intake, imaging, incomplete sessions, and complete session views. Each screen now features consistent back button functionality that integrates with the existing navigation events like NavigateBackToLandingScreen, NavigateBackToCompleteSessionListScreen already defined in the ViewModels.