### PR TITLE
SOF-297: Fix for database seeding issue on some devices

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
@@ -61,39 +61,56 @@ object RoomDatabaseModule {
                         programs.forEach { program ->
                             db.execSQL(
                                 """
-                                    INSERT INTO program (id, name, country) 
-                                    VALUES (?, ?, ?)
-                                    ON CONFLICT (id) DO UPDATE SET
-                                        name = excluded.name,
-                                        country = excluded.country
-                                    WHERE
-                                        name != excluded.name OR
-                                        country != excluded.country
+                                    INSERT OR IGNORE INTO `program` (`id`, `name`, `country`) VALUES (?, ?, ?)
                                 """.trimIndent(), arrayOf(program.id, program.name, program.country)
+                            )
+
+                            db.execSQL(
+                                """
+                                    UPDATE `program`
+                                        SET `name` = ?, `country` = ?
+                                    WHERE `id` = ?
+                                        AND (`name` != ? OR `country` != ?)
+                                """.trimIndent(), arrayOf(
+                                    program.name,
+                                    program.country,
+                                    program.id,
+                                    program.name,
+                                    program.country
+                                )
                             )
                         }
 
                         sites.forEach { site ->
                             db.execSQL(
                                 """
-                                    INSERT INTO site (id, programId, district, subCounty, parish, sentinelSite, healthCenter)
+                                    INSERT OR IGNORE INTO `site` 
+                                        (`id`, `programId`, `district`, `subCounty`, `parish`, `sentinelSite`, `healthCenter`) 
                                     VALUES (?, ?, ?, ?, ?, ?, ?)
-                                    ON CONFLICT (id) DO UPDATE SET
-                                        programId = excluded.programId,
-                                        district = excluded.district,
-                                        subCounty = excluded.subCounty,
-                                        parish = excluded.parish,
-                                        sentinelSite = excluded.sentinelSite,
-                                        healthCenter = excluded.healthCenter
-                                    WHERE
-                                        programId != excluded.programId OR
-                                        district != excluded.district OR
-                                        subCounty != excluded.subCounty OR
-                                        parish != excluded.parish OR
-                                        sentinelSite != excluded.sentinelSite OR
-                                        healthCenter != excluded.healthCenter
-                                """.trimIndent(),
-                                arrayOf(
+                                """.trimIndent(), arrayOf(
+                                    site.id,
+                                    site.programId,
+                                    site.district,
+                                    site.subCounty,
+                                    site.parish,
+                                    site.sentinelSite,
+                                    site.healthCenter
+                                )
+                            )
+
+                            db.execSQL(
+                                """
+                                    UPDATE `site`
+                                        SET `programId` = ?, `district` = ?, `subCounty` = ?, `parish` = ?, `sentinelSite` = ?, `healthCenter` = ?
+                                    WHERE `id` = ?
+                                        AND (`programId` != ? OR `district` != ? OR `subCounty` != ? OR `parish` != ? OR `sentinelSite` != ? OR `healthCenter` != ?)
+                                """.trimIndent(), arrayOf(
+                                    site.programId,
+                                    site.district,
+                                    site.subCounty,
+                                    site.parish,
+                                    site.sentinelSite,
+                                    site.healthCenter,
                                     site.id,
                                     site.programId,
                                     site.district,

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
@@ -38,13 +38,14 @@ object RoomDatabaseModule {
     fun provideDatabase(
         @ApplicationContext context: Context,
     ): VectorCamDatabase {
-        return Room.databaseBuilder(
+        lateinit var db: VectorCamDatabase
+        db = Room.databaseBuilder(
             context,
             VectorCamDatabase::class.java,
             DB_NAME,
         ).addCallback(object : RoomDatabase.Callback() {
-            override fun onOpen(db: SupportSQLiteDatabase) {
-                super.onOpen(db)
+            override fun onOpen(sqLiteDb: SupportSQLiteDatabase) {
+                super.onOpen(sqLiteDb)
 
                 try {
                     val programsJson = context.assets.open(PROGRAM_DATA_FILENAME).bufferedReader()
@@ -55,11 +56,11 @@ object RoomDatabaseModule {
                     val programs = Json.decodeFromString<List<ProgramDto>>(programsJson)
                     val sites = Json.decodeFromString<List<SiteDto>>(sitesJson)
 
-                    db.beginTransaction()
+                    sqLiteDb.beginTransaction()
                     try {
                         // Use direct SQL to avoid circular dependency
                         programs.forEach { program ->
-                            db.execSQL(
+                            sqLiteDb.execSQL(
                                 """
                                     INSERT INTO program (id, name, country) 
                                     VALUES (?, ?, ?)
@@ -74,7 +75,7 @@ object RoomDatabaseModule {
                         }
 
                         sites.forEach { site ->
-                            db.execSQL(
+                            sqLiteDb.execSQL(
                                 """
                                     INSERT INTO site (id, programId, district, subCounty, parish, sentinelSite, healthCenter)
                                     VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -105,18 +106,21 @@ object RoomDatabaseModule {
                             )
                         }
 
-                        db.setTransactionSuccessful()
+                        sqLiteDb.setTransactionSuccessful()
                         Log.i(
                             "RoomCallback", "Seeded ${programs.size} programs, ${sites.size} sites"
                         )
                     } finally {
-                        db.endTransaction()
+                        sqLiteDb.endTransaction()
+                        db.invalidationTracker.refreshAsync()
                     }
                 } catch (e: Exception) {
                     Log.e("RoomCallback", "Error seeding database", e)
                 }
             }
         }).addMigrations(*ALL_MIGRATIONS).build()
+
+        return db
     }
 
     @Provides

--- a/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/di/RoomDatabaseModule.kt
@@ -38,14 +38,13 @@ object RoomDatabaseModule {
     fun provideDatabase(
         @ApplicationContext context: Context,
     ): VectorCamDatabase {
-        lateinit var db: VectorCamDatabase
-        db = Room.databaseBuilder(
+        return Room.databaseBuilder(
             context,
             VectorCamDatabase::class.java,
             DB_NAME,
         ).addCallback(object : RoomDatabase.Callback() {
-            override fun onOpen(sqLiteDb: SupportSQLiteDatabase) {
-                super.onOpen(sqLiteDb)
+            override fun onOpen(db: SupportSQLiteDatabase) {
+                super.onOpen(db)
 
                 try {
                     val programsJson = context.assets.open(PROGRAM_DATA_FILENAME).bufferedReader()
@@ -56,11 +55,11 @@ object RoomDatabaseModule {
                     val programs = Json.decodeFromString<List<ProgramDto>>(programsJson)
                     val sites = Json.decodeFromString<List<SiteDto>>(sitesJson)
 
-                    sqLiteDb.beginTransaction()
+                    db.beginTransaction()
                     try {
                         // Use direct SQL to avoid circular dependency
                         programs.forEach { program ->
-                            sqLiteDb.execSQL(
+                            db.execSQL(
                                 """
                                     INSERT INTO program (id, name, country) 
                                     VALUES (?, ?, ?)
@@ -75,7 +74,7 @@ object RoomDatabaseModule {
                         }
 
                         sites.forEach { site ->
-                            sqLiteDb.execSQL(
+                            db.execSQL(
                                 """
                                     INSERT INTO site (id, programId, district, subCounty, parish, sentinelSite, healthCenter)
                                     VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -106,21 +105,18 @@ object RoomDatabaseModule {
                             )
                         }
 
-                        sqLiteDb.setTransactionSuccessful()
+                        db.setTransactionSuccessful()
                         Log.i(
                             "RoomCallback", "Seeded ${programs.size} programs, ${sites.size} sites"
                         )
                     } finally {
-                        sqLiteDb.endTransaction()
-                        db.invalidationTracker.refreshAsync()
+                        db.endTransaction()
                     }
                 } catch (e: Exception) {
                     Log.e("RoomCallback", "Error seeding database", e)
                 }
             }
         }).addMigrations(*ALL_MIGRATIONS).build()
-
-        return db
     }
 
     @Provides


### PR DESCRIPTION
This PR fixes an issue where programs were not being seeded into the database for SQL versions < 3.24.0 because these version of SQL dont support UPSERT-like SQL syntax. With this PR, the insertion and update combined command is split into 2 different commands, one for insert or ignore, and another for updates if applicable. 