### PR TITLE
SOF-352: Give CompleteSessionListTile a background hue based on progress

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
 import com.vci.vectorcamapp.R
 import com.vci.vectorcamapp.core.domain.model.composites.SessionAndSite
 import com.vci.vectorcamapp.core.domain.model.helpers.SessionUploadProgress
@@ -54,6 +55,9 @@ fun CompleteSessionListTile(
     val UPLOAD_ICON_MIN_ALPHA = 0.3f
     val UPLOAD_ICON_MAX_ALPHA = 1f
 
+    val STRONG_SHADOW_ALPHA = 0.4f
+    val WEAK_SHADOW_ALPHA = 0.25f
+
     val session = sessionAndSite.session
     val site = sessionAndSite.site
     val dateFormatter = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
@@ -68,7 +72,11 @@ fun CompleteSessionListTile(
     session.completedAt?.let { completedAt ->
         ActionTile(
             onClick = onClick,
-            cardGlow = progressColor,
+            shadowColor = if (progressColor == MaterialTheme.colors.primary) progressColor.copy(alpha=STRONG_SHADOW_ALPHA) else progressColor.copy(alpha=WEAK_SHADOW_ALPHA),
+            shadowOffsetX = 0.dp,
+            shadowOffsetY = 0.dp,
+            shadowSpread = MaterialTheme.dimensions.shadowOffsetSmall,
+            shadowBlurRadius = MaterialTheme.dimensions.shadowBlurMedium,
             modifier = modifier,
         ) {
             Column(

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -38,6 +38,7 @@ import com.vci.vectorcamapp.core.presentation.components.pill.InfoPill
 import com.vci.vectorcamapp.core.presentation.components.tile.ActionTile
 import com.vci.vectorcamapp.core.presentation.extensions.displayText
 import com.vci.vectorcamapp.ui.extensions.colors
+import com.vci.vectorcamapp.ui.extensions.customShadow
 import com.vci.vectorcamapp.ui.extensions.dimensions
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -55,9 +56,6 @@ fun CompleteSessionListTile(
     val UPLOAD_ICON_MIN_ALPHA = 0.3f
     val UPLOAD_ICON_MAX_ALPHA = 1f
 
-    val STRONG_SHADOW_ALPHA = 0.4f
-    val WEAK_SHADOW_ALPHA = 0.25f
-
     val session = sessionAndSite.session
     val site = sessionAndSite.site
     val dateFormatter = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
@@ -65,19 +63,14 @@ fun CompleteSessionListTile(
         remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
 
     val progressColor =
-        if (sessionUploadProgress.totalImageCount == 0 || (sessionUploadProgress.uploadedImageCount.toFloat() / sessionUploadProgress.totalImageCount.toFloat()) == 1f) MaterialTheme.colors.primary
+        if (sessionUploadProgress.totalImageCount == 0 || sessionUploadProgress.uploadedImageCount == sessionUploadProgress.totalImageCount) MaterialTheme.colors.primary
         else if (sessionUploadProgress.isUploading) MaterialTheme.colors.warning
         else MaterialTheme.colors.error
 
     session.completedAt?.let { completedAt ->
         ActionTile(
             onClick = onClick,
-            shadowColor = if (progressColor == MaterialTheme.colors.primary) progressColor.copy(alpha=STRONG_SHADOW_ALPHA) else progressColor.copy(alpha=WEAK_SHADOW_ALPHA),
-            shadowOffsetX = 0.dp,
-            shadowOffsetY = 0.dp,
-            shadowSpread = MaterialTheme.dimensions.shadowOffsetSmall,
-            shadowBlurRadius = MaterialTheme.dimensions.shadowBlurMedium,
-            modifier = modifier,
+            hue = progressColor.copy(0.3f),
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium),

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -70,7 +70,7 @@ fun CompleteSessionListTile(
     session.completedAt?.let { completedAt ->
         ActionTile(
             onClick = onClick,
-            hue = progressColor.copy(0.3f),
+            hue = progressColor,
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium),

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -60,9 +60,15 @@ fun CompleteSessionListTile(
     val dateTimeFormatter =
         remember { SimpleDateFormat("MMM dd, yyyy 'at' h:mm a", Locale.getDefault()) }
 
+    val progressColor =
+        if (sessionUploadProgress.totalImageCount == 0 || (sessionUploadProgress.uploadedImageCount.toFloat() / sessionUploadProgress.totalImageCount.toFloat()) == 1f) MaterialTheme.colors.primary
+        else if (sessionUploadProgress.isUploading) MaterialTheme.colors.warning
+        else MaterialTheme.colors.error
+
     session.completedAt?.let { completedAt ->
         ActionTile(
             onClick = onClick,
+            cardGlow = progressColor,
             modifier = modifier,
         ) {
             Column(
@@ -232,12 +238,7 @@ fun CompleteSessionListTile(
                                     else sessionUploadProgress.uploadedImageCount.toFloat() / sessionUploadProgress.totalImageCount.toFloat()
                                 )
                                 .height(MaterialTheme.dimensions.componentHeightExtraExtraExtraSmall)
-                                .background(
-                                    if (sessionUploadProgress.totalImageCount == 0 || (sessionUploadProgress.uploadedImageCount.toFloat() / sessionUploadProgress.totalImageCount.toFloat()) == 1f) MaterialTheme.colors.primary
-                                    else if (sessionUploadProgress.isUploading) MaterialTheme.colors.warning
-                                    else MaterialTheme.colors.error,
-                                    RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusSmall)
-                                )
+                                .background(progressColor, RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusSmall))
                         )
                     }
                 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
@@ -18,12 +18,7 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 fun ActionTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    shadowColor: Color = MaterialTheme.colors.cardGlow.copy(alpha = 0.2f),
-    shadowOffsetX: Dp = MaterialTheme.dimensions.shadowOffsetSmall,
-    shadowOffsetY: Dp  = MaterialTheme.dimensions.shadowOffsetSmall,
-    shadowCornerRadius: Dp  = MaterialTheme.dimensions.cornerRadiusMedium,
-    shadowSpread: Dp  = MaterialTheme.dimensions.shadowSpreadSmall,
-    shadowBlurRadius: Dp  = MaterialTheme.dimensions.shadowBlurSmall,
+    hue: Color = MaterialTheme.colors.cardGlow.copy(alpha = 0.2f),
     content: @Composable () -> Unit
 ) {
     Card(
@@ -37,12 +32,12 @@ fun ActionTile(
                 vertical = MaterialTheme.dimensions.paddingSmall
             )
             .customShadow(
-                color = shadowColor,
-                offsetX = shadowOffsetX,
-                offsetY = shadowOffsetY,
-                cornerRadius = shadowCornerRadius,
-                spread = shadowSpread,
-                blurRadius = shadowBlurRadius,
+                color = hue,
+                offsetX = MaterialTheme.dimensions.shadowOffsetSmall,
+                offsetY = MaterialTheme.dimensions.shadowOffsetSmall,
+                cornerRadius = MaterialTheme.dimensions.cornerRadiusMedium,
+                spread = MaterialTheme.dimensions.shadowSpreadSmall,
+                blurRadius = MaterialTheme.dimensions.shadowBlurSmall,
             )
             .fillMaxWidth()
     ) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.customShadow
 import com.vci.vectorcamapp.ui.extensions.dimensions
@@ -18,7 +17,7 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 fun ActionTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    hue: Color = MaterialTheme.colors.cardGlow.copy(alpha = 0.2f),
+    hue: Color = MaterialTheme.colors.cardGlow,
     content: @Composable () -> Unit
 ) {
     Card(
@@ -32,7 +31,7 @@ fun ActionTile(
                 vertical = MaterialTheme.dimensions.paddingSmall
             )
             .customShadow(
-                color = hue,
+                color = hue.copy(alpha = 0.25f),
                 offsetX = MaterialTheme.dimensions.shadowOffsetSmall,
                 offsetY = MaterialTheme.dimensions.shadowOffsetSmall,
                 cornerRadius = MaterialTheme.dimensions.cornerRadiusMedium,

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.customShadow
 import com.vci.vectorcamapp.ui.extensions.dimensions
@@ -17,7 +18,12 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 fun ActionTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    cardGlow: Color = MaterialTheme.colors.cardGlow,
+    shadowColor: Color = MaterialTheme.colors.cardGlow.copy(alpha = 0.2f),
+    shadowOffsetX: Dp = MaterialTheme.dimensions.shadowOffsetSmall,
+    shadowOffsetY: Dp  = MaterialTheme.dimensions.shadowOffsetSmall,
+    shadowCornerRadius: Dp  = MaterialTheme.dimensions.cornerRadiusMedium,
+    shadowSpread: Dp  = MaterialTheme.dimensions.shadowSpreadSmall,
+    shadowBlurRadius: Dp  = MaterialTheme.dimensions.shadowBlurSmall,
     content: @Composable () -> Unit
 ) {
     Card(
@@ -31,12 +37,12 @@ fun ActionTile(
                 vertical = MaterialTheme.dimensions.paddingSmall
             )
             .customShadow(
-                color = cardGlow.copy(alpha = 0.2f),
-                offsetX = MaterialTheme.dimensions.shadowOffsetSmall,
-                offsetY = MaterialTheme.dimensions.shadowOffsetSmall,
-                cornerRadius = MaterialTheme.dimensions.cornerRadiusMedium,
-                spread = MaterialTheme.dimensions.shadowSpreadSmall,
-                blurRadius = MaterialTheme.dimensions.shadowBlurSmall,
+                color = shadowColor,
+                offsetX = shadowOffsetX,
+                offsetY = shadowOffsetY,
+                cornerRadius = shadowCornerRadius,
+                spread = shadowSpread,
+                blurRadius = shadowBlurRadius,
             )
             .fillMaxWidth()
     ) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/ActionTile.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.customShadow
 import com.vci.vectorcamapp.ui.extensions.dimensions
@@ -16,6 +17,7 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 fun ActionTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    cardGlow: Color = MaterialTheme.colors.cardGlow,
     content: @Composable () -> Unit
 ) {
     Card(
@@ -29,7 +31,7 @@ fun ActionTile(
                 vertical = MaterialTheme.dimensions.paddingSmall
             )
             .customShadow(
-                color = MaterialTheme.colors.cardGlow.copy(alpha = 0.2f),
+                color = cardGlow.copy(alpha = 0.2f),
                 offsetX = MaterialTheme.dimensions.shadowOffsetSmall,
                 offsetY = MaterialTheme.dimensions.shadowOffsetSmall,
                 cornerRadius = MaterialTheme.dimensions.cornerRadiusMedium,

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/InfoTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tile/InfoTile.kt
@@ -8,13 +8,17 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.customShadow
 import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
-fun InfoTile(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
-
+fun InfoTile(
+    modifier: Modifier = Modifier,
+    hue: Color = MaterialTheme.colors.cardGlow,
+    content: @Composable () -> Unit
+) {
     Card(
         border = CardDefaults.outlinedCardBorder(),
         shape = RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusMedium),
@@ -25,7 +29,7 @@ fun InfoTile(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
                 vertical = MaterialTheme.dimensions.paddingSmall
             )
             .customShadow(
-                color = MaterialTheme.colors.cardGlow.copy(alpha = 0.2f),
+                color = hue.copy(alpha = 0.25f),
                 offsetX = MaterialTheme.dimensions.shadowOffsetSmall,
                 offsetY = MaterialTheme.dimensions.shadowOffsetSmall,
                 cornerRadius = MaterialTheme.dimensions.cornerRadiusMedium,


### PR DESCRIPTION
This pull request gives the `CompleteSessionListTile` a background hue that matches the progress bar. Since the `customShadow` of the `ActionTile` previously had a fixed shadow offset, shadow color, and shadow blur, the `CompleteSessionListTile` and the `ActionTile` had to be updated to allow for such customizations.  

The code request was tested on the Samsung A15.