### PR TITLE
SOF-356: Add tooltip and tooltip component for search and filter bars to explain comma and spaces

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsAction.kt
@@ -6,4 +6,6 @@ sealed interface CompleteSessionDetailsAction {
     data object ReturnToCompleteSessionListScreen : CompleteSessionDetailsAction
     data class ChangeSelectedTab(val selectedTab: CompleteSessionDetailsTab) : CompleteSessionDetailsAction
     data class UpdateSearchQuery(val searchQuery: String) : CompleteSessionDetailsAction
+    data object ShowSearchTooltipDialog : CompleteSessionDetailsAction
+    data object HideSearchTooltipDialog : CompleteSessionDetailsAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
@@ -69,7 +69,8 @@ fun CompleteSessionDetailsScreen(
                     },
                     modifier = modifier,
                     isSearchTooltipVisible = state.isSearchTooltipVisible,
-                    onAction = onAction
+                    onShowSearchTooltip = { onAction(CompleteSessionDetailsAction.ShowSearchTooltipDialog) },
+                    onDismissSearchTooltip = { onAction(CompleteSessionDetailsAction.HideSearchTooltipDialog) }
                 )
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsScreen.kt
@@ -67,7 +67,9 @@ fun CompleteSessionDetailsScreen(
                     onUpdateSearchQuery = { searchQuery ->
                         onAction(CompleteSessionDetailsAction.UpdateSearchQuery(searchQuery))
                     },
-                    modifier = modifier
+                    modifier = modifier,
+                    isSearchTooltipVisible = state.isSearchTooltipVisible,
+                    onAction = onAction
                 )
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
@@ -38,5 +38,6 @@ data class CompleteSessionDetailsState(
     ),
     val surveillanceForm: SurveillanceForm? = null,
     val specimensWithImagesAndInferenceResults: List<SpecimenWithSpecimenImagesAndInferenceResults> = emptyList(),
