### PR TITLE
SOF-296: Add inference times for each individual classifier model

### DIFF
--- a/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/11.json
+++ b/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/11.json
@@ -1,0 +1,608 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "23754fed7e5f65c087a84f67b2276d91",
+    "entities": [
+      {
+        "tableName": "program",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_program_country",
+            "unique": false,
+            "columnNames": [
+              "country"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_program_country` ON `${TABLE_NAME}` (`country`)"
+          }
+        ]
+      },
+      {
+        "tableName": "site",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `programId` INTEGER NOT NULL, `district` TEXT NOT NULL, `subCounty` TEXT NOT NULL, `parish` TEXT NOT NULL, `sentinelSite` TEXT NOT NULL, `healthCenter` TEXT NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`programId`) REFERENCES `program`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "programId",
+            "columnName": "programId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subCounty",
+            "columnName": "subCounty",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parish",
+            "columnName": "parish",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sentinelSite",
+            "columnName": "sentinelSite",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthCenter",
+            "columnName": "healthCenter",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_site_programId",
+            "unique": false,
+            "columnNames": [
+              "programId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_site_programId` ON `${TABLE_NAME}` (`programId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "program",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "programId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `siteId` INTEGER NOT NULL, `remoteId` INTEGER, `houseNumber` TEXT NOT NULL, `collectorTitle` TEXT NOT NULL, `collectorName` TEXT NOT NULL, `collectionDate` INTEGER NOT NULL, `collectionMethod` TEXT NOT NULL, `specimenCondition` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `completedAt` INTEGER, `submittedAt` INTEGER, `notes` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `type` TEXT NOT NULL, PRIMARY KEY(`localId`), FOREIGN KEY(`siteId`) REFERENCES `site`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "houseNumber",
+            "columnName": "houseNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorTitle",
+            "columnName": "collectorTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorName",
+            "columnName": "collectorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionDate",
+            "columnName": "collectionDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionMethod",
+            "columnName": "collectionMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenCondition",
+            "columnName": "specimenCondition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_session_siteId",
+            "unique": false,
+            "columnNames": [
+              "siteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_siteId` ON `${TABLE_NAME}` (`siteId`)"
+          },
+          {
+            "name": "index_session_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "site",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "siteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, PRIMARY KEY(`id`, `sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen_image",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `specimenId` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `species` TEXT, `sex` TEXT, `abdomenStatus` TEXT, `imageUri` TEXT NOT NULL, `metadataUploadStatus` TEXT NOT NULL, `imageUploadStatus` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL, `submittedAt` INTEGER, PRIMARY KEY(`localId`), FOREIGN KEY(`specimenId`, `sessionId`) REFERENCES `specimen`(`id`, `sessionId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenId",
+            "columnName": "specimenId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "species",
+            "columnName": "species",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sex",
+            "columnName": "sex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatus",
+            "columnName": "abdomenStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUri",
+            "columnName": "imageUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataUploadStatus",
+            "columnName": "metadataUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUploadStatus",
+            "columnName": "imageUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_image_specimenId_sessionId",
+            "unique": false,
+            "columnNames": [
+              "specimenId",
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_image_specimenId_sessionId` ON `${TABLE_NAME}` (`specimenId`, `sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "specimen",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenId",
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id",
+              "sessionId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inference_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`specimenImageId` TEXT NOT NULL, `bboxTopLeftX` REAL NOT NULL, `bboxTopLeftY` REAL NOT NULL, `bboxWidth` REAL NOT NULL, `bboxHeight` REAL NOT NULL, `bboxConfidence` REAL NOT NULL, `bboxClassId` INTEGER NOT NULL, `speciesLogits` TEXT, `sexLogits` TEXT, `abdomenStatusLogits` TEXT, `speciesInferenceDuration` INTEGER, `sexInferenceDuration` INTEGER, `abdomenStatusInferenceDuration` INTEGER, PRIMARY KEY(`specimenImageId`), FOREIGN KEY(`specimenImageId`) REFERENCES `specimen_image`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "specimenImageId",
+            "columnName": "specimenImageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftX",
+            "columnName": "bboxTopLeftX",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftY",
+            "columnName": "bboxTopLeftY",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxWidth",
+            "columnName": "bboxWidth",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxHeight",
+            "columnName": "bboxHeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxConfidence",
+            "columnName": "bboxConfidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxClassId",
+            "columnName": "bboxClassId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speciesLogits",
+            "columnName": "speciesLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sexLogits",
+            "columnName": "sexLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatusLogits",
+            "columnName": "abdomenStatusLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "speciesInferenceDuration",
+            "columnName": "speciesInferenceDuration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sexInferenceDuration",
+            "columnName": "sexInferenceDuration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "abdomenStatusInferenceDuration",
+            "columnName": "abdomenStatusInferenceDuration",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "specimenImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "specimen_image",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenImageId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "surveillance_form",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `numPeopleSleptInHouse` INTEGER NOT NULL, `wasIrsConducted` INTEGER NOT NULL, `monthsSinceIrs` INTEGER, `numLlinsAvailable` INTEGER NOT NULL, `llinType` TEXT, `llinBrand` TEXT, `numPeopleSleptUnderLlin` INTEGER, `submittedAt` INTEGER, PRIMARY KEY(`sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeopleSleptInHouse",
+            "columnName": "numPeopleSleptInHouse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wasIrsConducted",
+            "columnName": "wasIrsConducted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monthsSinceIrs",
+            "columnName": "monthsSinceIrs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "numLlinsAvailable",
+            "columnName": "numLlinsAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "llinType",
+            "columnName": "llinType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "llinBrand",
+            "columnName": "llinBrand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPeopleSleptUnderLlin",
+            "columnName": "numPeopleSleptUnderLlin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '23754fed7e5f65c087a84f67b2276d91')"
+    ]
+  }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/inference_result/InferenceResultDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/inference_result/InferenceResultDto.kt
@@ -13,4 +13,7 @@ data class InferenceResultDto(
     val speciesLogits: List<Float>? = null,
     val sexLogits: List<Float>? = null,
     val abdomenStatusLogits: List<Float>? = null,
+    val speciesInferenceDuration: Long?,
+    val sexInferenceDuration: Long?,
+    val abdomenStatusInferenceDuration: Long?,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/InferenceResultMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/InferenceResultMapper.kt
@@ -14,7 +14,10 @@ fun InferenceResultEntity.toDomain() : InferenceResult {
         bboxClassId = this.bboxClassId,
         speciesLogits = this.speciesLogits,
         sexLogits = this.sexLogits,
-        abdomenStatusLogits = this.abdomenStatusLogits
+        abdomenStatusLogits = this.abdomenStatusLogits,
+        speciesInferenceDuration = this.speciesInferenceDuration,
+        sexInferenceDuration = this.sexInferenceDuration,
+        abdomenStatusInferenceDuration = this.abdomenStatusInferenceDuration
     )
 }
 
@@ -29,6 +32,9 @@ fun InferenceResult.toEntity(specimenImageId: String) : InferenceResultEntity {
         bboxClassId = this.bboxClassId,
         speciesLogits = this.speciesLogits,
         sexLogits = this.sexLogits,
-        abdomenStatusLogits = this.abdomenStatusLogits
+        abdomenStatusLogits = this.abdomenStatusLogits,
+        speciesInferenceDuration = this.speciesInferenceDuration,
+        sexInferenceDuration = this.sexInferenceDuration,
+        abdomenStatusInferenceDuration = this.abdomenStatusInferenceDuration
     )
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
@@ -46,7 +46,10 @@ class RemoteSpecimenImageDataSource @Inject constructor(
                                 bboxClassId = it.bboxClassId,
                                 speciesLogits = it.speciesLogits,
                                 sexLogits = it.sexLogits,
-                                abdomenStatusLogits = it.abdomenStatusLogits
+                                abdomenStatusLogits = it.abdomenStatusLogits,
+                                speciesInferenceDuration = it.speciesInferenceDuration,
+                                sexInferenceDuration = it.sexInferenceDuration,
+                                abdomenStatusInferenceDuration = it.abdomenStatusInferenceDuration
                             )
                         }
                     )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
@@ -25,7 +25,7 @@ import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
 
 @Database(
     entities = [ProgramEntity::class, SiteEntity::class, SessionEntity::class, SpecimenEntity::class, SpecimenImageEntity::class, InferenceResultEntity::class, SurveillanceFormEntity::class],
-    version = 10,
+    version = 11,
 )
 @TypeConverters(
     UuidConverter::class,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/InferenceResultEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/InferenceResultEntity.kt
@@ -27,4 +27,7 @@ data class InferenceResultEntity(
     val speciesLogits: List<Float>? = null,
     val sexLogits: List<Float>? = null,
     val abdomenStatusLogits: List<Float>? = null,
+    val speciesInferenceDuration: Long?,
+    val sexInferenceDuration: Long?,
+    val abdomenStatusInferenceDuration: Long?
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.data.room.migrations
 
+import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_10_11_ADD_INFERENCE_DURATION_COLUMNS
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_2_3_CREATE_SURVEILLANCE_FORM_TABLE
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_3_4_SCHEMA_V2
@@ -19,5 +20,6 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_6_7_BOUNDING_BOX_TO_INFERENCE_RESULT,
     MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION,
     MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN,
-    MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS
+    MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS,
+    MIGRATION_10_11_ADD_INFERENCE_DURATION_COLUMNS
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_10_11_AddInferenceDurationColumns.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_10_11_AddInferenceDurationColumns.kt
@@ -1,0 +1,13 @@
+package com.vci.vectorcamapp.core.data.room.migrations.versions
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_10_11_ADD_INFERENCE_DURATION_COLUMNS = object: Migration(10, 11) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // Add the three new inference duration columns to the existing inference_result table
+        db.execSQL("ALTER TABLE `inference_result` ADD COLUMN `speciesInferenceDuration` INTEGER")
+        db.execSQL("ALTER TABLE `inference_result` ADD COLUMN `sexInferenceDuration` INTEGER")
+        db.execSQL("ALTER TABLE `inference_result` ADD COLUMN `abdomenStatusInferenceDuration` INTEGER")
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -480,7 +480,10 @@ class MetadataUploadWorker @AssistedInject constructor(
                         bboxClassId = it.bboxClassId,
                         speciesLogits = it.speciesLogits,
                         sexLogits = it.sexLogits,
-                        abdomenStatusLogits = it.abdomenStatusLogits
+                        abdomenStatusLogits = it.abdomenStatusLogits,
+                        speciesInferenceDuration = it.speciesInferenceDuration,
+                        sexInferenceDuration = it.sexInferenceDuration,
+                        abdomenStatusInferenceDuration = it.abdomenStatusInferenceDuration
                     )
                 })
 
@@ -555,7 +558,10 @@ class MetadataUploadWorker @AssistedInject constructor(
                     bboxClassId = it.bboxClassId,
                     speciesLogits = it.speciesLogits,
                     sexLogits = it.sexLogits,
-                    abdomenStatusLogits = it.abdomenStatusLogits
+                    abdomenStatusLogits = it.abdomenStatusLogits,
+                    speciesInferenceDuration = it.speciesInferenceDuration,
+                    sexInferenceDuration = it.sexInferenceDuration,
+                    abdomenStatusInferenceDuration = it.abdomenStatusInferenceDuration,
                 )
             }
 

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/InferenceResult.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/InferenceResult.kt
@@ -10,4 +10,7 @@ data class InferenceResult(
     val speciesLogits: List<Float>?,
     val sexLogits: List<Float>?,
     val abdomenStatusLogits: List<Float>?,
+    val speciesInferenceDuration: Long?,
+    val sexInferenceDuration: Long?,
+    val abdomenStatusInferenceDuration: Long?
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/results/ClassifierResult.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/results/ClassifierResult.kt
@@ -1,0 +1,6 @@
+package com.vci.vectorcamapp.core.domain.model.results
+
+data class ClassifierResult(
+    val logits: List<Float>?,
+    val inferenceDuration: Long?
+)

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
@@ -252,6 +252,9 @@ class TfLiteSpecimenDetector(
                 speciesLogits = null,
                 sexLogits = null,
                 abdomenStatusLogits = null,
+                speciesInferenceDuration = null,
+                sexInferenceDuration = null,
+                abdomenStatusInferenceDuration = null,
             )
             Log.d("InferenceResult", "($topLeftX, $topLeftY) -> ($width, $height)")
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/InferenceRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/InferenceRepositoryImplementation.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognizer
 import com.vci.vectorcamapp.core.domain.model.InferenceResult
+import com.vci.vectorcamapp.core.domain.model.results.ClassifierResult
 import com.vci.vectorcamapp.imaging.data.GpuDelegateManager
 import com.vci.vectorcamapp.imaging.di.AbdomenStatusClassifier
 import com.vci.vectorcamapp.imaging.di.Detector
@@ -53,22 +54,22 @@ class InferenceRepositoryImplementation @Inject constructor(
             specimenDetector.detect(bitmap)
         }
 
-    override suspend fun classifySpecimen(croppedBitmap: Bitmap): Triple<List<Float>?, List<Float>?, List<Float>?> =
+    override suspend fun classifySpecimen(croppedBitmap: Bitmap): Triple<ClassifierResult?, ClassifierResult?, ClassifierResult?> =
         withContext(Dispatchers.Default) {
-            val speciesLogitsPromise = async { getClassification(croppedBitmap, speciesClassifier) }
-            val sexLogitsPromise = async { getClassification(croppedBitmap, sexClassifier) }
-            val abdomenStatusLogitsPromise = async { getClassification(croppedBitmap, abdomenStatusClassifier) }
+            val speciesResultPromise = async { getClassification(croppedBitmap, speciesClassifier) }
+            val sexResultPromise = async { getClassification(croppedBitmap, sexClassifier) }
+            val abdomenStatusResultPromise = async { getClassification(croppedBitmap, abdomenStatusClassifier) }
             
-            val speciesLogits = speciesLogitsPromise.await()
-            val sexLogits = sexLogitsPromise.await()
-            val abdomenStatusLogits = abdomenStatusLogitsPromise.await()
+            val speciesResult = speciesResultPromise.await()
+            val sexResult = sexResultPromise.await()
+            val abdomenStatusResult = abdomenStatusResultPromise.await()
 
-            Triple(speciesLogits, sexLogits, abdomenStatusLogits)
+            Triple(speciesResult, sexResult, abdomenStatusResult)
         }
 
     private suspend fun getClassification(
         croppedBitmap: Bitmap, classifier: SpecimenClassifier
-    ): List<Float>? = classifier.classify(croppedBitmap)
+    ): ClassifierResult? = classifier.classify(croppedBitmap)
 
     override fun closeResources() {
         specimenIdRecognizer.close()

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/SpecimenClassifier.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/SpecimenClassifier.kt
@@ -1,10 +1,11 @@
 package com.vci.vectorcamapp.imaging.domain
 
 import android.graphics.Bitmap
+import com.vci.vectorcamapp.core.domain.model.results.ClassifierResult
 import java.io.Closeable
 
 interface SpecimenClassifier : Closeable {
     fun getInputTensorShape() : Pair<Int, Int>
     fun getOutputTensorShape() : Int
-    suspend fun classify(croppedBitmap: Bitmap): List<Float>?
+    suspend fun classify(croppedBitmap: Bitmap): ClassifierResult?
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/InferenceRepository.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/repository/InferenceRepository.kt
@@ -2,10 +2,11 @@ package com.vci.vectorcamapp.imaging.domain.repository
 
 import android.graphics.Bitmap
 import com.vci.vectorcamapp.core.domain.model.InferenceResult
+import com.vci.vectorcamapp.core.domain.model.results.ClassifierResult
 
 interface InferenceRepository {
-    suspend fun readSpecimenId(bitmap: Bitmap) : String
-    suspend fun detectSpecimen(bitmap: Bitmap) : List<InferenceResult>
-    suspend fun classifySpecimen(croppedBitmap: Bitmap) : Triple<List<Float>?, List<Float>?, List<Float>?>
+    suspend fun readSpecimenId(bitmap: Bitmap): String
+    suspend fun detectSpecimen(bitmap: Bitmap): List<InferenceResult>
+    suspend fun classifySpecimen(croppedBitmap: Bitmap): Triple<ClassifierResult?, ClassifierResult?, ClassifierResult?>
     fun closeResources()
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/concrete/SurveillanceImagingWorkflow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/strategy/concrete/SurveillanceImagingWorkflow.kt
@@ -62,23 +62,18 @@ class SurveillanceImagingWorkflow @Inject constructor(
                         clampedHeight
                     )
 
-                    var (speciesLogits, sexLogits, abdomenStatusLogits) = inferenceRepository.classifySpecimen(
-                        croppedBitmap
-                    )
+                    var (speciesResult, sexResult, abdomenStatusResult) = inferenceRepository.classifySpecimen(croppedBitmap)
 
-                    val speciesIndex =
-                        speciesLogits?.let { logits -> logits.indexOf(logits.max()) }
-                    var sexIndex =
-                        sexLogits?.let { logits -> logits.indexOf(logits.max()) }
-                    var abdomenStatusIndex =
-                        abdomenStatusLogits?.let { logits -> logits.indexOf(logits.max()) }
+                    val speciesIndex = speciesResult?.logits?.let { logits -> logits.indexOf(logits.max()) }
+                    var sexIndex = sexResult?.logits?.let { logits -> logits.indexOf(logits.max()) }
+                    var abdomenStatusIndex = abdomenStatusResult?.logits?.let { logits -> logits.indexOf(logits.max()) }
 
-                    if (speciesLogits == null || speciesIndex == SpeciesLabel.NON_MOSQUITO.ordinal) {
-                        sexLogits = null
+                    if (speciesResult?.logits == null || speciesIndex == SpeciesLabel.NON_MOSQUITO.ordinal) {
+                        sexResult = null
                         sexIndex = null
                     }
-                    if (sexLogits == null || sexIndex == SexLabel.MALE.ordinal) {
-                        abdomenStatusLogits = null
+                    if (sexResult?.logits == null || sexIndex == SexLabel.MALE.ordinal) {
+                        abdomenStatusResult = null
                         abdomenStatusIndex = null
                     }
 
@@ -94,9 +89,12 @@ class SurveillanceImagingWorkflow @Inject constructor(
                                 bboxHeight = captureInferenceResult.bboxHeight,
                                 bboxConfidence = captureInferenceResult.bboxConfidence,
                                 bboxClassId = captureInferenceResult.bboxClassId,
-                                speciesLogits = speciesLogits,
-                                sexLogits = sexLogits,
-                                abdomenStatusLogits = abdomenStatusLogits
+                                speciesLogits = speciesResult?.logits,
+                                sexLogits = sexResult?.logits,
+                                abdomenStatusLogits = abdomenStatusResult?.logits,
+                                speciesInferenceDuration = speciesResult?.inferenceDuration,
+                                sexInferenceDuration = sexResult?.inferenceDuration,
+                                abdomenStatusInferenceDuration = abdomenStatusResult?.inferenceDuration,
                             )
                         )
                     )


### PR DESCRIPTION
This PR adds 3 new columns to the inferenceResult table, enabling us to keep track of how long it took for the model to produce output on average. It can also be used to correlate inference time with phone models. This change involves local database table updates to store the 3 new time durations, updating the InferenceResult domain model, and the DTO for upload to the backend.