### PR TITLE
SOF-317: Allow user to type when the user selects "Other" on the Intake Screen

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/intake/domain/use_cases/ValidateCollectionMethodUseCase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/domain/use_cases/ValidateCollectionMethodUseCase.kt
@@ -1,15 +1,19 @@
 package com.vci.vectorcamapp.intake.domain.use_cases
 
 import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.intake.domain.model.IntakeDropdownOptions
 import com.vci.vectorcamapp.intake.domain.util.FormValidationError
 import javax.inject.Inject
 
 class ValidateCollectionMethodUseCase @Inject constructor() {
     operator fun invoke(collectionMethod: String): Result<Unit, FormValidationError> {
-        return if (collectionMethod.isBlank()) {
-            Result.Error(FormValidationError.BLANK_COLLECTION_METHOD)
-        } else {
-            Result.Success(Unit)
+        if (collectionMethod.isBlank()) return Result.Error(FormValidationError.BLANK_COLLECTION_METHOD)
+
+        if (collectionMethod.startsWith(IntakeDropdownOptions.CollectionMethodOption.OTHER.label, ignoreCase = true)) {
+            val suffix = collectionMethod.substringAfter(IntakeDropdownOptions.CollectionMethodOption.OTHER.label).trim()
+            if (suffix.isBlank()) return Result.Error(FormValidationError.BLANK_COLLECTION_METHOD)
         }
+
+        return Result.Success(Unit)
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/domain/use_cases/ValidateSpecimenConditionUseCase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/domain/use_cases/ValidateSpecimenConditionUseCase.kt
@@ -1,15 +1,19 @@
 package com.vci.vectorcamapp.intake.domain.use_cases
 
 import com.vci.vectorcamapp.core.domain.util.Result
+import com.vci.vectorcamapp.intake.domain.model.IntakeDropdownOptions
 import com.vci.vectorcamapp.intake.domain.util.FormValidationError
 import javax.inject.Inject
 
 class ValidateSpecimenConditionUseCase @Inject constructor() {
     operator fun invoke(specimenCondition: String): Result<Unit, FormValidationError> {
-        return if (specimenCondition.isBlank()) {
-            Result.Error(FormValidationError.BLANK_SPECIMEN_CONDITION)
-        } else {
-            Result.Success(Unit)
+        if (specimenCondition.isBlank()) return Result.Error(FormValidationError.BLANK_SPECIMEN_CONDITION)
+
+        if (specimenCondition.startsWith(IntakeDropdownOptions.SpecimenConditionOption.OTHER.label, ignoreCase = true)) {
+            val suffix = specimenCondition.substringAfter(IntakeDropdownOptions.SpecimenConditionOption.OTHER.label).trim()
+            if (suffix.isBlank()) return Result.Error(FormValidationError.BLANK_SPECIMEN_CONDITION)
         }
+
+        return Result.Success(Unit)
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeAction.kt
@@ -1,9 +1,7 @@
 package com.vci.vectorcamapp.intake.presentation
 
-import com.vci.vectorcamapp.intake.domain.model.IntakeDropdownOptions.CollectionMethodOption
 import com.vci.vectorcamapp.intake.domain.model.IntakeDropdownOptions.LlinBrandOption
 import com.vci.vectorcamapp.intake.domain.model.IntakeDropdownOptions.LlinTypeOption
-import com.vci.vectorcamapp.intake.domain.model.IntakeDropdownOptions.SpecimenConditionOption
 
 sealed interface IntakeAction {
     data object ReturnToLandingScreen: IntakeAction
@@ -21,8 +19,8 @@ sealed interface IntakeAction {
     data class SelectLlinBrand(val option: LlinBrandOption) : IntakeAction
     data class EnterNumPeopleSleptUnderLlin(val count: String) : IntakeAction
     data class PickCollectionDate(val date: Long) : IntakeAction
-    data class SelectCollectionMethod(val option: CollectionMethodOption) : IntakeAction
-    data class SelectSpecimenCondition(val option: SpecimenConditionOption) : IntakeAction
+    data class UpdateCollectionMethod(val collectionMethod: String) : IntakeAction
+    data class UpdateSpecimenCondition(val specimenCondition: String) : IntakeAction
     data class EnterNotes(val text: String) : IntakeAction
     data object RetryLocation: IntakeAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -100,16 +99,22 @@ fun IntakeScreen(
                     modifier = Modifier.fillMaxWidth()
                 )
 
+                val isOtherCollectionMethod =
+                    state.session.collectionMethod.startsWith("Other:", ignoreCase = true)
+
                 DropdownField(
                     label = "Collection Method",
                     options = IntakeDropdownOptions.CollectionMethodOption.entries,
-                    selectedOption = IntakeDropdownOptions.CollectionMethodOption.entries.firstOrNull { it.label == state.session.collectionMethod },
-                    onOptionSelected = {
-                        onAction(
-                            IntakeAction.SelectCollectionMethod(
-                                it
-                            )
-                        )
+                    selectedOption = if (isOtherCollectionMethod)
+                        IntakeDropdownOptions.CollectionMethodOption.OTHER
+                    else
+                        IntakeDropdownOptions.CollectionMethodOption.entries.firstOrNull { it.label == state.session.collectionMethod },
+                    onOptionSelected = { opt ->
+                        if (opt == IntakeDropdownOptions.CollectionMethodOption.OTHER) {
+                            onAction(IntakeAction.UpdateCollectionMethod("Other: "))
+                        } else {
+                            onAction(IntakeAction.UpdateCollectionMethod(opt.label))
+                        }
                     },
                     error = state.intakeErrors.collectionMethod,
                     modifier = Modifier.fillMaxWidth()
@@ -121,11 +126,35 @@ fun IntakeScreen(
                     )
                 }
 
+                if (isOtherCollectionMethod) {
+                    TextEntryField(
+                        label = "Other Collection Method",
+                        value = state.session.collectionMethod.removePrefix("Other: ").trimStart(),
+                        onValueChange = { typed ->
+                            onAction(IntakeAction.UpdateCollectionMethod("Other: $typed"))
+                        },
+                        singleLine = true,
+                        error = state.intakeErrors.collectionMethod
+                    )
+                }
+
+                val isOtherSpecimenCondition =
+                    state.session.specimenCondition.startsWith("Other:", ignoreCase = true)
+
                 DropdownField(
                     label = "Specimen Condition",
                     options = IntakeDropdownOptions.SpecimenConditionOption.entries,
-                    selectedOption = IntakeDropdownOptions.SpecimenConditionOption.entries.firstOrNull { it.label == state.session.specimenCondition },
-                    onOptionSelected = { onAction(IntakeAction.SelectSpecimenCondition(it)) },
+                    selectedOption = if (isOtherSpecimenCondition)
+                        IntakeDropdownOptions.SpecimenConditionOption.OTHER
+                    else
+                        IntakeDropdownOptions.SpecimenConditionOption.entries.firstOrNull { it.label == state.session.specimenCondition },
+                    onOptionSelected = { opt ->
+                        if (opt == IntakeDropdownOptions.SpecimenConditionOption.OTHER) {
+                            onAction(IntakeAction.UpdateSpecimenCondition("Other: "))
+                        } else {
+                            onAction(IntakeAction.UpdateSpecimenCondition(opt.label))
+                        }
+                    },
                     error = state.intakeErrors.specimenCondition,
                     modifier = Modifier.fillMaxWidth()
                 ) { specimenCondition ->
@@ -133,6 +162,18 @@ fun IntakeScreen(
                         text = specimenCondition.label,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colors.textPrimary
+                    )
+                }
+
+                if (isOtherSpecimenCondition) {
+                    TextEntryField(
+                        label = "Other Specimen Condition",
+                        value = state.session.specimenCondition.removePrefix("Other: ").trimStart(),
+                        onValueChange = { typed ->
+                            onAction(IntakeAction.UpdateSpecimenCondition("Other: $typed"))
+                        },
+                        singleLine = true,
+                        error = state.intakeErrors.specimenCondition
                     )
                 }
             }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
@@ -100,7 +100,7 @@ fun IntakeScreen(
                 )
 
                 val isOtherCollectionMethod =
-                    state.session.collectionMethod.startsWith("Other:", ignoreCase = true)
+                    state.session.collectionMethod.startsWith(IntakeDropdownOptions.CollectionMethodOption.OTHER.label, ignoreCase = true)
 
                 DropdownField(
                     label = "Collection Method",
@@ -109,13 +109,7 @@ fun IntakeScreen(
                         IntakeDropdownOptions.CollectionMethodOption.OTHER
                     else
                         IntakeDropdownOptions.CollectionMethodOption.entries.firstOrNull { it.label == state.session.collectionMethod },
-                    onOptionSelected = { opt ->
-                        if (opt == IntakeDropdownOptions.CollectionMethodOption.OTHER) {
-                            onAction(IntakeAction.UpdateCollectionMethod("Other: "))
-                        } else {
-                            onAction(IntakeAction.UpdateCollectionMethod(opt.label))
-                        }
-                    },
+                    onOptionSelected = { onAction(IntakeAction.UpdateCollectionMethod(it.label)) },
                     error = state.intakeErrors.collectionMethod,
                     modifier = Modifier.fillMaxWidth()
                 ) { collectionMethod ->
@@ -129,17 +123,15 @@ fun IntakeScreen(
                 if (isOtherCollectionMethod) {
                     TextEntryField(
                         label = "Other Collection Method",
-                        value = state.session.collectionMethod.removePrefix("Other: ").trimStart(),
-                        onValueChange = { typed ->
-                            onAction(IntakeAction.UpdateCollectionMethod("Other: $typed"))
-                        },
+                        value = state.session.collectionMethod.removePrefix(IntakeDropdownOptions.CollectionMethodOption.OTHER.label).trimStart(),
+                        onValueChange = { onAction(IntakeAction.UpdateCollectionMethod("${IntakeDropdownOptions.CollectionMethodOption.OTHER.label} $it")) },
                         singleLine = true,
                         error = state.intakeErrors.collectionMethod
                     )
                 }
 
                 val isOtherSpecimenCondition =
-                    state.session.specimenCondition.startsWith("Other:", ignoreCase = true)
+                    state.session.specimenCondition.startsWith(IntakeDropdownOptions.SpecimenConditionOption.OTHER.label, ignoreCase = true)
 
                 DropdownField(
                     label = "Specimen Condition",
@@ -148,13 +140,7 @@ fun IntakeScreen(
                         IntakeDropdownOptions.SpecimenConditionOption.OTHER
                     else
                         IntakeDropdownOptions.SpecimenConditionOption.entries.firstOrNull { it.label == state.session.specimenCondition },
-                    onOptionSelected = { opt ->
-                        if (opt == IntakeDropdownOptions.SpecimenConditionOption.OTHER) {
-                            onAction(IntakeAction.UpdateSpecimenCondition("Other: "))
-                        } else {
-                            onAction(IntakeAction.UpdateSpecimenCondition(opt.label))
-                        }
-                    },
+                    onOptionSelected = { onAction(IntakeAction.UpdateSpecimenCondition(it.label)) },
                     error = state.intakeErrors.specimenCondition,
                     modifier = Modifier.fillMaxWidth()
                 ) { specimenCondition ->
@@ -168,10 +154,8 @@ fun IntakeScreen(
                 if (isOtherSpecimenCondition) {
                     TextEntryField(
                         label = "Other Specimen Condition",
-                        value = state.session.specimenCondition.removePrefix("Other: ").trimStart(),
-                        onValueChange = { typed ->
-                            onAction(IntakeAction.UpdateSpecimenCondition("Other: $typed"))
-                        },
+                        value = state.session.specimenCondition.removePrefix(IntakeDropdownOptions.SpecimenConditionOption.OTHER.label).trimStart(),
+                        onValueChange = { onAction(IntakeAction.UpdateSpecimenCondition("${IntakeDropdownOptions.SpecimenConditionOption.OTHER.label} $it")) },
                         singleLine = true,
                         error = state.intakeErrors.specimenCondition
                     )

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -1,6 +1,5 @@
 package com.vci.vectorcamapp.intake.presentation
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.data.room.TransactionHelper
@@ -334,7 +333,8 @@ class IntakeViewModel @Inject constructor(
                 is IntakeAction.UpdateCollectionMethod -> {
                     _state.update {
                         it.copy(
-                            session = it.session.copy(collectionMethod = action.collectionMethod
+                            session = it.session.copy(
+                                collectionMethod = action.collectionMethod
                             )
                         )
                     }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.intake.presentation
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.data.room.TransactionHelper
@@ -330,21 +331,20 @@ class IntakeViewModel @Inject constructor(
                     }
                 }
 
-                is IntakeAction.SelectCollectionMethod -> {
+                is IntakeAction.UpdateCollectionMethod -> {
                     _state.update {
                         it.copy(
-                            session = it.session.copy(
-                                collectionMethod = action.option.label
+                            session = it.session.copy(collectionMethod = action.collectionMethod
                             )
                         )
                     }
                 }
 
-                is IntakeAction.SelectSpecimenCondition -> {
+                is IntakeAction.UpdateSpecimenCondition -> {
                     _state.update {
                         it.copy(
                             session = it.session.copy(
-                                specimenCondition = action.option.label
+                                specimenCondition = action.specimenCondition
                             )
                         )
                     }


### PR DESCRIPTION
This PR implements a simple, consistent “Other” workflow for Collection Method and Specimen Condition on the Intake screen. When the user selects Other from either dropdown, a contextual text field appears (“Other Collection Method” / “Other Specimen Condition”), and anything typed is stored back into the same session.collectionMethod / session.specimenCondition fields prefixed as Other <text>—no extra flags, state, or schema changes. The dropdowns now treat any value starting with Other as the Other option for proper selection display, while the ViewModel updates keep the value as a plain string (prefix included). Validation was tightened for specimen condition so that Other requires a non-blank detail, reusing the existing blank error to keep changes minimal. Net effect: cleaner UX, minimal code surface, and fully backward-compatible state handling.