### PR TITLE
SOF-381: Adjust error message text for invalid specimen ID

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="imaging_error_processing_error">Could not process the photo. Please try again.</string>
 
     <!-- Imaging error: Invalid specimen ID -->
-    <string name="imaging_error_invalid_specimen_id">This specimen ID does not match the expected pattern.</string>
+    <string name="imaging_error_invalid_specimen_id">Specimen ID must be 3 letters followed by 3 numbers (e.g., ABC123).</string>
 
     <!-- Imaging error: No specimen found -->
     <string name="imaging_error_no_specimen_found">No specimen found in the photo. Please try again with a clearer image.</string>


### PR DESCRIPTION
This pull request updates the error message shown when a user enters an invalid specimen ID to provide a clearer, more specific description of the required format.

- User experience improvement:
  * Updated the `imaging_error_invalid_specimen_id` string in `strings.xml` to specify that the specimen ID must be 3 letters followed by 3 numbers (e.g., ABC123), making the validation requirements clearer to users.