### PR TITLE
SOF-325: Add button to close exit session AlertDialog on ImagingScreen

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -198,108 +198,134 @@ fun ImagingScreen(
 
             else -> {
                 if (state.showExitDialog) {
-                    AlertDialog(onDismissRequest = {
-                        onAction(ImagingAction.DismissExitDialog)
-                    }, title = {
-                        Text(
-                            text = if (state.pendingAction == null) "Exit session?" else "Confirm Action",
-                            style = MaterialTheme.typography.headlineMedium,
-                            color = MaterialTheme.colors.textPrimary
-                        )
-                    }, text = {
-                        val dialogText = when (state.pendingAction) {
-                            null -> "Would you like to save this session for later or submit it now?"
-                            is ImagingAction.SaveSessionProgress -> "Are you sure you want to save the session and exit?"
-                            is ImagingAction.SubmitSession -> "Are you sure you want to submit the session?"
-                            else -> ""
-                        }
-                        Column {
-                            if (dialogText.isNotEmpty()) {
+                    AlertDialog(
+                        onDismissRequest = {
+                            onAction(ImagingAction.DismissExitDialog)
+                        },
+                        title = {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
                                 Text(
-                                    text = dialogText,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colors.textSecondary
+                                    text = if (state.pendingAction == null) "Exit session?" else "Confirm Action",
+                                    style = MaterialTheme.typography.headlineMedium,
+                                    color = MaterialTheme.colors.textPrimary,
+                                    modifier = Modifier.weight(1f)
                                 )
-                            }
 
-                            if (state.specimensWithImagesAndInferenceResults.isEmpty() && state.pendingAction is ImagingAction.SubmitSession) {
-                                Text(
-                                    text = "Warning: You are about to submit a session with zero specimens.",
-                                    style = MaterialTheme.typography.titleLarge,
-                                    color = MaterialTheme.colors.error,
-                                    modifier = Modifier.padding(top = MaterialTheme.dimensions.paddingMedium)
-                                )
-                            }
-                        }
-                    }, confirmButton = {
-                        if (state.pendingAction == null) {
-                            OutlinedButton(
-                                onClick = { onAction(ImagingAction.SelectPendingAction(ImagingAction.SubmitSession)) },
-                                border = BorderStroke(
-                                    MaterialTheme.dimensions.borderThicknessThick,
-                                    MaterialTheme.colors.successConfirm
-                                )
-                            ) {
-                                Icon(
-                                    painter = painterResource(id = R.drawable.ic_cloud_upload),
-                                    contentDescription = "Submit Icon",
-                                    tint = MaterialTheme.colors.successConfirm,
+                                IconButton(
+                                    onClick = { onAction(ImagingAction.DismissExitDialog) },
                                     modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
-                                )
-                                Spacer(Modifier.size(MaterialTheme.dimensions.paddingSmall))
-                                Text(
-                                    text = "Submit",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colors.successConfirm
-                                )
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_close),
+                                        contentDescription = "Close dialog",
+                                        tint = MaterialTheme.colors.icon,
+                                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeLarge)
+                                    )
+                                }
                             }
-                        } else {
-                            Button(
-                                onClick = {
-                                    onAction(ImagingAction.ConfirmPendingAction)
-                                }, colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colors.error
-                                )
-                            ) {
-                                Text(
-                                    text = "Yes, Confirm",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colors.buttonText
-                                )
+                        },
+                        text = {
+                            val dialogText = when (state.pendingAction) {
+                                null -> "Would you like to save this session for later or submit it now?"
+                                is ImagingAction.SaveSessionProgress -> "Are you sure you want to save the session and exit?"
+                                is ImagingAction.SubmitSession -> "Are you sure you want to submit the session?"
+                                else -> ""
+                            }
+                            Column {
+                                if (dialogText.isNotEmpty()) {
+                                    Text(
+                                        text = dialogText,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.textSecondary
+                                    )
+                                }
+
+                                if (state.specimensWithImagesAndInferenceResults.isEmpty() && state.pendingAction is ImagingAction.SubmitSession) {
+                                    Text(
+                                        text = "Warning: You are about to submit a session with zero specimens.",
+                                        style = MaterialTheme.typography.titleLarge,
+                                        color = MaterialTheme.colors.error,
+                                        modifier = Modifier.padding(top = MaterialTheme.dimensions.paddingMedium)
+                                    )
+                                }
+                            }
+                        },
+                        confirmButton = {
+                            if (state.pendingAction == null) {
+                                OutlinedButton(
+                                    onClick = { onAction(ImagingAction.SelectPendingAction(ImagingAction.SubmitSession)) },
+                                    border = BorderStroke(
+                                        MaterialTheme.dimensions.borderThicknessThick,
+                                        MaterialTheme.colors.successConfirm
+                                    )
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_cloud_upload),
+                                        contentDescription = "Submit Icon",
+                                        tint = MaterialTheme.colors.successConfirm,
+                                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+                                    )
+                                    Spacer(Modifier.size(MaterialTheme.dimensions.paddingSmall))
+                                    Text(
+                                        text = "Submit",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.successConfirm
+                                    )
+                                }
+                            } else {
+                                Button(
+                                    onClick = {
+                                        onAction(ImagingAction.ConfirmPendingAction)
+                                    },
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colors.error
+                                    )
+                                ) {
+                                    Text(
+                                        text = "Yes, Confirm",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.buttonText
+                                    )
+                                }
+                            }
+                        },
+                        dismissButton = {
+                            if (state.pendingAction == null) {
+                                OutlinedButton(
+                                    onClick = { onAction(ImagingAction.SelectPendingAction(ImagingAction.SaveSessionProgress)) },
+                                    border = BorderStroke(
+                                        MaterialTheme.dimensions.borderThicknessThick,
+                                        MaterialTheme.colors.info
+                                    )
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_save),
+                                        contentDescription = "Save Icon",
+                                        tint = MaterialTheme.colors.info,
+                                        modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+                                    )
+                                    Spacer(Modifier.size(MaterialTheme.dimensions.paddingSmall))
+                                    Text(
+                                        "Save",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.info
+                                    )
+                                }
+                            } else {
+                                TextButton(onClick = { onAction(ImagingAction.ClearPendingAction) }) {
+                                    Text(
+                                        "Back",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colors.textPrimary
+                                    )
+                                }
                             }
                         }
