### PR TITLE
SOF-313: Add backend authentication for text data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ android {
 
         buildConfigField("String", "POSTHOG_API_KEY", "\"${secretsProperties["POSTHOG_API_KEY"]}\"")
         buildConfigField("String", "POSTHOG_HOST", "\"${secretsProperties["POSTHOG_HOST"]}\"")
+        buildConfigField("String", "VECTORCAM_API_KEY", "\"${secretsProperties["VECTORCAM_API_KEY"]}\"")
 
         ndk {
             abiFilters += listOf("armeabi-v7a", "arm64-v8a")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -234,6 +234,7 @@
 -keep class com.vci.vectorcamapp.BuildConfig {
     public static final java.lang.String POSTHOG_API_KEY;
     public static final java.lang.String POSTHOG_HOST;
+    public static final java.lang.String VECTORCAM_API_KEY;
     public static final java.lang.String BASE_URL;
 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteDeviceDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteDeviceDataSource.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.data.network.api
 
+import com.vci.vectorcamapp.BuildConfig
 import com.vci.vectorcamapp.core.data.dto.device.DeviceDto
 import com.vci.vectorcamapp.core.data.dto.device.RegisterDeviceRequestDto
 import com.vci.vectorcamapp.core.data.dto.device.RegisterDeviceResponseDto
@@ -10,6 +11,7 @@ import com.vci.vectorcamapp.core.domain.network.api.DeviceDataSource
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -25,6 +27,7 @@ class RemoteDeviceDataSource @Inject constructor(
     ): Result<RegisterDeviceResponseDto, NetworkError> {
         return safeCall<RegisterDeviceResponseDto> {
             httpClient.post(constructUrl("devices/register")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
                 setBody(
                     RegisterDeviceRequestDto(
@@ -40,6 +43,7 @@ class RemoteDeviceDataSource @Inject constructor(
     override suspend fun getDeviceById(deviceId: Int): Result<DeviceDto, NetworkError> {
         return safeCall<DeviceDto> {
             httpClient.get(constructUrl("devices/$deviceId")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.data.network.api
 
+import com.vci.vectorcamapp.BuildConfig
 import com.vci.vectorcamapp.core.data.dto.session.PostSessionRequestDto
 import com.vci.vectorcamapp.core.data.dto.session.PostSessionResponseDto
 import com.vci.vectorcamapp.core.data.dto.session.SessionDto
@@ -10,6 +11,7 @@ import com.vci.vectorcamapp.core.domain.network.api.SessionDataSource
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -31,6 +33,7 @@ class RemoteSessionDataSource @Inject constructor(
 
         return safeCall<PostSessionResponseDto> {
             httpClient.post(constructUrl("sessions")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
                 setBody(
                     PostSessionRequestDto(
@@ -58,6 +61,7 @@ class RemoteSessionDataSource @Inject constructor(
     override suspend fun getSessionByFrontendId(localId: UUID): Result<SessionDto, NetworkError> {
         return safeCall<SessionDto> {
             httpClient.get(constructUrl("sessions/$localId")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.data.network.api
 
+import com.vci.vectorcamapp.BuildConfig
 import com.vci.vectorcamapp.core.data.dto.specimen.PostSpecimenRequestDto
 import com.vci.vectorcamapp.core.data.dto.specimen.PostSpecimenResponseDto
 import com.vci.vectorcamapp.core.data.dto.specimen.SpecimenDto
@@ -10,6 +11,7 @@ import com.vci.vectorcamapp.core.domain.network.api.SpecimenDataSource
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -26,6 +28,7 @@ class RemoteSpecimenDataSource @Inject constructor(
     ): Result<PostSpecimenResponseDto, NetworkError> {
         return safeCall<PostSpecimenResponseDto> {
             httpClient.post(constructUrl("sessions/$sessionId/specimens")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
                 setBody(
                     PostSpecimenRequestDto(
@@ -39,6 +42,7 @@ class RemoteSpecimenDataSource @Inject constructor(
     override suspend fun getSpecimenByIdAndSessionId(specimenId: String, sessionId: Int): Result<SpecimenDto, NetworkError> {
         return safeCall<SpecimenDto> {
             httpClient.get(constructUrl("sessions/$sessionId/specimens/$specimenId")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenImageDataSource.kt
@@ -1,6 +1,7 @@
 package com.vci.vectorcamapp.core.data.network.api
 
 import android.util.Log
+import com.vci.vectorcamapp.BuildConfig
 import com.vci.vectorcamapp.core.data.dto.inference_result.InferenceResultDto
 import com.vci.vectorcamapp.core.data.dto.specimen_image.PostSpecimenImageRequestDto
 import com.vci.vectorcamapp.core.data.dto.specimen_image.PostSpecimenImageResponseDto
@@ -13,6 +14,7 @@ import com.vci.vectorcamapp.core.domain.network.api.SpecimenImageDataSource
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -28,6 +30,7 @@ class RemoteSpecimenImageDataSource @Inject constructor(
     ): Result<PostSpecimenImageResponseDto, NetworkError> {
         return safeCall<PostSpecimenImageResponseDto> {
             httpClient.post(constructUrl("specimens/${specimenId}/images/data")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
                 setBody(
                     PostSpecimenImageRequestDto(
@@ -63,6 +66,7 @@ class RemoteSpecimenImageDataSource @Inject constructor(
     ): Result<SpecimenImageDto, NetworkError> {
         return safeCall<SpecimenImageDto> {
             httpClient.get(constructUrl("specimens/${specimenId}/images/data/${specimenImageId}")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSurveillanceFormDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSurveillanceFormDataSource.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.data.network.api
 
+import com.vci.vectorcamapp.BuildConfig
 import com.vci.vectorcamapp.core.data.dto.surveillance_form.PostSurveillanceFormRequestDto
 import com.vci.vectorcamapp.core.data.dto.surveillance_form.PostSurveillanceFormResponseDto
 import com.vci.vectorcamapp.core.data.dto.surveillance_form.SurveillanceFormDto
@@ -10,6 +11,7 @@ import com.vci.vectorcamapp.core.domain.network.api.SurveillanceFormDataSource
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -27,6 +29,7 @@ class RemoteSurveillanceFormDataSource @Inject constructor(
     ): Result<PostSurveillanceFormResponseDto, NetworkError> {
         return safeCall<PostSurveillanceFormResponseDto> {
             httpClient.post(constructUrl("sessions/$sessionId/survey")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
                 setBody(
                     PostSurveillanceFormRequestDto(
@@ -47,6 +50,7 @@ class RemoteSurveillanceFormDataSource @Inject constructor(
     override suspend fun getSurveillanceFormBySessionId(sessionId: Int): Result<SurveillanceFormDto, NetworkError> {
         return safeCall<SurveillanceFormDto> {
             httpClient.get(constructUrl("sessions/$sessionId/survey")) {
+                bearerAuth(BuildConfig.VECTORCAM_API_KEY)
                 contentType(ContentType.Application.Json)
             }
         }


### PR DESCRIPTION
This PR adds bearer authentication headers to all text data upload endpoints. This will help protect all our data upload endpoints against malicious users. This involved using the bearerAuth() function offered by KTOR client which allows us to attach the token in the header as:

Authorization Bearer <token>