### PR TITLE
SOF-292: Removed unused Getting Started tile on landing screen

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
@@ -1,9 +1,7 @@
 package com.vci.vectorcamapp.landing.presentation
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog

--- a/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/landing/presentation/LandingScreen.kt
@@ -3,6 +3,7 @@ package com.vci.vectorcamapp.landing.presentation
 import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
@@ -36,14 +37,9 @@ fun LandingScreen(
     ) {
         item {
             Column(
-                verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium)
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium),
+                modifier = Modifier.padding(top = MaterialTheme.dimensions.spacingMedium)
             ) {
-                LandingActionTile(
-                    title = "Getting Started",
-                    description = "Learn how to use the app and start your first session.",
-                    icon = painterResource(R.drawable.ic_help),
-                    onClick = { Log.d("LandingScreen", "Getting Started") })
-
                 LandingSection(title = "Imaging") {
                     LandingActionTile(
                         title = "New Surveillance Session",


### PR DESCRIPTION
This PR removed the unused Getting Started tile on the landing screen.