### PR TITLE
SOF-289: Fix camera frame rotation issue

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -28,7 +28,6 @@ data class ImagingState(
     val currentImageBytes: ByteArray? = null,
     val previewInferenceResults: List<InferenceResult> = emptyList(),
     val specimensWithImagesAndInferenceResults: List<SpecimenWithSpecimenImagesAndInferenceResults> = emptyList(),
-    val displayOrientation: Int = 0,
     val manualFocusPoint: Offset? = null,
     val isCameraReady: Boolean = false,
     val showExitDialog: Boolean = false,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/extensions/ImageProxyExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/extensions/ImageProxyExtensions.kt
@@ -4,22 +4,10 @@ import android.graphics.Bitmap
 import android.graphics.Matrix
 import androidx.camera.core.ImageProxy
 
-fun ImageProxy.toUprightBitmap(displayOrientation: Int): Bitmap {
+fun ImageProxy.toUprightBitmap(): Bitmap {
     val bitmap = this.toBitmap()
-
-    val imageDegrees = this.imageInfo.rotationDegrees
-
-    val displayDegrees = when (displayOrientation) {
-        in 45..134 -> 90
-        in 135..224 -> 180
-        in 225..314 -> 270
-        else -> 0
-    }
-
-    val totalDegrees = (imageDegrees - displayDegrees + 360) % 360
-
     val matrix = Matrix().apply {
-        postRotate(totalDegrees.toFloat(), bitmap.width / 2f, bitmap.height / 2f)
+        postRotate(90f, bitmap.width / 2f, bitmap.height / 2f)
     }
 
     return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)


### PR DESCRIPTION
This PR addresses the issue where the camera frame rotated whenever the phone's orientation was changed. By default the frames are rotated by 90 degrees regardless of phone orientation, so this value has now been hardcoded into the app. 