### PR TITLE
SOF-293: Replace the text box on the imaging screen with a text field

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -353,12 +353,10 @@ fun ImagingScreen(
                                 )
                             }
 
-                            TextEntryField(
-                                placeholder = "Specimen ID",
-                                value = state.currentSpecimen.id,
-                                onValueChange = { onAction(ImagingAction.CorrectSpecimenId(it)) },
-                                singleLine = true,
-                                modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.paddingMedium)
+                            Text(
+                                text = if (state.currentSpecimen.id == "") "Specimen ID will appear here" else state.currentSpecimen.id,
+                                style = MaterialTheme.typography.headlineLarge,
+                                color = if (state.currentSpecimen.id == "") MaterialTheme.colors.textSecondary else MaterialTheme.colors.textPrimary,
                             )
 
                             LiveCameraPreview(


### PR DESCRIPTION
This PR modified the UI of the imaging screen slightly to remove the text box in the ImagingScreen which appears right before the LiveCameraPreviewPage. The purpose of this change is to ensure that the user does not try to modify the specimen ID on this screen because otherwise it gets overridden by the Text Recognizer. Instead, we allow the user to make modifications right before the specimen gets added to the session.