### PR TITLE
SOF-327: Ensure that the correct date is displayed on completed session specimens (capturedAt)

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
@@ -62,7 +62,6 @@ fun CompleteSessionDetailsScreen(
                 )
 
                 CompleteSessionDetailsTab.SESSION_SPECIMENS -> CompleteSessionSpecimens(
-                    session = state.session,
                     specimensWithImagesAndInferenceResults = state.specimensWithImagesAndInferenceResults,
                     searchQuery = state.searchQuery,
                     onUpdateSearchQuery = { searchQuery ->

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -27,7 +27,6 @@ import com.vci.vectorcamapp.ui.theme.screenWidthFraction
 
 @Composable
 fun CompleteSessionSpecimens(
-    session: Session,
     specimensWithImagesAndInferenceResults: List<SpecimenWithSpecimenImagesAndInferenceResults>,
     searchQuery: String,
     onUpdateSearchQuery: (String) -> Unit,
@@ -82,7 +81,6 @@ fun CompleteSessionSpecimens(
                         val totalImages = imageList.size
                         imageList.mapIndexed { index, (specimenImage, _) ->
                             CompleteSessionSpecimensTile(
-                                session = session,
                                 specimen = specimen,
                                 specimenImage = specimenImage,
                                 badgeText = "${index + 1} of $totalImages",

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimensTile.kt
@@ -49,7 +49,6 @@ import com.vci.vectorcamapp.ui.extensions.zoomPanGesture
 
 @Composable
 fun CompleteSessionSpecimensTile(
-    session: Session,
     specimen: Specimen,
     specimenImage: SpecimenImage,
     modifier: Modifier = Modifier,
@@ -57,7 +56,7 @@ fun CompleteSessionSpecimensTile(
 ) {
 
     val context = LocalContext.current
-    var density = LocalDensity.current
+    val density = LocalDensity.current
     val dateTimeFormatter =
         remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
 
@@ -166,7 +165,7 @@ fun CompleteSessionSpecimensTile(
             )
 
             Text(
-                text = "Captured At: ${dateTimeFormatter.format(session.createdAt)}",
+                text = "Captured On: ${dateTimeFormatter.format(specimenImage.capturedAt)}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colors.textPrimary
             )


### PR DESCRIPTION
This PR involves a very simple fix to the CompleteSessionSpecimens tab, where the timestamp for specimen image capture was incorrect. It has been corrected to reflect the timestamp when the image was actually captured, not when the session was created.