### PR TITLE
SOF-342: If metadata upload fails on one specimen, it should not block the upload of other specimen metadata.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -37,6 +37,7 @@ import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
 import com.vci.vectorcamapp.core.domain.repository.SurveillanceFormRepository
 import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 import com.vci.vectorcamapp.core.domain.util.onError
+import com.vci.vectorcamapp.core.domain.util.onSuccess
 import com.vci.vectorcamapp.core.presentation.util.error.toString
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -133,6 +134,8 @@ class MetadataUploadWorker @AssistedInject constructor(
             val localSpecimensWithImagesAndInferenceResults =
                 specimenRepository.getSpecimenImagesAndInferenceResultsBySession(syncedSession.localId)
             val totalSpecimens = localSpecimensWithImagesAndInferenceResults.size
+            var failedImagesCount = 0
+
             localSpecimensWithImagesAndInferenceResults.forEachIndexed { specimenIndex, specimenWithImagesAndInferenceResults ->
                 val totalImages =
                     specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.size
@@ -142,30 +145,36 @@ class MetadataUploadWorker @AssistedInject constructor(
                     syncedSession.remoteId
                 )) {
                     is DomainResult.Success -> syncSpecimenResult.data
-                    is DomainResult.Error -> return retryOrFailure(
-                        syncSpecimenResult.error.toString(context)
-                    )
+                    is DomainResult.Error -> {
+                        failedImagesCount += specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.size
+                        return@forEachIndexed
+                    }
                 }
 
                 specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.forEachIndexed { imageIndex, (specimenImage, inferenceResult) ->
                     if (specimenImage.metadataUploadStatus != UploadStatus.COMPLETED) {
                         syncSpecimenImageAndInferenceResultIfNeeded(
                             specimenImage, inferenceResult, syncedSpecimen, syncedSession.localId
-                        ).onError { error ->
-                            return retryOrFailure(error.toString(context))
+                        ).onSuccess {
+                            showSpecimenProgressNotification(
+                                specimenId = syncedSpecimen.id,
+                                currentSpecimenIndex = specimenIndex,
+                                totalSpecimens = totalSpecimens,
+                                currentImageIndex = imageIndex,
+                                totalImagesForSpecimen = totalImages
+                            )
+                        }.onError {
+                            failedImagesCount++
                         }
                     }
-                    showSpecimenProgressNotification(
-                        specimenId = syncedSpecimen.id,
-                        currentSpecimenIndex = specimenIndex,
-                        totalSpecimens = totalSpecimens,
-                        currentImageIndex = imageIndex,
-                        totalImagesForSpecimen = totalImages
-                    )
                 }
             }
 
-            return WorkerResult.success()
+            return if (failedImagesCount > 0) {
+                retryOrFailure("Upload failed for one or more images.")
+            } else {
+                WorkerResult.success()
+            }
         } catch (e: IOException) {
             return retryOrFailure("Lost internet connection while uploading.")
         } catch (e: Exception) {
@@ -492,7 +501,8 @@ class MetadataUploadWorker @AssistedInject constructor(
                         sexInferenceDuration = it.sexInferenceDuration,
                         abdomenStatusInferenceDuration = it.abdomenStatusInferenceDuration
                     )
-                })
+                }
+            )
 
             if (syncedSpecimen.remoteId == null) {
                 return DomainResult.Error(NetworkError.CLIENT_ERROR)

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -134,7 +134,7 @@ class MetadataUploadWorker @AssistedInject constructor(
             val localSpecimensWithImagesAndInferenceResults =
                 specimenRepository.getSpecimenImagesAndInferenceResultsBySession(syncedSession.localId)
             val totalSpecimens = localSpecimensWithImagesAndInferenceResults.size
-            var failedImagesCount = 0
+            var hasFailure = false
 
             localSpecimensWithImagesAndInferenceResults.forEachIndexed { specimenIndex, specimenWithImagesAndInferenceResults ->
                 val totalImages =
@@ -146,7 +146,16 @@ class MetadataUploadWorker @AssistedInject constructor(
                 )) {
                     is DomainResult.Success -> syncSpecimenResult.data
                     is DomainResult.Error -> {
-                        failedImagesCount += specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.size
+                        hasFailure = true
+                        specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.forEach { (specimenImage, _) ->
+                            if (specimenImage.metadataUploadStatus != UploadStatus.COMPLETED) {
+                                specimenImageRepository.updateSpecimenImage(
+                                    specimenImage.copy(metadataUploadStatus = UploadStatus.FAILED),
+                                    specimenWithImagesAndInferenceResults.specimen.id,
+                                    syncedSession.localId
+                                )
+                            }
+                        }
                         return@forEachIndexed
                     }
                 }
@@ -164,13 +173,18 @@ class MetadataUploadWorker @AssistedInject constructor(
                                 totalImagesForSpecimen = totalImages
                             )
                         }.onError {
-                            failedImagesCount++
+                            hasFailure = true
+                            specimenImageRepository.updateSpecimenImage(
+                                specimenImage.copy(metadataUploadStatus = UploadStatus.FAILED),
+                                syncedSpecimen.id,
+                                syncedSession.localId
+                            )
                         }
                     }
                 }
             }
 