-                    }, dismissButton = {
-                        if (state.pendingAction == null) {
-                            OutlinedButton(
-                                onClick = { onAction(ImagingAction.SelectPendingAction(ImagingAction.SaveSessionProgress)) },
-                                border = BorderStroke(
-                                    MaterialTheme.dimensions.borderThicknessThick,
-                                    MaterialTheme.colors.info
-                                )
-                            ) {
-                                Icon(
-                                    painter = painterResource(id = R.drawable.ic_save),
-                                    contentDescription = "Save Icon",
-                                    tint = MaterialTheme.colors.info,
-                                    modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
-                                )
-                                Spacer(Modifier.size(MaterialTheme.dimensions.paddingSmall))
-                                Text(
-                                    "Save",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colors.info
-                                )
-                            }
-                        } else {
-                            TextButton(onClick = { onAction(ImagingAction.ClearPendingAction) }) {
-                                Text(
-                                    "Back",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colors.textPrimary
-                                )
-                            }
-                        }
-                    })
+                    )
                 }
 
                 Column(

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -6,7 +6,7 @@
   <path
       android:pathData="M25,1L1,25M1,1L25,25"
       android:strokeLineJoin="round"
-      android:strokeWidth="3"
+      android:strokeWidth="3.5"
       android:fillColor="#00000000"
       android:strokeColor="#1E1E1E"
       android:strokeLineCap="round"/>

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="26dp"
+    android:height="26dp"
+    android:viewportWidth="26"
+    android:viewportHeight="26">
+  <path
+      android:pathData="M25,1L1,25M1,1L25,25"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
This pull request adds a small 'X' icon button to the top right corner of the exit session `AlertDialog`, allowing users to dismiss the `AlertDialog` by tapping the 'X' icon button. This improves the UX, as users may not be aware that they can dismiss the `AlertDialog` by tapping on other parts of the screen.