### PR TITLE
SOF-288: Fix camera initialization issue

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/CameraRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/CameraRepositoryImplementation.kt
@@ -29,20 +29,22 @@ class CameraRepositoryImplementation @Inject constructor(
     @ApplicationContext private val context: Context
 ) : CameraRepository {
     override suspend fun captureImage(controller: LifecycleCameraController): Result<ImageProxy, ImagingError> {
-        return suspendCoroutine { continuation ->
-            controller.takePicture(
-                ContextCompat.getMainExecutor(context),
-                object : OnImageCapturedCallback() {
-                    override fun onCaptureSuccess(image: ImageProxy) {
-                        super.onCaptureSuccess(image)
-                        continuation.resume(Result.Success(image))
-                    }
+        return withContext(Dispatchers.Main) {
+            suspendCoroutine { continuation ->
+                controller.takePicture(
+                    ContextCompat.getMainExecutor(context),
+                    object : OnImageCapturedCallback() {
+                        override fun onCaptureSuccess(image: ImageProxy) {
+                            super.onCaptureSuccess(image)
+                            continuation.resume(Result.Success(image))
+                        }
 
-                    override fun onError(exception: ImageCaptureException) {
-                        super.onError(exception)
-                        continuation.resume(Result.Error(ImagingError.CAPTURE_ERROR))
-                    }
-                })
+                        override fun onError(exception: ImageCaptureException) {
+                            super.onError(exception)
+                            continuation.resume(Result.Error(ImagingError.CAPTURE_ERROR))
+                        }
+                    })
+            }
         }
     }
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -139,34 +139,31 @@ class ImagingViewModel @Inject constructor(
                 }
 
                 is ImagingAction.ProcessFrame -> {
-                    withContext(Dispatchers.Main) {
-                        try {
-                            if (!_state.value.isCameraReady) {
-                                _state.update { it.copy(isCameraReady = true) }
-                            }
-                            withContext(Dispatchers.Default) {
-                                val bitmap = action.frame.toUprightBitmap()
-                                val liveFrameProcessingResult = imagingWorkflow.processLiveFrame(bitmap)
-
-                                withContext(Dispatchers.Main) {
-                                    validateSpecimenIdUseCase(
-                                        liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
-                                    ).onSuccess { correctedSpecimenId ->
-                                        _state.update {
-                                            it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
-                                        }
-                                    }
-
-                                    _state.update {
-                                        it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
-                                    }
-                                }
-                            }
-                        } catch (e: Exception) {
-                            emitError(ImagingError.PROCESSING_ERROR)
-                        } finally {
-                            action.frame.close()
+                    try {
+                        if (!_state.value.isCameraReady) {
+                            _state.update { it.copy(isCameraReady = true) }
                         }
+
+                        val bitmap = action.frame.toUprightBitmap()
+
+                        val liveFrameProcessingResult =
+                            imagingWorkflow.processLiveFrame(bitmap)
+
+                        validateSpecimenIdUseCase(
+                            liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
+                        ).onSuccess { correctedSpecimenId ->
+                            _state.update {
+                                it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
+                            }
+                        }
+
+                        _state.update {
+                            it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
+                        }
+                    } catch (e: Exception) {
+                        emitError(ImagingError.PROCESSING_ERROR)
+                    } finally {
+                        action.frame.close()
                     }
                 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -196,60 +196,54 @@ class ImagingViewModel @Inject constructor(
 
                     _state.update { it.copy(isProcessing = true) }
 
-                    withContext(Dispatchers.Main) {
-                        val captureResult = cameraRepository.captureImage(action.controller)
+                    val captureResult = cameraRepository.captureImage(action.controller)
 
-                        withContext(Dispatchers.Default) {
-                            captureResult.onSuccess { image ->
-                                val bitmap = image.toUprightBitmap()
-                                image.close()
+                    withContext(Dispatchers.Default) {
+                        captureResult.onSuccess { image ->
+                            val bitmap = image.toUprightBitmap()
+                            image.close()
 
-                                val jpegStream = ByteArrayOutputStream()
-                                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
-                                val jpegByteArray = jpegStream.toByteArray()
-                                val jpegBitmap =
-                                    BitmapFactory.decodeByteArray(
-                                        jpegByteArray,
-                                        0,
-                                        jpegByteArray.size
-                                    )
+                            val jpegStream = ByteArrayOutputStream()
+                            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
+                            val jpegByteArray = jpegStream.toByteArray()
+                            val jpegBitmap =
+                                BitmapFactory.decodeByteArray(
+                                    jpegByteArray,
+                                    0,
+                                    jpegByteArray.size
+                                )
 
-                                val capturedFrameProcessingResult =
-                                    imagingWorkflow.processCapturedFrame(jpegBitmap)
+                            val capturedFrameProcessingResult =
+                                imagingWorkflow.processCapturedFrame(jpegBitmap)
 
-                                withContext(Dispatchers.Main) {
-                                    capturedFrameProcessingResult.onSuccess { result ->
-                                        _state.update {
-                                            it.copy(
-                                                currentSpecimenImage = it.currentSpecimenImage.copy(
-                                                    species = result.species,
-                                                    sex = result.sex,
-                                                    abdomenStatus = result.abdomenStatus
-                                                ),
-                                                currentImageBytes = jpegByteArray,
-                                                currentInferenceResult = result.capturedInferenceResult,
-                                                previewInferenceResults = emptyList()
-                                            )
-                                        }
-                                    }
-                                }.onError { error ->
-                                    withContext(Dispatchers.Main) {
-                                        emitError(error, SnackbarDuration.Short)
+                            withContext(Dispatchers.Main) {
+                                capturedFrameProcessingResult.onSuccess { result ->
+                                    _state.update {
+                                        it.copy(
+                                            currentSpecimenImage = it.currentSpecimenImage.copy(
+                                                species = result.species,
+                                                sex = result.sex,
+                                                abdomenStatus = result.abdomenStatus
+                                            ),
+                                            currentImageBytes = jpegByteArray,
+                                            currentInferenceResult = result.capturedInferenceResult,
+                                            previewInferenceResults = emptyList()
+                                        )
                                     }
                                 }
                             }.onError { error ->
-                                withContext(Dispatchers.Main) {
-                                    if (error == ImagingError.NO_ACTIVE_SESSION) {
-                                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                                    }
-                                    emitError(error)
+                                emitError(error, SnackbarDuration.Short)
+                            }
+                        }.onError { error ->
+                            withContext(Dispatchers.Main) {
+                                if (error == ImagingError.NO_ACTIVE_SESSION) {
+                                    _events.send(ImagingEvent.NavigateBackToLandingScreen)
                                 }
+                                emitError(error)
                             }
                         }
                     }
-                    withContext(Dispatchers.Main) {
-                        _state.update { it.copy(isProcessing = false) }
-                    }
+                    _state.update { it.copy(isProcessing = false) }
                 }
 
                 ImagingAction.RetakeImage -> {

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -196,54 +196,60 @@ class ImagingViewModel @Inject constructor(
 
                     _state.update { it.copy(isProcessing = true) }
 
-                    val captureResult = cameraRepository.captureImage(action.controller)
+                    withContext(Dispatchers.Main) {
+                        val captureResult = cameraRepository.captureImage(action.controller)
 
-                    withContext(Dispatchers.Default) {
-                        captureResult.onSuccess { image ->
-                            val bitmap = image.toUprightBitmap()
-                            image.close()
+                        withContext(Dispatchers.Default) {
+                            captureResult.onSuccess { image ->
+                                val bitmap = image.toUprightBitmap()
+                                image.close()
 
-                            val jpegStream = ByteArrayOutputStream()
-                            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
-                            val jpegByteArray = jpegStream.toByteArray()
-                            val jpegBitmap =
-                                BitmapFactory.decodeByteArray(
-                                    jpegByteArray,
-                                    0,
-                                    jpegByteArray.size
-                                )
+                                val jpegStream = ByteArrayOutputStream()
+                                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
+                                val jpegByteArray = jpegStream.toByteArray()
+                                val jpegBitmap =
+                                    BitmapFactory.decodeByteArray(
+                                        jpegByteArray,
+                                        0,
+                                        jpegByteArray.size
+                                    )
 
-                            val capturedFrameProcessingResult =
-                                imagingWorkflow.processCapturedFrame(jpegBitmap)
+                                val capturedFrameProcessingResult =
+                                    imagingWorkflow.processCapturedFrame(jpegBitmap)
 
-                            withContext(Dispatchers.Main) {
-                                capturedFrameProcessingResult.onSuccess { result ->
-                                    _state.update {
-                                        it.copy(
-                                            currentSpecimenImage = it.currentSpecimenImage.copy(
-                                                species = result.species,
-                                                sex = result.sex,
-                                                abdomenStatus = result.abdomenStatus
-                                            ),
-                                            currentImageBytes = jpegByteArray,
-                                            currentInferenceResult = result.capturedInferenceResult,
-                                            previewInferenceResults = emptyList()
-                                        )
+                                withContext(Dispatchers.Main) {
+                                    capturedFrameProcessingResult.onSuccess { result ->
+                                        _state.update {
+                                            it.copy(
+                                                currentSpecimenImage = it.currentSpecimenImage.copy(
+                                                    species = result.species,
+                                                    sex = result.sex,
+                                                    abdomenStatus = result.abdomenStatus
+                                                ),
+                                                currentImageBytes = jpegByteArray,
+                                                currentInferenceResult = result.capturedInferenceResult,
+                                                previewInferenceResults = emptyList()
+                                            )
+                                        }
+                                    }
+                                }.onError { error ->
+                                    withContext(Dispatchers.Main) {
+                                        emitError(error, SnackbarDuration.Short)
                                     }
                                 }
                             }.onError { error ->
-                                emitError(error, SnackbarDuration.Short)
-                            }
-                        }.onError { error ->
-                            withContext(Dispatchers.Main) {
-                                if (error == ImagingError.NO_ACTIVE_SESSION) {
-                                    _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                                withContext(Dispatchers.Main) {
+                                    if (error == ImagingError.NO_ACTIVE_SESSION) {
+                                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                                    }
+                                    emitError(error)
                                 }
-                                emitError(error)
                             }
                         }
                     }
-                    _state.update { it.copy(isProcessing = false) }
+                    withContext(Dispatchers.Main) {
+                        _state.update { it.copy(isProcessing = false) }
+                    }
                 }
 
                 ImagingAction.RetakeImage -> {

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -99,245 +99,253 @@ class ImagingViewModel @Inject constructor(
 
     fun onAction(action: ImagingAction) {
         viewModelScope.launch {
-            when (action) {
-                ImagingAction.ShowExitDialog -> {
-                    _state.update { it.copy(showExitDialog = true) }
-                }
-
-                ImagingAction.DismissExitDialog -> {
-                    _state.update { it.copy(showExitDialog = false, pendingAction = null) }
-                }
-
-                is ImagingAction.SelectPendingAction -> {
-                    _state.update { it.copy(pendingAction = action.pendingAction) }
-                }
-
-                ImagingAction.ClearPendingAction -> {
-                    _state.update { it.copy(pendingAction = null) }
-                }
-
-                ImagingAction.ConfirmPendingAction -> {
-                    val actionToConfirm = _state.value.pendingAction
-                    _state.update { it.copy(showExitDialog = false, pendingAction = null) }
-                    actionToConfirm?.let { onAction(it) }
-                }
-
-                is ImagingAction.ManualFocusAt -> {
-                    _state.update { it.copy(manualFocusPoint = action.offset) }
-                }
-
-                is ImagingAction.CancelManualFocus -> {
-                    _state.update { it.copy(manualFocusPoint = null) }
-                }
-
-                is ImagingAction.CorrectSpecimenId -> {
-                    _state.update {
-                        it.copy(
-                            currentSpecimen = it.currentSpecimen.copy(id = action.specimenId)
-                        )
+            withContext(Dispatchers.Main) {
+                when (action) {
+                    ImagingAction.ShowExitDialog -> {
+                        _state.update { it.copy(showExitDialog = true) }
                     }
-                }
 
-                is ImagingAction.ProcessFrame -> {
-                    try {
-                        if (!_state.value.isCameraReady) {
-                            _state.update { it.copy(isCameraReady = true) }
-                        }
+                    ImagingAction.DismissExitDialog -> {
+                        _state.update { it.copy(showExitDialog = false, pendingAction = null) }
+                    }
 
-                        val bitmap = action.frame.toUprightBitmap()
+                    is ImagingAction.SelectPendingAction -> {
+                        _state.update { it.copy(pendingAction = action.pendingAction) }
+                    }
 
-                        val liveFrameProcessingResult =
-                            imagingWorkflow.processLiveFrame(bitmap)
+                    ImagingAction.ClearPendingAction -> {
+                        _state.update { it.copy(pendingAction = null) }
+                    }
 
-                        validateSpecimenIdUseCase(
-                            liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
-                        ).onSuccess { correctedSpecimenId ->
-                            _state.update {
-                                it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
-                            }
-                        }
+                    ImagingAction.ConfirmPendingAction -> {
+                        val actionToConfirm = _state.value.pendingAction
+                        _state.update { it.copy(showExitDialog = false, pendingAction = null) }
+                        actionToConfirm?.let { onAction(it) }
+                    }
 
+                    is ImagingAction.ManualFocusAt -> {
+                        _state.update { it.copy(manualFocusPoint = action.offset) }
+                    }
+
+                    is ImagingAction.CancelManualFocus -> {
+                        _state.update { it.copy(manualFocusPoint = null) }
+                    }
+
+                    is ImagingAction.CorrectSpecimenId -> {
                         _state.update {
-                            it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
+                            it.copy(
+                                currentSpecimen = it.currentSpecimen.copy(id = action.specimenId)
+                            )
                         }
-                    } catch (e: Exception) {
-                        emitError(ImagingError.PROCESSING_ERROR)
-                    } finally {
-                        action.frame.close()
-                    }
-                }
-
-                ImagingAction.SaveSessionProgress -> {
-                    currentSessionCache.clearSession()
-                    _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                }
-
-                ImagingAction.SubmitSession -> {
-                    val currentSession = currentSessionCache.getSession()
-                    val currentSessionSiteId = currentSessionCache.getSiteId()
-
-                    if (currentSession == null || currentSessionSiteId == null) {
-                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                        return@launch
                     }
 
-                    val success = sessionRepository.markSessionAsComplete(currentSession.localId)
-                    if (success) {
-                        workRepository.enqueueSessionUpload(
-                            currentSession.localId, currentSessionSiteId
-                        )
+                    is ImagingAction.ProcessFrame -> {
+                        try {
+                            if (!_state.value.isCameraReady) {
+                                _state.update { it.copy(isCameraReady = true) }
+                            }
+
+                            val bitmap = action.frame.toUprightBitmap()
+
+                            val liveFrameProcessingResult =
+                                imagingWorkflow.processLiveFrame(bitmap)
+
+                            validateSpecimenIdUseCase(
+                                liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
+                            ).onSuccess { correctedSpecimenId ->
+                                _state.update {
+                                    it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
+                                }
+                            }
+
+                            _state.update {
+                                it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
+                            }
+                        } catch (e: Exception) {
+                            emitError(ImagingError.PROCESSING_ERROR)
+                        } finally {
+                            action.frame.close()
+                        }
+                    }
+
+                    ImagingAction.SaveSessionProgress -> {
                         currentSessionCache.clearSession()
                         _events.send(ImagingEvent.NavigateBackToLandingScreen)
                     }
-                }
 
-                is ImagingAction.CaptureImage -> {
-                    if (!_state.value.isCameraReady) return@launch
+                    ImagingAction.SubmitSession -> {
+                        val currentSession = currentSessionCache.getSession()
+                        val currentSessionSiteId = currentSessionCache.getSiteId()
 
-                    _state.update { it.copy(isProcessing = true) }
+                        if (currentSession == null || currentSessionSiteId == null) {
+                            _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                            return@withContext
+                        }
 
-                    val captureResult = cameraRepository.captureImage(action.controller)
+                        val success =
+                            sessionRepository.markSessionAsComplete(currentSession.localId)
+                        if (success) {
+                            workRepository.enqueueSessionUpload(
+                                currentSession.localId, currentSessionSiteId
+                            )
+                            currentSessionCache.clearSession()
+                            _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                        }
+                    }
 
-                    withContext(Dispatchers.Default) {
-                        captureResult.onSuccess { image ->
-                            val bitmap = image.toUprightBitmap()
-                            image.close()
+                    is ImagingAction.CaptureImage -> {
+                        if (!_state.value.isCameraReady) return@withContext
 
-                            val jpegStream = ByteArrayOutputStream()
-                            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
-                            val jpegByteArray = jpegStream.toByteArray()
-                            val jpegBitmap =
-                                BitmapFactory.decodeByteArray(
-                                    jpegByteArray,
-                                    0,
-                                    jpegByteArray.size
-                                )
+                        _state.update { it.copy(isProcessing = true) }
 
-                            val capturedFrameProcessingResult =
-                                imagingWorkflow.processCapturedFrame(jpegBitmap)
+                        val captureResult = cameraRepository.captureImage(action.controller)
 
-                            withContext(Dispatchers.Main) {
-                                capturedFrameProcessingResult.onSuccess { result ->
-                                    _state.update {
-                                        it.copy(
-                                            currentSpecimenImage = it.currentSpecimenImage.copy(
-                                                species = result.species,
-                                                sex = result.sex,
-                                                abdomenStatus = result.abdomenStatus
-                                            ),
-                                            currentImageBytes = jpegByteArray,
-                                            currentInferenceResult = result.capturedInferenceResult,
-                                            previewInferenceResults = emptyList()
-                                        )
+                        withContext(Dispatchers.Default) {
+                            captureResult.onSuccess { image ->
+                                val bitmap = image.toUprightBitmap()
+                                image.close()
+
+                                val jpegStream = ByteArrayOutputStream()
+                                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
+                                val jpegByteArray = jpegStream.toByteArray()
+                                val jpegBitmap =
+                                    BitmapFactory.decodeByteArray(
+                                        jpegByteArray,
+                                        0,
+                                        jpegByteArray.size
+                                    )
+
+                                val capturedFrameProcessingResult =
+                                    imagingWorkflow.processCapturedFrame(jpegBitmap)
+
+                                withContext(Dispatchers.Main) {
+                                    capturedFrameProcessingResult.onSuccess { result ->
+                                        _state.update {
+                                            it.copy(
+                                                currentSpecimenImage = it.currentSpecimenImage.copy(
+                                                    species = result.species,
+                                                    sex = result.sex,
+                                                    abdomenStatus = result.abdomenStatus
+                                                ),
+                                                currentImageBytes = jpegByteArray,
+                                                currentInferenceResult = result.capturedInferenceResult,
+                                                previewInferenceResults = emptyList()
+                                            )
+                                        }
                                     }
+                                }.onError { error ->
+                                    emitError(error, SnackbarDuration.Short)
                                 }
                             }.onError { error ->
-                                emitError(error, SnackbarDuration.Short)
+                                withContext(Dispatchers.Main) {
+                                    if (error == ImagingError.NO_ACTIVE_SESSION) {
+                                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                                    }
+                                    emitError(error)
+                                }
+                            }
+                        }
+                        _state.update { it.copy(isProcessing = false) }
+                    }
+
+                    ImagingAction.RetakeImage -> {
+                        clearStateFields()
+                    }
+
+                    ImagingAction.SaveImageToSession -> {
+                        val currentSession = currentSessionCache.getSession()
+                        if (currentSession == null) {
+                            _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                            return@withContext
+                        }
+
+                        val specimenId = when (val validationResult = validateSpecimenIdUseCase(
+                            _state.value.currentSpecimen.id, shouldAutoCorrect = false
+                        )) {
+                            is Result.Success -> validationResult.data
+                            is Result.Error -> {
+                                emitError(validationResult.error)
+                                return@withContext
+                            }
+                        }
+
+                        val jpegBytes = _state.value.currentImageBytes ?: return@withContext
+                        val timestamp = System.currentTimeMillis()
+                        val filename = buildString {
+                            append(specimenId)
+                            append("_")
+                            append(timestamp)
+                            append(".jpg")
+                        }
+
+                        val saveResult =
+                            cameraRepository.saveImage(jpegBytes, filename, currentSession)
+
+                        saveResult.onSuccess { imageUri ->
+                            val specimen = Specimen(id = specimenId, remoteId = null)
+                            val specimenImage = SpecimenImage(
+                                localId = calculateMd5(jpegBytes),
+                                remoteId = null,
+                                species = _state.value.currentSpecimenImage.species,
+                                sex = _state.value.currentSpecimenImage.sex,
+                                abdomenStatus = _state.value.currentSpecimenImage.abdomenStatus,
+                                imageUri = imageUri,
+                                imageUploadStatus = UploadStatus.NOT_STARTED,
+                                metadataUploadStatus = UploadStatus.NOT_STARTED,
+                                capturedAt = timestamp,
+                                submittedAt = null
+                            )
+
+                            val success = transactionHelper.runAsTransaction {
+                                val inferenceResult = _state.value.currentInferenceResult
+
+                                val existingSpecimen =
+                                    specimenRepository.getSpecimenByIdAndSessionId(
+                                        specimenId, currentSession.localId
+                                    )
+                                val specimenInsertionResult = if (existingSpecimen == null) {
+                                    specimenRepository.insertSpecimen(
+                                        specimen,
+                                        currentSession.localId
+                                    )
+                                } else {
+                                    Result.Success(Unit)
+                                }
+                                val specimenImageInsertionResult =
+                                    specimenImageRepository.insertSpecimenImage(
+                                        specimenImage, specimen.id, currentSession.localId
+                                    )
+
+                                val inferenceResultInsertionResult = inferenceResult?.let {
+                                    inferenceResultRepository.insertInferenceResult(
+                                        inferenceResult, specimenImage.localId
+                                    )
+                                } ?: Result.Success(Unit)
+
+                                specimenInsertionResult.onError { error ->
+                                    emitError(error)
+                                }
+
+                                specimenImageInsertionResult.onError { error ->
+                                    emitError(error)
+                                }
+
+                                inferenceResultInsertionResult.onError { error ->
+                                    emitError(error)
+                                }
+
+                                (specimenInsertionResult !is Result.Error) && (specimenImageInsertionResult !is Result.Error) && (inferenceResultInsertionResult !is Result.Error)
+                            }
+
+                            if (success) {
+                                clearStateFields()
+                            } else {
+                                emitError(ImagingError.SAVE_ERROR)
+                                cameraRepository.deleteSavedImage(imageUri)
                             }
                         }.onError { error ->
-                            withContext(Dispatchers.Main) {
-                                if (error == ImagingError.NO_ACTIVE_SESSION) {
-                                    _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                                }
-                                emitError(error)
-                            }
+                            emitError(error)
                         }
-                    }
-                    _state.update { it.copy(isProcessing = false) }
-                }
-
-                ImagingAction.RetakeImage -> {
-                    clearStateFields()
-                }
-
-                ImagingAction.SaveImageToSession -> {
-                    val currentSession = currentSessionCache.getSession()
-                    if (currentSession == null) {
-                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                        return@launch
-                    }
-
-                    val specimenId = when (val validationResult = validateSpecimenIdUseCase(
-                        _state.value.currentSpecimen.id, shouldAutoCorrect = false
-                    )) {
-                        is Result.Success -> validationResult.data
-                        is Result.Error -> {
-                            emitError(validationResult.error)
-                            return@launch
-                        }
-                    }
-
-                    val jpegBytes = _state.value.currentImageBytes ?: return@launch
-                    val timestamp = System.currentTimeMillis()
-                    val filename = buildString {
-                        append(specimenId)
-                        append("_")
-                        append(timestamp)
-                        append(".jpg")
-                    }
-
-                    val saveResult = cameraRepository.saveImage(jpegBytes, filename, currentSession)
-
-                    saveResult.onSuccess { imageUri ->
-                        val specimen = Specimen(id = specimenId, remoteId = null)
-                        val specimenImage = SpecimenImage(
-                            localId = calculateMd5(jpegBytes),
-                            remoteId = null,
-                            species = _state.value.currentSpecimenImage.species,
-                            sex = _state.value.currentSpecimenImage.sex,
-                            abdomenStatus = _state.value.currentSpecimenImage.abdomenStatus,
-                            imageUri = imageUri,
-                            imageUploadStatus = UploadStatus.NOT_STARTED,
-                            metadataUploadStatus = UploadStatus.NOT_STARTED,
-                            capturedAt = timestamp,
-                            submittedAt = null
-                        )
-
-                        val success = transactionHelper.runAsTransaction {
-                            val inferenceResult = _state.value.currentInferenceResult
-
-                            val existingSpecimen = specimenRepository.getSpecimenByIdAndSessionId(
-                                specimenId, currentSession.localId
-                            )
-                            val specimenInsertionResult = if (existingSpecimen == null) {
-                                specimenRepository.insertSpecimen(specimen, currentSession.localId)
-                            } else {
-                                Result.Success(Unit)
-                            }
-                            val specimenImageInsertionResult =
-                                specimenImageRepository.insertSpecimenImage(
-                                    specimenImage, specimen.id, currentSession.localId
-                                )
-
-                            val inferenceResultInsertionResult = inferenceResult?.let {
-                                inferenceResultRepository.insertInferenceResult(
-                                    inferenceResult, specimenImage.localId
-                                )
-                            } ?: Result.Success(Unit)
-
-                            specimenInsertionResult.onError { error ->
-                                emitError(error)
-                            }
-
-                            specimenImageInsertionResult.onError { error ->
-                                emitError(error)
-                            }
-
-                            inferenceResultInsertionResult.onError { error ->
-                                emitError(error)
-                            }
-
-                            (specimenInsertionResult !is Result.Error) && (specimenImageInsertionResult !is Result.Error) && (inferenceResultInsertionResult !is Result.Error)
-                        }
-
-                        if (success) {
-                            clearStateFields()
-                        } else {
-                            emitError(ImagingError.SAVE_ERROR)
-                            cameraRepository.deleteSavedImage(imageUri)
-                        }
-                    }.onError { error ->
-                        emitError(error)
                     }
                 }
             }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -139,31 +139,34 @@ class ImagingViewModel @Inject constructor(
                 }
 
                 is ImagingAction.ProcessFrame -> {
-                    try {
-                        if (!_state.value.isCameraReady) {
-                            _state.update { it.copy(isCameraReady = true) }
-                        }
-
-                        val bitmap = action.frame.toUprightBitmap()
-
-                        val liveFrameProcessingResult =
-                            imagingWorkflow.processLiveFrame(bitmap)
-
-                        validateSpecimenIdUseCase(
-                            liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
-                        ).onSuccess { correctedSpecimenId ->
-                            _state.update {
-                                it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
+                    withContext(Dispatchers.Main) {
+                        try {
+                            if (!_state.value.isCameraReady) {
+                                _state.update { it.copy(isCameraReady = true) }
                             }
-                        }
+                            withContext(Dispatchers.Default) {
+                                val bitmap = action.frame.toUprightBitmap()
+                                val liveFrameProcessingResult = imagingWorkflow.processLiveFrame(bitmap)
 
-                        _state.update {
-                            it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
+                                withContext(Dispatchers.Main) {
+                                    validateSpecimenIdUseCase(
+                                        liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
+                                    ).onSuccess { correctedSpecimenId ->
+                                        _state.update {
+                                            it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
+                                        }
+                                    }
+
+                                    _state.update {
+                                        it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
+                                    }
+                                }
+                            }
+                        } catch (e: Exception) {
+                            emitError(ImagingError.PROCESSING_ERROR)
+                        } finally {
+                            action.frame.close()
                         }
-                    } catch (e: Exception) {
-                        emitError(ImagingError.PROCESSING_ERROR)
-                    } finally {
-                        action.frame.close()
                     }
                 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -99,253 +99,245 @@ class ImagingViewModel @Inject constructor(
 
     fun onAction(action: ImagingAction) {
         viewModelScope.launch {
-            withContext(Dispatchers.Main) {
-                when (action) {
-                    ImagingAction.ShowExitDialog -> {
-                        _state.update { it.copy(showExitDialog = true) }
-                    }
+            when (action) {
+                ImagingAction.ShowExitDialog -> {
+                    _state.update { it.copy(showExitDialog = true) }
+                }
 
-                    ImagingAction.DismissExitDialog -> {
-                        _state.update { it.copy(showExitDialog = false, pendingAction = null) }
-                    }
+                ImagingAction.DismissExitDialog -> {
+                    _state.update { it.copy(showExitDialog = false, pendingAction = null) }
+                }
 
-                    is ImagingAction.SelectPendingAction -> {
-                        _state.update { it.copy(pendingAction = action.pendingAction) }
-                    }
+                is ImagingAction.SelectPendingAction -> {
+                    _state.update { it.copy(pendingAction = action.pendingAction) }
+                }
 
-                    ImagingAction.ClearPendingAction -> {
-                        _state.update { it.copy(pendingAction = null) }
-                    }
+                ImagingAction.ClearPendingAction -> {
+                    _state.update { it.copy(pendingAction = null) }
+                }
 
-                    ImagingAction.ConfirmPendingAction -> {
-                        val actionToConfirm = _state.value.pendingAction
-                        _state.update { it.copy(showExitDialog = false, pendingAction = null) }
-                        actionToConfirm?.let { onAction(it) }
-                    }
+                ImagingAction.ConfirmPendingAction -> {
+                    val actionToConfirm = _state.value.pendingAction
+                    _state.update { it.copy(showExitDialog = false, pendingAction = null) }
+                    actionToConfirm?.let { onAction(it) }
+                }
 
-                    is ImagingAction.ManualFocusAt -> {
-                        _state.update { it.copy(manualFocusPoint = action.offset) }
-                    }
+                is ImagingAction.ManualFocusAt -> {
+                    _state.update { it.copy(manualFocusPoint = action.offset) }
+                }
 
-                    is ImagingAction.CancelManualFocus -> {
-                        _state.update { it.copy(manualFocusPoint = null) }
-                    }
+                is ImagingAction.CancelManualFocus -> {
+                    _state.update { it.copy(manualFocusPoint = null) }
+                }
 
-                    is ImagingAction.CorrectSpecimenId -> {
-                        _state.update {
-                            it.copy(
-                                currentSpecimen = it.currentSpecimen.copy(id = action.specimenId)
-                            )
+                is ImagingAction.CorrectSpecimenId -> {
+                    _state.update {
+                        it.copy(
+                            currentSpecimen = it.currentSpecimen.copy(id = action.specimenId)
+                        )
+                    }
+                }
+
+                is ImagingAction.ProcessFrame -> {
+                    try {
+                        if (!_state.value.isCameraReady) {
+                            _state.update { it.copy(isCameraReady = true) }
                         }
-                    }
 
-                    is ImagingAction.ProcessFrame -> {
-                        try {
-                            if (!_state.value.isCameraReady) {
-                                _state.update { it.copy(isCameraReady = true) }
-                            }
+                        val bitmap = action.frame.toUprightBitmap()
 
-                            val bitmap = action.frame.toUprightBitmap()
+                        val liveFrameProcessingResult =
+                            imagingWorkflow.processLiveFrame(bitmap)
 
-                            val liveFrameProcessingResult =
-                                imagingWorkflow.processLiveFrame(bitmap)
-
-                            validateSpecimenIdUseCase(
-                                liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
-                            ).onSuccess { correctedSpecimenId ->
-                                _state.update {
-                                    it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
-                                }
-                            }
-
+                        validateSpecimenIdUseCase(
+                            liveFrameProcessingResult.specimenId, shouldAutoCorrect = true
+                        ).onSuccess { correctedSpecimenId ->
                             _state.update {
-                                it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
+                                it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
                             }
-                        } catch (e: Exception) {
-                            emitError(ImagingError.PROCESSING_ERROR)
-                        } finally {
-                            action.frame.close()
                         }
+
+                        _state.update {
+                            it.copy(previewInferenceResults = liveFrameProcessingResult.previewInferenceResults)
+                        }
+                    } catch (e: Exception) {
+                        emitError(ImagingError.PROCESSING_ERROR)
+                    } finally {
+                        action.frame.close()
+                    }
+                }
+
+                ImagingAction.SaveSessionProgress -> {
+                    currentSessionCache.clearSession()
+                    _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                }
+
+                ImagingAction.SubmitSession -> {
+                    val currentSession = currentSessionCache.getSession()
+                    val currentSessionSiteId = currentSessionCache.getSiteId()
+
+                    if (currentSession == null || currentSessionSiteId == null) {
+                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                        return@launch
                     }
 
-                    ImagingAction.SaveSessionProgress -> {
+                    val success = sessionRepository.markSessionAsComplete(currentSession.localId)
+                    if (success) {
+                        workRepository.enqueueSessionUpload(
+                            currentSession.localId, currentSessionSiteId
+                        )
                         currentSessionCache.clearSession()
                         _events.send(ImagingEvent.NavigateBackToLandingScreen)
                     }
+                }
 
-                    ImagingAction.SubmitSession -> {
-                        val currentSession = currentSessionCache.getSession()
-                        val currentSessionSiteId = currentSessionCache.getSiteId()
+                is ImagingAction.CaptureImage -> {
+                    if (!_state.value.isCameraReady) return@launch
 
-                        if (currentSession == null || currentSessionSiteId == null) {
-                            _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                            return@withContext
-                        }
+                    _state.update { it.copy(isProcessing = true) }
 
-                        val success =
-                            sessionRepository.markSessionAsComplete(currentSession.localId)
-                        if (success) {
-                            workRepository.enqueueSessionUpload(
-                                currentSession.localId, currentSessionSiteId
-                            )
-                            currentSessionCache.clearSession()
-                            _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                        }
-                    }
+                    val captureResult = cameraRepository.captureImage(action.controller)
 
-                    is ImagingAction.CaptureImage -> {
-                        if (!_state.value.isCameraReady) return@withContext
+                    withContext(Dispatchers.Default) {
+                        captureResult.onSuccess { image ->
+                            val bitmap = image.toUprightBitmap()
+                            image.close()
 
-                        _state.update { it.copy(isProcessing = true) }
+                            val jpegStream = ByteArrayOutputStream()
+                            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
+                            val jpegByteArray = jpegStream.toByteArray()
+                            val jpegBitmap =
+                                BitmapFactory.decodeByteArray(
+                                    jpegByteArray,
+                                    0,
+                                    jpegByteArray.size
+                                )
 
-                        val captureResult = cameraRepository.captureImage(action.controller)
+                            val capturedFrameProcessingResult =
+                                imagingWorkflow.processCapturedFrame(jpegBitmap)
 
-                        withContext(Dispatchers.Default) {
-                            captureResult.onSuccess { image ->
-                                val bitmap = image.toUprightBitmap()
-                                image.close()
-
-                                val jpegStream = ByteArrayOutputStream()
-                                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
-                                val jpegByteArray = jpegStream.toByteArray()
-                                val jpegBitmap =
-                                    BitmapFactory.decodeByteArray(
-                                        jpegByteArray,
-                                        0,
-                                        jpegByteArray.size
-                                    )
-
-                                val capturedFrameProcessingResult =
-                                    imagingWorkflow.processCapturedFrame(jpegBitmap)
-
-                                withContext(Dispatchers.Main) {
-                                    capturedFrameProcessingResult.onSuccess { result ->
-                                        _state.update {
-                                            it.copy(
-                                                currentSpecimenImage = it.currentSpecimenImage.copy(
-                                                    species = result.species,
-                                                    sex = result.sex,
-                                                    abdomenStatus = result.abdomenStatus
-                                                ),
-                                                currentImageBytes = jpegByteArray,
-                                                currentInferenceResult = result.capturedInferenceResult,
-                                                previewInferenceResults = emptyList()
-                                            )
-                                        }
+                            withContext(Dispatchers.Main) {
+                                capturedFrameProcessingResult.onSuccess { result ->
+                                    _state.update {
+                                        it.copy(
+                                            currentSpecimenImage = it.currentSpecimenImage.copy(
+                                                species = result.species,
+                                                sex = result.sex,
+                                                abdomenStatus = result.abdomenStatus
+                                            ),
+                                            currentImageBytes = jpegByteArray,
+                                            currentInferenceResult = result.capturedInferenceResult,
+                                            previewInferenceResults = emptyList()
+                                        )
                                     }
-                                }.onError { error ->
-                                    emitError(error, SnackbarDuration.Short)
                                 }
                             }.onError { error ->
-                                withContext(Dispatchers.Main) {
-                                    if (error == ImagingError.NO_ACTIVE_SESSION) {
-                                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                                    }
-                                    emitError(error)
-                                }
-                            }
-                        }
-                        _state.update { it.copy(isProcessing = false) }
-                    }
-
-                    ImagingAction.RetakeImage -> {
-                        clearStateFields()
-                    }
-
-                    ImagingAction.SaveImageToSession -> {
-                        val currentSession = currentSessionCache.getSession()
-                        if (currentSession == null) {
-                            _events.send(ImagingEvent.NavigateBackToLandingScreen)
-                            return@withContext
-                        }
-
-                        val specimenId = when (val validationResult = validateSpecimenIdUseCase(
-                            _state.value.currentSpecimen.id, shouldAutoCorrect = false
-                        )) {
-                            is Result.Success -> validationResult.data
-                            is Result.Error -> {
-                                emitError(validationResult.error)
-                                return@withContext
-                            }
-                        }
-
-                        val jpegBytes = _state.value.currentImageBytes ?: return@withContext
-                        val timestamp = System.currentTimeMillis()
-                        val filename = buildString {
-                            append(specimenId)
-                            append("_")
-                            append(timestamp)
-                            append(".jpg")
-                        }
-
-                        val saveResult =
-                            cameraRepository.saveImage(jpegBytes, filename, currentSession)
-
-                        saveResult.onSuccess { imageUri ->
-                            val specimen = Specimen(id = specimenId, remoteId = null)
-                            val specimenImage = SpecimenImage(
-                                localId = calculateMd5(jpegBytes),
-                                remoteId = null,
-                                species = _state.value.currentSpecimenImage.species,
-                                sex = _state.value.currentSpecimenImage.sex,
-                                abdomenStatus = _state.value.currentSpecimenImage.abdomenStatus,
-                                imageUri = imageUri,
-                                imageUploadStatus = UploadStatus.NOT_STARTED,
-                                metadataUploadStatus = UploadStatus.NOT_STARTED,
-                                capturedAt = timestamp,
-                                submittedAt = null
-                            )
-
-                            val success = transactionHelper.runAsTransaction {
-                                val inferenceResult = _state.value.currentInferenceResult
-
-                                val existingSpecimen =
-                                    specimenRepository.getSpecimenByIdAndSessionId(
-                                        specimenId, currentSession.localId
-                                    )
-                                val specimenInsertionResult = if (existingSpecimen == null) {
-                                    specimenRepository.insertSpecimen(
-                                        specimen,
-                                        currentSession.localId
-                                    )
-                                } else {
-                                    Result.Success(Unit)
-                                }
-                                val specimenImageInsertionResult =
-                                    specimenImageRepository.insertSpecimenImage(
-                                        specimenImage, specimen.id, currentSession.localId
-                                    )
-
-                                val inferenceResultInsertionResult = inferenceResult?.let {
-                                    inferenceResultRepository.insertInferenceResult(
-                                        inferenceResult, specimenImage.localId
-                                    )
-                                } ?: Result.Success(Unit)
-
-                                specimenInsertionResult.onError { error ->
-                                    emitError(error)
-                                }
-
-                                specimenImageInsertionResult.onError { error ->
-                                    emitError(error)
-                                }
-
-                                inferenceResultInsertionResult.onError { error ->
-                                    emitError(error)
-                                }
-
-                                (specimenInsertionResult !is Result.Error) && (specimenImageInsertionResult !is Result.Error) && (inferenceResultInsertionResult !is Result.Error)
-                            }
-
-                            if (success) {
-                                clearStateFields()
-                            } else {
-                                emitError(ImagingError.SAVE_ERROR)
-                                cameraRepository.deleteSavedImage(imageUri)
+                                emitError(error, SnackbarDuration.Short)
                             }
                         }.onError { error ->
-                            emitError(error)
+                            withContext(Dispatchers.Main) {
+                                if (error == ImagingError.NO_ACTIVE_SESSION) {
+                                    _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                                }
+                                emitError(error)
+                            }
                         }
+                    }
+                    _state.update { it.copy(isProcessing = false) }
+                }
+
+                ImagingAction.RetakeImage -> {
+                    clearStateFields()
+                }
+
+                ImagingAction.SaveImageToSession -> {
+                    val currentSession = currentSessionCache.getSession()
+                    if (currentSession == null) {
+                        _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                        return@launch
+                    }
+
+                    val specimenId = when (val validationResult = validateSpecimenIdUseCase(
+                        _state.value.currentSpecimen.id, shouldAutoCorrect = false
+                    )) {
+                        is Result.Success -> validationResult.data
+                        is Result.Error -> {
+                            emitError(validationResult.error)
+                            return@launch
+                        }
+                    }
+
+                    val jpegBytes = _state.value.currentImageBytes ?: return@launch
+                    val timestamp = System.currentTimeMillis()
+                    val filename = buildString {
+                        append(specimenId)
+                        append("_")
+                        append(timestamp)
+                        append(".jpg")
+                    }
+
+                    val saveResult = cameraRepository.saveImage(jpegBytes, filename, currentSession)
+
+                    saveResult.onSuccess { imageUri ->
+                        val specimen = Specimen(id = specimenId, remoteId = null)
+                        val specimenImage = SpecimenImage(
+                            localId = calculateMd5(jpegBytes),
+                            remoteId = null,
+                            species = _state.value.currentSpecimenImage.species,
+                            sex = _state.value.currentSpecimenImage.sex,
+                            abdomenStatus = _state.value.currentSpecimenImage.abdomenStatus,
+                            imageUri = imageUri,
+                            imageUploadStatus = UploadStatus.NOT_STARTED,
+                            metadataUploadStatus = UploadStatus.NOT_STARTED,
+                            capturedAt = timestamp,
+                            submittedAt = null
+                        )
+
+                        val success = transactionHelper.runAsTransaction {
+                            val inferenceResult = _state.value.currentInferenceResult
+
+                            val existingSpecimen = specimenRepository.getSpecimenByIdAndSessionId(
+                                specimenId, currentSession.localId
+                            )
+                            val specimenInsertionResult = if (existingSpecimen == null) {
+                                specimenRepository.insertSpecimen(specimen, currentSession.localId)
+                            } else {
+                                Result.Success(Unit)
+                            }
+                            val specimenImageInsertionResult =
+                                specimenImageRepository.insertSpecimenImage(
+                                    specimenImage, specimen.id, currentSession.localId
+                                )
+
+                            val inferenceResultInsertionResult = inferenceResult?.let {
+                                inferenceResultRepository.insertInferenceResult(
+                                    inferenceResult, specimenImage.localId
+                                )
+                            } ?: Result.Success(Unit)
+
+                            specimenInsertionResult.onError { error ->
+                                emitError(error)
+                            }
+
+                            specimenImageInsertionResult.onError { error ->
+                                emitError(error)
+                            }
+
+                            inferenceResultInsertionResult.onError { error ->
+                                emitError(error)
+                            }
+
+                            (specimenInsertionResult !is Result.Error) && (specimenImageInsertionResult !is Result.Error) && (inferenceResultInsertionResult !is Result.Error)
+                        }
+
+                        if (success) {
+                            clearStateFields()
+                        } else {
+                            emitError(ImagingError.SAVE_ERROR)
+                            cameraRepository.deleteSavedImage(imageUri)
+                        }
+                    }.onError { error ->
+                        emitError(error)
                     }
                 }
             }


### PR DESCRIPTION
This pull request resolves crashes on Sentry with the error message "IllegalStateException: Not in application's main thread" that occurred when camera operations were called from background threads. `CameraX` requires all camera operations to run on the main thread, but the current code calls `cameraRepository.captureImage()` directly in the coroutine scope without guaranteeing that it runs in the main thread. The fix wraps all camera operations in `withContext(Dispatchers.Main)` to ensure they execute on the main thread, then switches to background threads for image processing, and returns to the main thread for UI updates. This pattern has been applied to both `CaptureImage` and `ProcessFrame` actions. 