### PR TITLE
SOF-294: Add the "type" field to session DTOs when uploading to the backend.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
@@ -1,6 +1,8 @@
 package com.vci.vectorcamapp.core.data.dto.session
 
+import com.vci.vectorcamapp.core.data.dto.serializers.SessionTypeSerializer
 import com.vci.vectorcamapp.core.data.dto.serializers.UuidSerializer
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
@@ -19,6 +21,8 @@ data class PostSessionRequestDto(
     val notes: String = "",
     val latitude: Float? = null,
     val longitude: Float? = null,
+    @Serializable(with = SessionTypeSerializer::class)
+    val type: SessionType = SessionType.SURVEILLANCE,
     val siteId: Int = -1,
     val deviceId: Int = -1,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionDto.kt
@@ -1,6 +1,8 @@
 package com.vci.vectorcamapp.core.data.dto.session
 
+import com.vci.vectorcamapp.core.data.dto.serializers.SessionTypeSerializer
 import com.vci.vectorcamapp.core.data.dto.serializers.UuidSerializer
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
@@ -21,6 +23,8 @@ data class SessionDto(
     val notes: String = "",
     val latitude: Float? = null,
     val longitude: Float? = null,
+    @Serializable(with = SessionTypeSerializer::class)
+    val type: SessionType = SessionType.SURVEILLANCE,
     val siteId: Int = -1,
     val deviceId: Int = -1,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
@@ -46,6 +46,7 @@ class RemoteSessionDataSource @Inject constructor(
                         notes = session.notes,
                         latitude = session.latitude,
                         longitude = session.longitude,
+                        type = session.type,
                         siteId = siteId,
                         deviceId = deviceId,
                     )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -4,7 +4,6 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.ServiceInfo
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
@@ -267,6 +266,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 notes = localSession.notes,
                 latitude = localSession.latitude,
                 longitude = localSession.longitude,
+                type = localSession.type,
                 siteId = localSiteId,
                 deviceId = syncedDeviceId
             )
@@ -306,7 +306,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 notes = remoteSessionDto.notes,
                 latitude = remoteSessionDto.latitude,
                 longitude = remoteSessionDto.longitude,
-                type = localSession.type
+                type = remoteSessionDto.type
             )
 
             if (localSessionDto != remoteSessionDto) {
@@ -635,9 +635,9 @@ class MetadataUploadWorker @AssistedInject constructor(
             .setContentText("Specimen ${currentSpecimenIndex + 1} of $totalSpecimens").setStyle(
                 NotificationCompat.BigTextStyle().bigText(
                     """
-                Specimen ${currentSpecimenIndex + 1} of $totalSpecimens
-                Image ${currentImageIndex + 1} of $totalImagesForSpecimen
-                """.trimIndent()
+                        Specimen ${currentSpecimenIndex + 1} of $totalSpecimens
+                        Image ${currentImageIndex + 1} of $totalImagesForSpecimen
+                    """.trimIndent()
                 )
             ).setSmallIcon(R.drawable.ic_cloud_upload)
             .setProgress(totalSpecimens, currentSpecimenIndex + 1, false).setOngoing(true).build()


### PR DESCRIPTION
Session upload to the backend now requires passing in the session type explicitly. This will help the AI team distinguish between surveillance and data collection sessions.