-            return if (failedImagesCount > 0) {
+            return if (hasFailure) {
                 retryOrFailure("Upload failed for one or more images.")
             } else {
                 WorkerResult.success()
@@ -527,27 +541,13 @@ class MetadataUploadWorker @AssistedInject constructor(
                                     postSpecimenImageResult.data.image
                                 }
 
-                                is DomainResult.Error -> {
-                                    specimenImageRepository.updateSpecimenImage(
-                                        localSpecimenImage.copy(
-                                            metadataUploadStatus = UploadStatus.FAILED
-                                        ), syncedSpecimen.id, syncedLocalSessionId
-                                    )
-                                    return DomainResult.Error(
-                                        postSpecimenImageResult.error
-                                    )
-                                }
+                                is DomainResult.Error -> return DomainResult.Error(
+                                    postSpecimenImageResult.error
+                                )
                             }
                         }
 
-                        else -> {
-                            specimenImageRepository.updateSpecimenImage(
-                                localSpecimenImage.copy(
-                                    metadataUploadStatus = UploadStatus.FAILED
-                                ), syncedSpecimen.id, syncedLocalSessionId
-                            )
-                            return DomainResult.Error(remoteSpecimenImageResult.error)
-                        }
+                        else -> return DomainResult.Error(remoteSpecimenImageResult.error)
                     }
                 }
             }
@@ -614,18 +614,8 @@ class MetadataUploadWorker @AssistedInject constructor(
             )
             DomainResult.Success(Unit)
         } catch (e: IOException) {
-            specimenImageRepository.updateSpecimenImage(
-                localSpecimenImage.copy(metadataUploadStatus = UploadStatus.FAILED),
-                syncedSpecimen.id,
-                syncedLocalSessionId
-            )
             DomainResult.Error(NetworkError.NO_INTERNET)
         } catch (e: Exception) {
-            specimenImageRepository.updateSpecimenImage(
-                localSpecimenImage.copy(metadataUploadStatus = UploadStatus.FAILED),
-                syncedSpecimen.id,
-                syncedLocalSessionId
-            )
             DomainResult.Error(NetworkError.UNKNOWN_ERROR)
         }
     }


### PR DESCRIPTION
This pull request enhances error handling and reporting in the `MetadataUploadWorker` to ensure more robust and accurate uploads of specimen images and inference results. The main improvements are focused on tracking failed uploads and retrying the worker only when necessary, rather than failing on the first error.

**Error handling and upload robustness:**

* Added a `failedImagesCount` variable to track the number of image uploads that fail during the upload process, rather than immediately returning on the first failure.
* Modified the error handling logic for specimen and image uploads: now, if any image upload fails, the worker will retry or report failure only after all uploads have been attempted, instead of stopping at the first error.
* Updated the return logic to use `retryOrFailure` only if `failedImagesCount` is greater than zero, otherwise returning `WorkerResult.success()`. This ensures partial failures are handled gracefully and retried as needed.

**Code quality and maintainability:**

* Added the missing import for `onSuccess` to enable clearer and more idiomatic result handling in the image upload section.
* Minor formatting fix in a lambda expression for improved readability and consistency.