-    val searchQuery: String = ""
+    val searchQuery: String = "",
+    val isSearchTooltipVisible: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
@@ -85,6 +85,12 @@ class CompleteSessionDetailsViewModel @Inject constructor(
                 is CompleteSessionDetailsAction.UpdateSearchQuery -> {
                     _state.update { it.copy(searchQuery = action.searchQuery) }
                 }
+                CompleteSessionDetailsAction.ShowSearchTooltipDialog -> {
+                    _state.update { it.copy(isSearchTooltipVisible = true) }
+                }
+                CompleteSessionDetailsAction.HideSearchTooltipDialog -> {
+                    _state.update { it.copy(isSearchTooltipVisible = false) }
+                }
             }
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -52,6 +52,7 @@ fun CompleteSessionSpecimens(
                 modifier = Modifier.padding(
                     start = MaterialTheme.dimensions.spacingMedium,
                     end = MaterialTheme.dimensions.spacingMedium,
+                    top = MaterialTheme.dimensions.spacingSmall,
                     bottom = MaterialTheme.dimensions.spacingSmall
                 ),
                 isTooltipVisible = isSearchTooltipVisible,

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -54,6 +54,7 @@ fun CompleteSessionSpecimens(
                     end = MaterialTheme.dimensions.spacingMedium,
                     bottom = MaterialTheme.dimensions.spacingSmall
                 ),
+                isTooltipVisible = isSearchTooltipVisible,
                 onTooltipShow = { onAction(CompleteSessionDetailsAction.ShowSearchTooltipDialog) },
                 onTooltipDismiss = { onAction(CompleteSessionDetailsAction.HideSearchTooltipDialog) },
                 tooltipButtonText = "Tap to learn more about search and filter logic"

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -50,8 +50,9 @@ fun CompleteSessionSpecimens(
                 },
                 placeholder = "Search by specimen ID, species, etc.",
                 modifier = Modifier.padding(
-                    horizontal = MaterialTheme.dimensions.spacingMedium,
-                    vertical = MaterialTheme.dimensions.spacingSmall
+                    start = MaterialTheme.dimensions.spacingMedium,
+                    end = MaterialTheme.dimensions.spacingMedium,
+                    top = MaterialTheme.dimensions.spacingSmall
                 ),
                 isTooltipVisible = isSearchTooltipVisible,
                 onShowSearchTooltip = { onShowSearchTooltip },

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsAction
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
 import com.vci.vectorcamapp.core.presentation.search.SearchHelpTooltipContent
 import com.vci.vectorcamapp.core.presentation.search.SearchTextField
@@ -27,7 +26,8 @@ fun CompleteSessionSpecimens(
     searchQuery: String,
     onUpdateSearchQuery: (String) -> Unit,
     isSearchTooltipVisible: Boolean,
-    onAction: (CompleteSessionDetailsAction) -> Unit,
+    onShowSearchTooltip: () -> Unit,
+    onDismissSearchTooltip: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     if (specimensWithImagesAndInferenceResults.isEmpty() && searchQuery.isBlank()) {
@@ -50,15 +50,12 @@ fun CompleteSessionSpecimens(
                 },
                 placeholder = "Search by specimen ID, species, etc.",
                 modifier = Modifier.padding(
-                    start = MaterialTheme.dimensions.spacingMedium,
-                    end = MaterialTheme.dimensions.spacingMedium,
-                    top = MaterialTheme.dimensions.spacingSmall,
-                    bottom = MaterialTheme.dimensions.spacingSmall
+                    horizontal = MaterialTheme.dimensions.spacingMedium,
+                    vertical = MaterialTheme.dimensions.spacingSmall
                 ),
                 isTooltipVisible = isSearchTooltipVisible,
-                onTooltipShow = { onAction(CompleteSessionDetailsAction.ShowSearchTooltipDialog) },
-                onTooltipDismiss = { onAction(CompleteSessionDetailsAction.HideSearchTooltipDialog) },
-                tooltipButtonText = "Tap to learn more about search and filter logic"
+                onShowSearchTooltip = { onShowSearchTooltip },
+                onDismissSearchTooltip = { onDismissSearchTooltip }
             ) {
                 SearchHelpTooltipContent()
             }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -13,7 +13,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsAction
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
+import com.vci.vectorcamapp.core.presentation.search.SearchHelpTooltipContent
 import com.vci.vectorcamapp.core.presentation.search.SearchTextField
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
@@ -24,6 +26,8 @@ fun CompleteSessionSpecimens(
     specimensWithImagesAndInferenceResults: List<SpecimenWithSpecimenImagesAndInferenceResults>,
     searchQuery: String,
     onUpdateSearchQuery: (String) -> Unit,
+    isSearchTooltipVisible: Boolean,
+    onAction: (CompleteSessionDetailsAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
     if (specimensWithImagesAndInferenceResults.isEmpty() && searchQuery.isBlank()) {
@@ -45,8 +49,17 @@ fun CompleteSessionSpecimens(
                     onUpdateSearchQuery(newSearchQueryText)
                 },
                 placeholder = "Search by specimen ID, species, etc.",
-                modifier = Modifier.padding(horizontal = MaterialTheme.dimensions.spacingMedium)
-            )
+                modifier = Modifier.padding(
+                    start = MaterialTheme.dimensions.spacingMedium,
+                    end = MaterialTheme.dimensions.spacingMedium,
+                    bottom = MaterialTheme.dimensions.spacingSmall
+                ),
+                onTooltipPrimaryAction = { onAction(CompleteSessionDetailsAction.ShowSearchTooltipDialog) },
+                onTooltipDismiss = { onAction(CompleteSessionDetailsAction.HideSearchTooltipDialog) },
+                tooltipButtonText = "Tap to learn more about search and filter logic"
+            ) {
+                SearchHelpTooltipContent()
+            }
 
             if (specimensWithImagesAndInferenceResults.isEmpty()) {
                 Text(

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -54,7 +54,7 @@ fun CompleteSessionSpecimens(
                     end = MaterialTheme.dimensions.spacingMedium,
                     bottom = MaterialTheme.dimensions.spacingSmall
                 ),
-                onTooltipPrimaryAction = { onAction(CompleteSessionDetailsAction.ShowSearchTooltipDialog) },
+                onTooltipShow = { onAction(CompleteSessionDetailsAction.ShowSearchTooltipDialog) },
                 onTooltipDismiss = { onAction(CompleteSessionDetailsAction.HideSearchTooltipDialog) },
                 tooltipButtonText = "Tap to learn more about search and filter logic"
             ) {

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListAction.kt
@@ -7,4 +7,6 @@ sealed interface CompleteSessionListAction {
     data class ViewCompleteSessionDetails(val sessionId: UUID) : CompleteSessionListAction
     data object UploadAllPendingSessions : CompleteSessionListAction
     data class UpdateSearchQuery(val searchQuery: String) : CompleteSessionListAction
+    data object ShowSearchTooltipDialog : CompleteSessionListAction
+    data object HideSearchTooltipDialog : CompleteSessionListAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
@@ -82,6 +82,7 @@ fun CompleteSessionListScreen(
                     modifier = Modifier.padding(
                         start = MaterialTheme.dimensions.spacingMedium,
                         end = MaterialTheme.dimensions.spacingMedium,
+                        top = MaterialTheme.dimensions.spacingSmall,
                         bottom = MaterialTheme.dimensions.spacingSmall
                     ),
                     isTooltipVisible = state.isSearchTooltipVisible,

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
@@ -80,8 +80,9 @@ fun CompleteSessionListScreen(
                     },
                     placeholder = "Search by collector, district, session type, etc.",
                     modifier = Modifier.padding(
-                        horizontal = MaterialTheme.dimensions.spacingMedium,
-                        vertical = MaterialTheme.dimensions.spacingSmall
+                        start = MaterialTheme.dimensions.spacingMedium,
+                        end = MaterialTheme.dimensions.spacingMedium,
+                        top = MaterialTheme.dimensions.spacingSmall
                     ),
                     isTooltipVisible = state.isSearchTooltipVisible,
                     onShowSearchTooltip = { onAction(CompleteSessionListAction.ShowSearchTooltipDialog) },

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
@@ -80,15 +80,12 @@ fun CompleteSessionListScreen(
                     },
                     placeholder = "Search by collector, district, session type, etc.",
                     modifier = Modifier.padding(
-                        start = MaterialTheme.dimensions.spacingMedium,
-                        end = MaterialTheme.dimensions.spacingMedium,
-                        top = MaterialTheme.dimensions.spacingSmall,
-                        bottom = MaterialTheme.dimensions.spacingSmall
+                        horizontal = MaterialTheme.dimensions.spacingMedium,
+                        vertical = MaterialTheme.dimensions.spacingSmall
                     ),
                     isTooltipVisible = state.isSearchTooltipVisible,
-                    onTooltipShow = { onAction(CompleteSessionListAction.ShowSearchTooltipDialog) },
-                    onTooltipDismiss = { onAction(CompleteSessionListAction.HideSearchTooltipDialog) },
-                    tooltipButtonText = "Tap to learn more about search and filter logic"
+                    onShowSearchTooltip = { onAction(CompleteSessionListAction.ShowSearchTooltipDialog) },
+                    onDismissSearchTooltip = { onAction(CompleteSessionListAction.HideSearchTooltipDialog) }
                 ) {
                     SearchHelpTooltipContent()
                 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
@@ -31,7 +31,11 @@ import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.draw.rotate
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsAction
+import com.vci.vectorcamapp.core.presentation.search.SearchHelpTooltipContent
 
 @Composable
 fun CompleteSessionListScreen(
@@ -79,10 +83,16 @@ fun CompleteSessionListScreen(
                     },
                     placeholder = "Search by collector, district, session type, etc.",
                     modifier = Modifier.padding(
-                        start = MaterialTheme.dimensions.paddingMedium,
-                        end = MaterialTheme.dimensions.paddingMedium
-                    )
-                )
+                        start = MaterialTheme.dimensions.spacingMedium,
+                        end = MaterialTheme.dimensions.spacingMedium,
+                        bottom = MaterialTheme.dimensions.spacingSmall
+                    ),
+                    onTooltipPrimaryAction = { onAction(CompleteSessionListAction.ShowSearchTooltipDialog) },
+                    onTooltipDismiss = { onAction(CompleteSessionListAction.HideSearchTooltipDialog) },
+                    tooltipButtonText = "Tap to learn more about search and filter logic"
+                ) {
+                    SearchHelpTooltipContent()
+                }
             }
 
             if (state.sessionAndSiteToUploadProgress.isEmpty()) {

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
@@ -84,6 +84,7 @@ fun CompleteSessionListScreen(
                         end = MaterialTheme.dimensions.spacingMedium,
                         bottom = MaterialTheme.dimensions.spacingSmall
                     ),
+                    isTooltipVisible = state.isSearchTooltipVisible,
                     onTooltipShow = { onAction(CompleteSessionListAction.ShowSearchTooltipDialog) },
                     onTooltipDismiss = { onAction(CompleteSessionListAction.HideSearchTooltipDialog) },
                     tooltipButtonText = "Tap to learn more about search and filter logic"

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListScreen.kt
@@ -31,10 +31,7 @@ import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.draw.rotate
-import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsAction
 import com.vci.vectorcamapp.core.presentation.search.SearchHelpTooltipContent
 
 @Composable
@@ -87,7 +84,7 @@ fun CompleteSessionListScreen(
                         end = MaterialTheme.dimensions.spacingMedium,
                         bottom = MaterialTheme.dimensions.spacingSmall
                     ),
-                    onTooltipPrimaryAction = { onAction(CompleteSessionListAction.ShowSearchTooltipDialog) },
+                    onTooltipShow = { onAction(CompleteSessionListAction.ShowSearchTooltipDialog) },
                     onTooltipDismiss = { onAction(CompleteSessionListAction.HideSearchTooltipDialog) },
                     tooltipButtonText = "Tap to learn more about search and filter logic"
                 ) {

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListState.kt
@@ -5,5 +5,6 @@ import com.vci.vectorcamapp.core.domain.model.helpers.SessionUploadProgress
 
 data class CompleteSessionListState(
     val sessionAndSiteToUploadProgress: Map<SessionAndSite, SessionUploadProgress> = emptyMap(),
-    val searchQuery: String = ""
+    val searchQuery: String = "",
+    val isSearchTooltipVisible: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListViewModel.kt
@@ -1,6 +1,7 @@
 package com.vci.vectorcamapp.complete_session.list.presentation
 
 import androidx.lifecycle.viewModelScope
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsAction
 import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.model.helpers.SessionUploadProgress
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
@@ -129,6 +130,13 @@ class CompleteSessionListViewModel @Inject constructor(
 
                 is CompleteSessionListAction.UpdateSearchQuery -> {
                     _state.update { it.copy(searchQuery = action.searchQuery) }
+                }
+
+                CompleteSessionListAction.ShowSearchTooltipDialog -> {
+                    _state.update { it.copy(isSearchTooltipVisible = true) }
+                }
+                CompleteSessionListAction.HideSearchTooltipDialog -> {
+                    _state.update { it.copy(isSearchTooltipVisible = false) }
                 }
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tooltip/Tooltip.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/tooltip/Tooltip.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
@@ -30,11 +31,13 @@ fun Tooltip(
     confirmText: String = "Done",
     iconSize: Dp = MaterialTheme.dimensions.iconSizeSmall,
     textStyle: TextStyle = MaterialTheme.typography.bodySmall,
+    modifier: Modifier = Modifier,
     content: @Composable (() -> Unit)
 ){
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
+            .fillMaxWidth()
             .clickable { onClick() }
     ) {
         Icon(

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchHelpTooltipContent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchHelpTooltipContent.kt
@@ -2,44 +2,53 @@ package com.vci.vectorcamapp.core.presentation.search
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
 fun SearchHelpTooltipContent() {
-    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)) {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingMedium)) {
         Text(
             text = "How Search Works",
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colors.textPrimary,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = MaterialTheme.dimensions.paddingSmall)
         )
-        Text(
-            text = "• Put a SPACE between words when you want results that include all the words.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colors.textPrimary
-        )
-        Text(
-            text = "• Put a COMMA between groups when any one group is okay.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colors.textPrimary
-        )
-        Text(
-            text = "Examples:",
-            style = MaterialTheme.typography.titleSmall,
-            color = MaterialTheme.colors.textPrimary,
-        )
-        Text(
-            text = "• Anopheles Male  → must include Anopheles and Male.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colors.textSecondary
-        )
-        Text(
-            text = "• Anopheles Male, Mansonia Female  → either (Anopheles and Male) or (Mansonia and Female).",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colors.textSecondary
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)) {
+            Text(
+                text = "• Put a SPACE between words when you want results that include all the words.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colors.textPrimary
+            )
+            Text(
+                text = "• Put a COMMA between groups when any one group is okay.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colors.textPrimary
+            )
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)) {
+            Text(
+                text = "Examples:",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colors.textSecondary,
+            )
+            Text(
+                text = "• Anopheles Male → must include Anopheles and Male.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colors.textSecondary
+            )
+            Text(
+                text = "• Anopheles Male, Mansonia Female → either (Anopheles and Male) or (Mansonia and Female).",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colors.textSecondary
+            )
+        }
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchHelpTooltipContent.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchHelpTooltipContent.kt
@@ -1,0 +1,45 @@
+package com.vci.vectorcamapp.core.presentation.search
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.vci.vectorcamapp.ui.extensions.colors
+import com.vci.vectorcamapp.ui.extensions.dimensions
+
+@Composable
+fun SearchHelpTooltipContent() {
+    Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)) {
+        Text(
+            text = "How Search Works",
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colors.textPrimary,
+        )
+        Text(
+            text = "• Put a SPACE between words when you want results that include all the words.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colors.textPrimary
+        )
+        Text(
+            text = "• Put a COMMA between groups when any one group is okay.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colors.textPrimary
+        )
+        Text(
+            text = "Examples:",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colors.textPrimary,
+        )
+        Text(
+            text = "• Anopheles Male  → must include Anopheles and Male.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colors.textSecondary
+        )
+        Text(
+            text = "• Anopheles Male, Mansonia Female  → either (Anopheles and Male) or (Mansonia and Female).",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colors.textSecondary
+        )
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
@@ -18,9 +18,8 @@ fun SearchTextField(
     isSingleLine: Boolean = true,
     isTooltipVisible: Boolean = false,
     onSearchSubmitted: (() -> Unit)? = null,
-    onTooltipShow: (() -> Unit)? = null,
-    onTooltipDismiss: (() -> Unit)? = null,
-    tooltipButtonText: String = "Tap to learn more about searching",
+    onShowSearchTooltip: (() -> Unit)? = null,
+    onDismissSearchTooltip: (() -> Unit)? = null,
     tooltipContent: (@Composable () -> Unit)? = null,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -40,12 +39,12 @@ fun SearchTextField(
         )
     )
 
-    if (tooltipContent != null && onTooltipShow != null && onTooltipDismiss != null) {
+    if (tooltipContent != null && onShowSearchTooltip != null && onDismissSearchTooltip != null) {
         Tooltip(
             isVisible = isTooltipVisible,
-            onClick = onTooltipShow,
-            onDismiss = onTooltipDismiss,
-            buttonText = tooltipButtonText,
+            onClick = onShowSearchTooltip,
+            onDismiss = onDismissSearchTooltip,
+            buttonText = "Tap to learn more about searching",
             modifier = modifier
         ) {
             tooltipContent()

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import com.vci.vectorcamapp.core.presentation.components.form.TextEntryField
+import com.vci.vectorcamapp.core.presentation.components.tooltip.Tooltip
 
 @Composable
 fun SearchTextField(
@@ -15,7 +16,11 @@ fun SearchTextField(
     placeholder: String,
     modifier: Modifier = Modifier,
     isSingleLine: Boolean = true,
-    onSearchSubmitted: (() -> Unit)? = null
+    onSearchSubmitted: (() -> Unit)? = null,
+    onTooltipPrimaryAction: (() -> Unit)? = null,
+    onTooltipDismiss: (() -> Unit)? = null,
+    tooltipButtonText: String = "Tap to learn more about searching",
+    tooltipContent: (@Composable () -> Unit)? = null,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -33,4 +38,16 @@ fun SearchTextField(
             }
         )
     )
+
+    if (tooltipContent != null && onTooltipPrimaryAction != null && onTooltipDismiss != null) {
+        Tooltip(
+            isVisible = true,
+            onClick = { onTooltipPrimaryAction() },
+            onDismiss = { onTooltipDismiss() },
+            buttonText = tooltipButtonText,
+            modifier = modifier
+        ) {
+            tooltipContent()
+        }
+    }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
@@ -17,7 +17,7 @@ fun SearchTextField(
     modifier: Modifier = Modifier,
     isSingleLine: Boolean = true,
     onSearchSubmitted: (() -> Unit)? = null,
-    onTooltipPrimaryAction: (() -> Unit)? = null,
+    onTooltipShow: (() -> Unit)? = null,
     onTooltipDismiss: (() -> Unit)? = null,
     tooltipButtonText: String = "Tap to learn more about searching",
     tooltipContent: (@Composable () -> Unit)? = null,
@@ -39,11 +39,11 @@ fun SearchTextField(
         )
     )
 
-    if (tooltipContent != null && onTooltipPrimaryAction != null && onTooltipDismiss != null) {
+    if (tooltipContent != null && onTooltipShow != null && onTooltipDismiss != null) {
         Tooltip(
             isVisible = true,
-            onClick = { onTooltipPrimaryAction() },
-            onDismiss = { onTooltipDismiss() },
+            onClick = { onTooltipShow },
+            onDismiss = { onTooltipDismiss },
             buttonText = tooltipButtonText,
             modifier = modifier
         ) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
@@ -16,6 +16,7 @@ fun SearchTextField(
     placeholder: String,
     modifier: Modifier = Modifier,
     isSingleLine: Boolean = true,
+    isTooltipVisible: Boolean = false,
     onSearchSubmitted: (() -> Unit)? = null,
     onTooltipShow: (() -> Unit)? = null,
     onTooltipDismiss: (() -> Unit)? = null,
@@ -41,9 +42,9 @@ fun SearchTextField(
 
     if (tooltipContent != null && onTooltipShow != null && onTooltipDismiss != null) {
         Tooltip(
-            isVisible = true,
-            onClick = { onTooltipShow },
-            onDismiss = { onTooltipDismiss },
+            isVisible = isTooltipVisible,
+            onClick = onTooltipShow,
+            onDismiss = onTooltipDismiss,
             buttonText = tooltipButtonText,
             modifier = modifier
         ) {

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionAction.kt
@@ -9,4 +9,6 @@ sealed interface IncompleteSessionAction {
     data object DismissDeleteDialog : IncompleteSessionAction
     data object ReturnToLandingScreen : IncompleteSessionAction
     data class UpdateSearchQuery(val searchQuery: String) : IncompleteSessionAction
+    data object ShowSearchTooltipDialog : IncompleteSessionAction
+    data object HideSearchTooltipDialog : IncompleteSessionAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -54,8 +54,9 @@ fun IncompleteSessionScreen(
                 },
                 placeholder = "Search by collector, district, session type, etc.",
                 modifier = Modifier.padding(
-                    horizontal = MaterialTheme.dimensions.paddingMedium,
-                    vertical = MaterialTheme.dimensions.spacingSmall
+                    start = MaterialTheme.dimensions.spacingMedium,
+                    end = MaterialTheme.dimensions.spacingMedium,
+                    top = MaterialTheme.dimensions.spacingSmall
                 ),
                 isTooltipVisible = state.isSearchTooltipVisible,
                 onShowSearchTooltip = { onAction(IncompleteSessionAction.ShowSearchTooltipDialog) },

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -58,6 +58,7 @@ fun IncompleteSessionScreen(
                     end = MaterialTheme.dimensions.paddingMedium,
                     bottom = MaterialTheme.dimensions.spacingSmall
                 ),
+                isTooltipVisible = state.isSearchTooltipVisible,
                 onTooltipShow = { onAction(IncompleteSessionAction.ShowSearchTooltipDialog) },
                 onTooltipDismiss = { onAction(IncompleteSessionAction.HideSearchTooltipDialog) },
                 tooltipButtonText = "Tap to learn more about search and filter logic"

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -54,15 +54,12 @@ fun IncompleteSessionScreen(
                 },
                 placeholder = "Search by collector, district, session type, etc.",
                 modifier = Modifier.padding(
-                    start = MaterialTheme.dimensions.paddingMedium,
-                    end = MaterialTheme.dimensions.paddingMedium,
-                    top = MaterialTheme.dimensions.spacingSmall,
-                    bottom = MaterialTheme.dimensions.spacingSmall
+                    horizontal = MaterialTheme.dimensions.paddingMedium,
+                    vertical = MaterialTheme.dimensions.spacingSmall
                 ),
                 isTooltipVisible = state.isSearchTooltipVisible,
-                onTooltipShow = { onAction(IncompleteSessionAction.ShowSearchTooltipDialog) },
-                onTooltipDismiss = { onAction(IncompleteSessionAction.HideSearchTooltipDialog) },
-                tooltipButtonText = "Tap to learn more about search and filter logic"
+                onShowSearchTooltip = { onAction(IncompleteSessionAction.ShowSearchTooltipDialog) },
+                onDismissSearchTooltip = { onAction(IncompleteSessionAction.HideSearchTooltipDialog) }
             ) {
                 SearchHelpTooltipContent()
             }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -56,6 +56,7 @@ fun IncompleteSessionScreen(
                 modifier = Modifier.padding(
                     start = MaterialTheme.dimensions.paddingMedium,
                     end = MaterialTheme.dimensions.paddingMedium,
+                    top = MaterialTheme.dimensions.spacingSmall,
                     bottom = MaterialTheme.dimensions.spacingSmall
                 ),
                 isTooltipVisible = state.isSearchTooltipVisible,

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -1,8 +1,6 @@
 package com.vci.vectorcamapp.incomplete_session.presentation
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -19,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import com.vci.vectorcamapp.R
-import com.vci.vectorcamapp.complete_session.list.presentation.CompleteSessionListAction
 import com.vci.vectorcamapp.core.presentation.search.SearchTextField
 import com.vci.vectorcamapp.core.presentation.components.header.ScreenHeader
 import com.vci.vectorcamapp.core.presentation.search.SearchHelpTooltipContent
@@ -61,7 +58,7 @@ fun IncompleteSessionScreen(
                     end = MaterialTheme.dimensions.paddingMedium,
                     bottom = MaterialTheme.dimensions.spacingSmall
                 ),
-                onTooltipPrimaryAction = { onAction(IncompleteSessionAction.ShowSearchTooltipDialog) },
+                onTooltipShow = { onAction(IncompleteSessionAction.ShowSearchTooltipDialog) },
                 onTooltipDismiss = { onAction(IncompleteSessionAction.HideSearchTooltipDialog) },
                 tooltipButtonText = "Tap to learn more about search and filter logic"
             ) {

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionScreen.kt
@@ -1,6 +1,8 @@
 package com.vci.vectorcamapp.incomplete_session.presentation
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,8 +19,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import com.vci.vectorcamapp.R
+import com.vci.vectorcamapp.complete_session.list.presentation.CompleteSessionListAction
 import com.vci.vectorcamapp.core.presentation.search.SearchTextField
 import com.vci.vectorcamapp.core.presentation.components.header.ScreenHeader
+import com.vci.vectorcamapp.core.presentation.search.SearchHelpTooltipContent
 import com.vci.vectorcamapp.incomplete_session.presentation.components.IncompleteSessionCard
 import com.vci.vectorcamapp.ui.extensions.colors
 import com.vci.vectorcamapp.ui.extensions.dimensions
@@ -54,9 +58,15 @@ fun IncompleteSessionScreen(
                 placeholder = "Search by collector, district, session type, etc.",
                 modifier = Modifier.padding(
                     start = MaterialTheme.dimensions.paddingMedium,
-                    end = MaterialTheme.dimensions.paddingMedium
-                )
-            )
+                    end = MaterialTheme.dimensions.paddingMedium,
+                    bottom = MaterialTheme.dimensions.spacingSmall
+                ),
+                onTooltipPrimaryAction = { onAction(IncompleteSessionAction.ShowSearchTooltipDialog) },
+                onTooltipDismiss = { onAction(IncompleteSessionAction.HideSearchTooltipDialog) },
+                tooltipButtonText = "Tap to learn more about search and filter logic"
+            ) {
+                SearchHelpTooltipContent()
+            }
         }
 
         if (state.sessionAndSites.isEmpty()) {

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionState.kt
@@ -6,5 +6,6 @@ import java.util.UUID
 data class IncompleteSessionState(
     val sessionAndSites: List<SessionAndSite> = emptyList(),
     val deleteDialogSessionId: UUID? = null,
-    val searchQuery: String = ""
+    val searchQuery: String = "",
+    val isSearchTooltipVisible: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -121,6 +122,12 @@ class IncompleteSessionViewModel @Inject constructor(
 
                 is IncompleteSessionAction.UpdateSearchQuery -> {
                     _state.value = _state.value.copy(searchQuery = action.searchQuery)
+                }
+                IncompleteSessionAction.ShowSearchTooltipDialog -> {
+                    _state.update { it.copy(isSearchTooltipVisible = true) }
+                }
+                IncompleteSessionAction.HideSearchTooltipDialog -> {
+                    _state.update { it.copy(isSearchTooltipVisible = false) }
                 }
             }
         }


### PR DESCRIPTION
This PR implements tooltip for search text bar to explain the usage of spaces and commas. It also includes an example to demonstrate that spaces serve as AND operators and commas serve as OR operators. This tooltip is currently visible on incomplete session list, complete session list, and complete session details.