### PR TITLE
SOF-328: Image upload edge case fix - Image marked as uploaded while backend receives no data

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -177,7 +177,7 @@ class ImageUploadWorker @AssistedInject constructor(
     ): DomainResult<String, NetworkError> {
         var tempFile: File? = null
         val (file, contentType, md5) = try {
-            val (prepared, type) = prepareFile(task.image.imageUri, task.specimen.id)
+            val (prepared, type) = prepareFile(task.image.imageUri, task.specimen.id, imageId = task.image.localId)
             tempFile = prepared
             Triple(prepared, type, task.image.localId)
         } catch (e: Exception) {
@@ -356,7 +356,7 @@ class ImageUploadWorker @AssistedInject constructor(
 
             val chunkResult = try {
                 DomainResult.Success(uploader.uploadChunk())
-            } catch (e: SocketTimeoutException) {
+            } catch (_: SocketTimeoutException) {
                 DomainResult.Error(NetworkError.TUS_TRANSIENT_ERROR)
             } catch (e: TusProtocolException) {
                 if (e.shouldRetry()) {
@@ -364,7 +364,7 @@ class ImageUploadWorker @AssistedInject constructor(
                 } else {
                     DomainResult.Error(NetworkError.TUS_PERMANENT_ERROR)
                 }
-            } catch (e: IOException) {
+            } catch (_: IOException) {
                 DomainResult.Error(NetworkError.TUS_TRANSIENT_ERROR)
             } catch (e: Exception) {
                 if (isStopped) {
@@ -459,7 +459,8 @@ class ImageUploadWorker @AssistedInject constructor(
 
     private suspend fun prepareFile(
         source: Uri,
-        specimenId: String
+        specimenId: String,
+        imageId: String
     ): Pair<File, String> =
         withContext(Dispatchers.IO) {
             val resolver = context.contentResolver
@@ -469,7 +470,7 @@ class ImageUploadWorker @AssistedInject constructor(
                 "image/png" -> "png"
                 else -> "bin"
             }
-            val filename = "upload_specimen_$specimenId.$extension"
+            val filename = "upload_${specimenId}_${imageId}.$extension"
             val destination = File(context.cacheDir, filename)
             if (!destination.exists()) {
                 resolver.openInputStream(source)?.use { input ->

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/image/ImageUploadWorker.kt
@@ -177,7 +177,7 @@ class ImageUploadWorker @AssistedInject constructor(
     ): DomainResult<String, NetworkError> {
         var tempFile: File? = null
         val (file, contentType, md5) = try {
-            val (prepared, type) = prepareFile(task.image.imageUri, task.specimen.id, imageId = task.image.localId)
+            val (prepared, type) = prepareFile(task.image.imageUri, task.specimen.id, task.image.localId)
             tempFile = prepared
             Triple(prepared, type, task.image.localId)
         } catch (e: Exception) {


### PR DESCRIPTION
This PR implements a fix for a very specific scenerio where the upload fails to reach the backend while being marked as complete locally.

In prepareFile, we name the temp file we create as val filename = "upload_specimen_$specimenId.$extension". This will cause collisions if we are trying to upload multiple images under a single specimen, since they will have the same file name. This would normally not be an issue since we delete the temp file across uploads anyways, but if the temp file deletion doesn't happen correctly (e.g. could be because of app terminations, worker terminations etc.), it will cause an issue. Currently, since we will skip the file creation if a file with that name already exists (and use the existing file instead), if the temp file (for the previous image) is not deleted, we will be trying to upload that file with the current image's details, so all info will be correct EXCEPT for the MD5 (well and the image itself but that doesn't matter since we don't go past upload creation), which causes a 409 error, which then we will mark the upload job as completed. This causes the backend to never receive the image and the local side to mark it as completed.

To fix the issue, we will add the image local id to the filename, so val filename = "upload_${specimenId}_${imageId}.$extension". This will resolve the file name duplication issue.