### PR TITLE
SOF-329: Add 1000 character text limit for session notes

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
@@ -17,8 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import com.vci.vectorcamapp.core.domain.util.Error
 import com.vci.vectorcamapp.core.presentation.util.error.toString
 import com.vci.vectorcamapp.ui.extensions.colors
@@ -31,7 +29,6 @@ fun TextEntryField(
     modifier: Modifier = Modifier,
     label: String? = null,
     singleLine: Boolean = false,
-    keyboardType: KeyboardType = KeyboardType.Text,
     error: Error? = null,
     placeholder: String? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -67,6 +64,7 @@ fun TextEntryField(
                     )
                 }
             },
+            maxLines = 8,
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = MaterialTheme.colors.transparent,
                 unfocusedBorderColor = MaterialTheme.colors.transparent,

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.presentation.components.button.ActionButton
@@ -218,7 +217,6 @@ fun IntakeScreen(
                         onValueChange = { onAction(IntakeAction.EnterNumPeopleSleptInHouse(it.filter { character -> character.isDigit() })) },
                         placeholder = "0",
                         singleLine = true,
-                        keyboardType = KeyboardType.Number,
                     )
                 }
 
@@ -312,7 +310,6 @@ fun IntakeScreen(
                             },
                             placeholder = "0",
                             singleLine = true,
-                            keyboardType = KeyboardType.Number,
                         )
                     }
 
@@ -322,7 +319,6 @@ fun IntakeScreen(
                         onValueChange = { onAction(IntakeAction.EnterNumLlinsAvailable(it.filter { character -> character.isDigit() })) },
                         placeholder = "0",
                         singleLine = true,
-                        keyboardType = KeyboardType.Number
                     )
 
                     surveillanceForm.llinType?.let { current ->
@@ -370,7 +366,6 @@ fun IntakeScreen(
                             },
                             placeholder = "0",
                             singleLine = true,
-                            keyboardType = KeyboardType.Number
                         )
                     }
                 }
@@ -386,7 +381,9 @@ fun IntakeScreen(
                 TextEntryField(
                     label = "Notes",
                     value = state.session.notes,
-                    onValueChange = { onAction(IntakeAction.EnterNotes(it)) })
+                    onValueChange = { onAction(IntakeAction.EnterNotes(it)) },
+                    placeholder = "1000 character limit...",
+                )
             }
         }
 

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -351,12 +351,14 @@ class IntakeViewModel @Inject constructor(
                 }
 
                 is IntakeAction.EnterNotes -> {
-                    _state.update {
-                        it.copy(
-                            session = it.session.copy(
-                                notes = action.text
+                    if (action.text.length <= 1000) {
+                        _state.update {
+                            it.copy(
+                                session = it.session.copy(
+                                    notes = action.text
+                                )
                             )
-                        )
+                        }
                     }
                 }
 


### PR DESCRIPTION
This PR implements a very simple change involving the addition of a 1000 character limit to the session notes. No one can print the script of the bee movie into the session notes anymore (unless it is somehow compressed to < 1000 characters :) )