### PR TITLE
SOF-302: Change IOU and confidence thresholds

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
@@ -288,8 +288,8 @@ class TfLiteSpecimenDetector(
         private const val DEFAULT_TENSOR_WIDTH = 640
         private const val DEFAULT_NUM_CHANNELS = 25200
         private const val DEFAULT_NUM_ELEMENTS = 6
-        private const val CONFIDENCE_THRESHOLD = 0.5f
-        private const val IOU_THRESHOLD = 0.5f
+        private const val CONFIDENCE_THRESHOLD = 0.4f
+        private const val IOU_THRESHOLD = 0.25f
 
         private const val PIXEL_NORMALIZATION_SCALE = 1f / 255f
         private const val ASPECT_RATIO = 4f / 3f

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/BoundingBoxOverlay.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/BoundingBoxOverlay.kt
@@ -22,9 +22,7 @@ fun BoundingBoxOverlay(
     val density = LocalDensity.current
     val strokeWidth = with(density) { MaterialTheme.dimensions.borderThicknessThick.toPx() }
 
-    // Extract colors in Composable context
-    val highConfidenceColor = MaterialTheme.colors.successConfirm
-    val lowConfidenceColor = MaterialTheme.colors.warning
+    val boxColor = MaterialTheme.colors.successConfirm
 
     Canvas(modifier = modifier) {
         val topLeft = Offset(
@@ -37,7 +35,7 @@ fun BoundingBoxOverlay(
         )
         
         drawRect(
-            color = if (inferenceResult.bboxConfidence > 0.9f) highConfidenceColor else lowConfidenceColor,
+            color = boxColor,
             topLeft = topLeft,
             size = boxSize,
             style = Stroke(width = strokeWidth)


### PR DESCRIPTION
This PR involves changing the IOU and confidence thresholds. This impacts the results output by the YOLO model. Currently, the app sometimes incorrectly outputs "Multiple specimens found" or "no specimen found" even if there is only one specimen visible on the screen. With a lower IOU threshold, the number of acceptable detections through Non Max Suppression will reduce, helping reduce the multiple specimens problem. Reducing the confidence threshold will help detect a specimen more easily. i also removed the threshold to display green vs. yellow bounding boxes because that means nothing to the user.