### PR TITLE
SOF-277: Add Specimen ID validation and corrections to common text re…

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
@@ -48,6 +48,7 @@ fun Error.toString(context: Context): String {
             ImagingError.CAPTURE_ERROR -> R.string.imaging_error_capture_error
             ImagingError.SAVE_ERROR -> R.string.imaging_error_save_error
             ImagingError.PROCESSING_ERROR -> R.string.imaging_error_processing_error
+            ImagingError.INVALID_SPECIMEN_ID -> R.string.imaging_error_invalid_specimen_id
             ImagingError.NO_SPECIMEN_FOUND -> R.string.imaging_error_no_specimen_found
             ImagingError.MULTIPLE_SPECIMENS_FOUND -> R.string.imaging_error_multiple_specimens_found
             ImagingError.NO_ACTIVE_SESSION -> R.string.imaging_error_no_active_session

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/use_cases/ValidateSpecimenIdUseCase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/use_cases/ValidateSpecimenIdUseCase.kt
@@ -1,0 +1,70 @@
+package com.vci.vectorcamapp.imaging.domain.use_cases
+
+import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
+import javax.inject.Inject
+
+class ValidateSpecimenIdUseCase @Inject constructor() {
+
+    companion object {
+        private const val SPECIMEN_ID_LENGTH = 6
+        private val SPECIMEN_ID_PATTERN = Regex("^[A-Z]{3}\\d{3}$")
+
+        private val LETTER_CORRECTIONS = mapOf(
+            "0" to "O",
+            "1" to "I",
+            "2" to "Z",
+            "3" to "E",
+            "4" to "A",
+            "5" to "S",
+            "6" to "G",
+            "7" to "T",
+            "8" to "B",
+            "9" to "P"
+        )
+
+        private val DIGIT_CORRECTIONS = mapOf(
+            "O" to "0",
+            "I" to "1",
+            "Z" to "2",
+            "E" to "3",
+            "A" to "4",
+            "S" to "5",
+            "G" to "6",
+            "T" to "7",
+            "B" to "8",
+            "P" to "9"
+        )
+    }
+
+    operator fun invoke(
+        specimenId: String, shouldAutoCorrect: Boolean
+    ): Result<String, ImagingError> {
+        val cleanedSpecimenId = specimenId.trim().replace(" ", "").uppercase()
+
+        if (cleanedSpecimenId.length != SPECIMEN_ID_LENGTH || !cleanedSpecimenId.all { it.isLetterOrDigit() }) {
+            return Result.Error(ImagingError.INVALID_SPECIMEN_ID)
+        }
+
+        val corrected = if (shouldAutoCorrect) {
+            buildString {
+                cleanedSpecimenId.forEachIndexed { index, character ->
+                    val correctedChar = if (index < 3) {
+                        LETTER_CORRECTIONS.getOrDefault(character.toString(), character)
+                    } else {
+                        DIGIT_CORRECTIONS.getOrDefault(character.toString(), character)
+                    }
+                    append(correctedChar)
+                }
+            }
+        } else {
+            cleanedSpecimenId
+        }
+
+        return if (SPECIMEN_ID_PATTERN.matches(corrected)) {
+            Result.Success(corrected)
+        } else {
+            Result.Error(ImagingError.INVALID_SPECIMEN_ID)
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/util/ImagingError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/util/ImagingError.kt
@@ -5,6 +5,7 @@ import com.vci.vectorcamapp.core.domain.util.Error
 enum class ImagingError : Error {
     CAPTURE_ERROR,
     SAVE_ERROR,
+    INVALID_SPECIMEN_ID,
     PROCESSING_ERROR,
     NO_SPECIMEN_FOUND,
     MULTIPLE_SPECIMENS_FOUND,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,4 +181,5 @@
     <!-- Image Upload Status: Upload failed -->
     <string name="upload_status_retry">Retry</string>
     <string name="roomdb_error_no_rows_affected">Could not save information. Please try again.</string>
+    <string name="imaging_error_invalid_specimen_id">This specimen ID is not acceptable. Please correct it.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
     <!-- Imaging error: Processing error -->
     <string name="imaging_error_processing_error">Could not process the photo. Please try again.</string>
 
+    <!-- Imaging error: Invalid specimen ID -->
+    <string name="imaging_error_invalid_specimen_id">This specimen ID does not match the expected pattern.</string>
+
     <!-- Imaging error: No specimen found -->
     <string name="imaging_error_no_specimen_found">No specimen found in the photo. Please try again with a clearer image.</string>
 
@@ -114,6 +117,9 @@
 
     <!-- RoomDb error: Constraint Violation -->
     <string name="roomdb_error_constraint_violation">Some of the information you entered was invalid or already exists. Please check and try again.</string>
+
+    <!-- RoomDb error: No Rows Affected -->
+    <string name="roomdb_error_no_rows_affected">Could not save information. Please try again.</string>
 
     <!-- RoomDb error: Unknown error -->
     <string name="roomdb_error_unknown_error">An unknown error occurred while saving data. Please contact support if this issue persists.</string>
@@ -180,6 +186,4 @@
 
     <!-- Image Upload Status: Upload failed -->
     <string name="upload_status_retry">Retry</string>
-    <string name="roomdb_error_no_rows_affected">Could not save information. Please try again.</string>
-    <string name="imaging_error_invalid_specimen_id">This specimen ID is not acceptable. Please correct it.</string>
 </resources>


### PR DESCRIPTION
This PR adds specimen ID validation during the SaveImageToSession workflow to ensure data integrity when users manually enter or review specimen IDs. The existing ValidateSpecimenIdUseCase is now invoked with shouldAutoCorrect = false at the time of saving, which prevents invalid or malformed IDs (e.g., incorrect length or use of non-alphanumeric characters) from being saved to the session. This complements the auto-corrected validation already in place during real-time frame processing, and ensures that we respect manual input while still enforcing a valid format (^[A-Z]{3}\\d{3}$). This change helps reduce errors in downstream data analysis and improves overall data quality.