### PR TITLE
SOF-376: Use .displayText() to show session type in IncompleteSessionCard

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -17,12 +17,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.domain.model.composites.SessionAndSite
 import com.vci.vectorcamapp.core.presentation.components.gestures.SwipeToReveal
 import com.vci.vectorcamapp.core.presentation.components.pill.InfoPill
 import com.vci.vectorcamapp.core.presentation.components.tile.ActionTile
+import com.vci.vectorcamapp.core.presentation.extensions.displayText
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 import java.text.SimpleDateFormat
@@ -35,6 +37,8 @@ fun IncompleteSessionCard(
     onDelete: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+
     val titleFormatter = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
     val detailFormatter = remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
 
@@ -85,7 +89,7 @@ fun IncompleteSessionCard(
                         }
                     }
 
-                    InfoPill(text = "Session Type: ${sessionAndSite.session.type}", color = MaterialTheme.colors.info)
+                    InfoPill(text = "Session Type: ${sessionAndSite.session.type.displayText(context)}", color = MaterialTheme.colors.info)
                 }
 
                 Column(


### PR DESCRIPTION
This pull request updates the UI of the IncompleteSessionCard such that the session type in the info pill of an `IncompleteSessionCard` is displayed using `.displayText(context)`. This ensures UI consistency across the info pills that display the session type. The code was tested on a Samsung A15.