### PR TITLE
SOF-384: Add new column to specimen table - wasSelectedForFurtherProcessing

### DIFF
--- a/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/16.json
+++ b/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/16.json
@@ -1,0 +1,656 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "5969d15fc351d6b4c210c243458974a5",
+    "entities": [
+      {
+        "tableName": "collector",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `title` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "program",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_program_country",
+            "unique": false,
+            "columnNames": [
+              "country"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_program_country` ON `${TABLE_NAME}` (`country`)"
+          }
+        ]
+      },
+      {
+        "tableName": "site",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `programId` INTEGER NOT NULL, `district` TEXT NOT NULL, `subCounty` TEXT NOT NULL, `parish` TEXT NOT NULL, `villageName` TEXT NOT NULL, `houseNumber` TEXT NOT NULL, `healthCenter` TEXT NOT NULL, `isActive` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`programId`) REFERENCES `program`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "programId",
+            "columnName": "programId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subCounty",
+            "columnName": "subCounty",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parish",
+            "columnName": "parish",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "villageName",
+            "columnName": "villageName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "houseNumber",
+            "columnName": "houseNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "healthCenter",
+            "columnName": "healthCenter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_site_programId",
+            "unique": false,
+            "columnNames": [
+              "programId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_site_programId` ON `${TABLE_NAME}` (`programId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "program",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "programId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `siteId` INTEGER NOT NULL, `remoteId` INTEGER, `collectorTitle` TEXT NOT NULL, `collectorName` TEXT NOT NULL, `collectionDate` INTEGER NOT NULL, `collectionMethod` TEXT NOT NULL, `specimenCondition` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `completedAt` INTEGER, `submittedAt` INTEGER, `notes` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `type` TEXT NOT NULL, PRIMARY KEY(`localId`), FOREIGN KEY(`siteId`) REFERENCES `site`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "collectorTitle",
+            "columnName": "collectorTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorName",
+            "columnName": "collectorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionDate",
+            "columnName": "collectionDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionMethod",
+            "columnName": "collectionMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenCondition",
+            "columnName": "specimenCondition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_session_siteId",
+            "unique": false,
+            "columnNames": [
+              "siteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_siteId` ON `${TABLE_NAME}` (`siteId`)"
+          },
+          {
+            "name": "index_session_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "site",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "siteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `wasSelectedForFurtherProcessing` INTEGER NOT NULL, PRIMARY KEY(`id`, `sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "wasSelectedForFurtherProcessing",
+            "columnName": "wasSelectedForFurtherProcessing",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen_image",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `specimenId` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `species` TEXT, `sex` TEXT, `abdomenStatus` TEXT, `imageUri` TEXT NOT NULL, `metadataUploadStatus` TEXT NOT NULL, `imageUploadStatus` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL, `submittedAt` INTEGER, PRIMARY KEY(`localId`), FOREIGN KEY(`specimenId`, `sessionId`) REFERENCES `specimen`(`id`, `sessionId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenId",
+            "columnName": "specimenId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "species",
+            "columnName": "species",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sex",
+            "columnName": "sex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatus",
+            "columnName": "abdomenStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUri",
+            "columnName": "imageUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataUploadStatus",
+            "columnName": "metadataUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUploadStatus",
+            "columnName": "imageUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_image_specimenId_sessionId",
+            "unique": false,
+            "columnNames": [
+              "specimenId",
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_image_specimenId_sessionId` ON `${TABLE_NAME}` (`specimenId`, `sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "specimen",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenId",
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id",
+              "sessionId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inference_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`specimenImageId` TEXT NOT NULL, `bboxTopLeftX` REAL NOT NULL, `bboxTopLeftY` REAL NOT NULL, `bboxWidth` REAL NOT NULL, `bboxHeight` REAL NOT NULL, `bboxConfidence` REAL NOT NULL, `bboxClassId` INTEGER NOT NULL, `speciesLogits` TEXT, `sexLogits` TEXT, `abdomenStatusLogits` TEXT, `bboxDetectionDuration` INTEGER NOT NULL, `speciesInferenceDuration` INTEGER, `sexInferenceDuration` INTEGER, `abdomenStatusInferenceDuration` INTEGER, PRIMARY KEY(`specimenImageId`), FOREIGN KEY(`specimenImageId`) REFERENCES `specimen_image`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "specimenImageId",
+            "columnName": "specimenImageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftX",
+            "columnName": "bboxTopLeftX",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftY",
+            "columnName": "bboxTopLeftY",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxWidth",
+            "columnName": "bboxWidth",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxHeight",
+            "columnName": "bboxHeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxConfidence",
+            "columnName": "bboxConfidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxClassId",
+            "columnName": "bboxClassId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speciesLogits",
+            "columnName": "speciesLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sexLogits",
+            "columnName": "sexLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatusLogits",
+            "columnName": "abdomenStatusLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bboxDetectionDuration",
+            "columnName": "bboxDetectionDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speciesInferenceDuration",
+            "columnName": "speciesInferenceDuration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sexInferenceDuration",
+            "columnName": "sexInferenceDuration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "abdomenStatusInferenceDuration",
+            "columnName": "abdomenStatusInferenceDuration",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "specimenImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "specimen_image",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenImageId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "surveillance_form",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `numPeopleSleptInHouse` INTEGER NOT NULL, `wasIrsConducted` INTEGER NOT NULL, `monthsSinceIrs` INTEGER, `numLlinsAvailable` INTEGER NOT NULL, `llinType` TEXT, `llinBrand` TEXT, `numPeopleSleptUnderLlin` INTEGER, `submittedAt` INTEGER, PRIMARY KEY(`sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeopleSleptInHouse",
+            "columnName": "numPeopleSleptInHouse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wasIrsConducted",
+            "columnName": "wasIrsConducted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monthsSinceIrs",
+            "columnName": "monthsSinceIrs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "numLlinsAvailable",
+            "columnName": "numLlinsAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "llinType",
+            "columnName": "llinType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "llinBrand",
+            "columnName": "llinBrand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPeopleSleptUnderLlin",
+            "columnName": "numPeopleSleptUnderLlin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5969d15fc351d6b4c210c243458974a5')"
+    ]
+  }
+}

--- a/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/16.json
+++ b/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/16.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 16,
-    "identityHash": "5969d15fc351d6b4c210c243458974a5",
+    "identityHash": "e80f22caa90610e5b8074b8064e8c9a7",
     "entities": [
       {
         "tableName": "collector",
@@ -306,7 +306,7 @@
       },
       {
         "tableName": "specimen",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `wasSelectedForFurtherProcessing` INTEGER NOT NULL, PRIMARY KEY(`id`, `sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `shouldProcessFurther` INTEGER NOT NULL, PRIMARY KEY(`id`, `sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "id",
@@ -326,8 +326,8 @@
             "affinity": "INTEGER"
           },
           {
-            "fieldPath": "wasSelectedForFurtherProcessing",
-            "columnName": "wasSelectedForFurtherProcessing",
+            "fieldPath": "shouldProcessFurther",
+            "columnName": "shouldProcessFurther",
             "affinity": "INTEGER",
             "notNull": true
           }
@@ -650,7 +650,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5969d15fc351d6b4c210c243458974a5')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e80f22caa90610e5b8074b8064e8c9a7')"
     ]
   }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
@@ -4,5 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PostSpecimenRequestDto(
-    val specimenId: String = ""
+    val specimenId: String = "",
+    val shouldProcessFurther: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
@@ -6,5 +6,6 @@ import kotlinx.serialization.Serializable
 data class SpecimenDto(
     val id: Int? = null,
     val specimenId: String = "",
-    val sessionId: Int = -1
+    val sessionId: Int = -1,
+    val wasSelectedForFurtherProcessing: Boolean? = null
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
@@ -7,5 +7,5 @@ data class SpecimenDto(
     val id: Int? = null,
     val specimenId: String = "",
     val sessionId: Int = -1,
-    val wasSelectedForFurtherProcessing: Boolean? = null
+    val wasSelectedForFurtherProcessing: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
@@ -7,5 +7,5 @@ data class SpecimenDto(
     val id: Int? = null,
     val specimenId: String = "",
     val sessionId: Int = -1,
-    val wasSelectedForFurtherProcessing: Boolean = false
+    val shouldProcessFurther: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
@@ -7,7 +7,8 @@ import java.util.UUID
 fun SpecimenEntity.toDomain(): Specimen {
     return Specimen(
         id = this.id,
-        remoteId = this.remoteId
+        remoteId = this.remoteId,
+        wasSelectedForFurtherProcessing = this.wasSelectedForFurtherProcessing
     )
 }
 
@@ -15,6 +16,7 @@ fun Specimen.toEntity(sessionId: UUID): SpecimenEntity {
     return SpecimenEntity(
         id = this.id,
         sessionId = sessionId,
-        remoteId = this.remoteId
+        remoteId = this.remoteId,
+        wasSelectedForFurtherProcessing = this.wasSelectedForFurtherProcessing
     )
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
@@ -8,7 +8,7 @@ fun SpecimenEntity.toDomain(): Specimen {
     return Specimen(
         id = this.id,
         remoteId = this.remoteId,
-        wasSelectedForFurtherProcessing = this.wasSelectedForFurtherProcessing
+        shouldProcessFurther = this.shouldProcessFurther
     )
 }
 
@@ -17,6 +17,6 @@ fun Specimen.toEntity(sessionId: UUID): SpecimenEntity {
         id = this.id,
         sessionId = sessionId,
         remoteId = this.remoteId,
-        wasSelectedForFurtherProcessing = this.wasSelectedForFurtherProcessing
+        shouldProcessFurther = this.shouldProcessFurther
     )
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
@@ -27,7 +27,7 @@ import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
 
 @Database(
     entities = [CollectorEntity::class, ProgramEntity::class, SiteEntity::class, SessionEntity::class, SpecimenEntity::class, SpecimenImageEntity::class, InferenceResultEntity::class, SurveillanceFormEntity::class],
-    version = 15,
+    version = 16,
 )
 @TypeConverters(
     UuidConverter::class,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
@@ -18,5 +18,5 @@ data class SpecimenEntity(
     val id: String = "",
     val sessionId: UUID = UUID(0, 0),
     val remoteId: Int? = null,
-    val wasSelectedForFurtherProcessing: Boolean = false
+    val shouldProcessFurther: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
@@ -17,5 +17,6 @@ import java.util.UUID
 data class SpecimenEntity(
     val id: String = "",
     val sessionId: UUID = UUID(0, 0),
-    val remoteId: Int? = null
+    val remoteId: Int? = null,
+    val wasSelectedForFurtherProcessing: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -14,6 +14,7 @@ import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_6_7_BOU
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS
+import com.vci.vectorcamapp.core.data.room.migrations.versions.Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN
 
 val ALL_MIGRATIONS = arrayOf(
     MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE,
@@ -29,5 +30,6 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_11_12_ADD_DETECTION_DURATION_COLUMN,
     MIGRATION_12_13_REMOVE_SENTINEL_SITE_AND_MOVE_HOUSE_NUMBER_UNDER_SITE,
     MIGRATION_13_14_ADD_COLLECTOR_TABLE,
-    MIGRATION_14_15_BACKFILL_COLLECTORS
+    MIGRATION_14_15_BACKFILL_COLLECTORS,
+    Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -14,7 +14,7 @@ import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_6_7_BOU
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS
-import com.vci.vectorcamapp.core.data.room.migrations.versions.Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN
+import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN
 
 val ALL_MIGRATIONS = arrayOf(
     MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE,
@@ -31,5 +31,5 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_12_13_REMOVE_SENTINEL_SITE_AND_MOVE_HOUSE_NUMBER_UNDER_SITE,
     MIGRATION_13_14_ADD_COLLECTOR_TABLE,
     MIGRATION_14_15_BACKFILL_COLLECTORS,
-    Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN,
+    MIGRATION_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -14,7 +14,7 @@ import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_6_7_BOU
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_7_8_SPECIMEN_IMAGE_SEPARATION
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_8_9_ADD_SESSION_TYPE_COLUMN
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_9_10_REFACTOR_SPECIMEN_IMAGE_AND_INFERENCE_RESULT_KEYS
-import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN
+import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_15_16_ADD_SPECIMEN_SHOULD_PROCESS_FURTHER_COLUMN
 
 val ALL_MIGRATIONS = arrayOf(
     MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE,
@@ -31,5 +31,5 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_12_13_REMOVE_SENTINEL_SITE_AND_MOVE_HOUSE_NUMBER_UNDER_SITE,
     MIGRATION_13_14_ADD_COLLECTOR_TABLE,
     MIGRATION_14_15_BACKFILL_COLLECTORS,
-    MIGRATION_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN,
+    MIGRATION_15_16_ADD_SPECIMEN_SHOULD_PROCESS_FURTHER_COLUMN,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN.kt
@@ -1,0 +1,12 @@
+package com.vci.vectorcamapp.core.data.room.migrations.versions
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN = object : Migration(15, 16){
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE `specimen` ADD COLUMN `wasSelectedForFurtherProcessing` INTEGER NOT NULL DEFAULT 0"
+        )
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN.kt
@@ -6,7 +6,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 val MIGRATION_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN = object : Migration(15, 16){
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL(
-            "ALTER TABLE `specimen` ADD COLUMN `wasSelectedForFurtherProcessing` INTEGER NOT NULL DEFAULT 0"
+            "ALTER TABLE `specimen` ADD COLUMN `shouldProcessFurther` INTEGER NOT NULL DEFAULT 0"
         )
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN.kt
@@ -3,7 +3,7 @@ package com.vci.vectorcamapp.core.data.room.migrations.versions
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-val Migration_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN = object : Migration(15, 16){
+val MIGRATION_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN = object : Migration(15, 16){
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL(
             "ALTER TABLE `specimen` ADD COLUMN `wasSelectedForFurtherProcessing` INTEGER NOT NULL DEFAULT 0"

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_AddSpecimenShouldProcessFurtherColumn.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_15_16_AddSpecimenShouldProcessFurtherColumn.kt
@@ -3,7 +3,7 @@ package com.vci.vectorcamapp.core.data.room.migrations.versions
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
-val MIGRATION_15_16_ADD_SPECIMEN_SELECTED_FOR_FURTHER_PROCESSING_COLUMN = object : Migration(15, 16){
+val MIGRATION_15_16_ADD_SPECIMEN_SHOULD_PROCESS_FURTHER_COLUMN = object : Migration(15, 16){
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL(
             "ALTER TABLE `specimen` ADD COLUMN `shouldProcessFurther` INTEGER NOT NULL DEFAULT 0"

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -436,7 +436,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 }
 
             val remoteSpecimen = Specimen(
-                id = remoteSpecimenDto.specimenId, remoteId = remoteSpecimenDto.id
+                id = remoteSpecimenDto.specimenId, remoteId = remoteSpecimenDto.id, wasSelectedForFurtherProcessing = false
             )
 
             if (remoteSpecimenDto != localSpecimenDto) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -436,7 +436,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 }
 
             val remoteSpecimen = Specimen(
-                id = remoteSpecimenDto.specimenId, remoteId = remoteSpecimenDto.id, wasSelectedForFurtherProcessing = remoteSpecimenDto.wasSelectedForFurtherProcessing
+                id = remoteSpecimenDto.specimenId, remoteId = remoteSpecimenDto.id, shouldProcessFurther = remoteSpecimenDto.shouldProcessFurther
             )
 
             if (remoteSpecimenDto != localSpecimenDto) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -436,7 +436,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 }
 
             val remoteSpecimen = Specimen(
-                id = remoteSpecimenDto.specimenId, remoteId = remoteSpecimenDto.id, wasSelectedForFurtherProcessing = false
+                id = remoteSpecimenDto.specimenId, remoteId = remoteSpecimenDto.id, wasSelectedForFurtherProcessing = remoteSpecimenDto.wasSelectedForFurtherProcessing
             )
 
             if (remoteSpecimenDto != localSpecimenDto) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
@@ -2,5 +2,6 @@ package com.vci.vectorcamapp.core.domain.model
 
 data class Specimen(
     val id: String,
-    val remoteId: Int?
+    val remoteId: Int?,
+    val wasSelectedForFurtherProcessing: Boolean = false
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
@@ -3,5 +3,5 @@ package com.vci.vectorcamapp.core.domain.model
 data class Specimen(
     val id: String,
     val remoteId: Int?,
-    val wasSelectedForFurtherProcessing: Boolean = false
+    val wasSelectedForFurtherProcessing: Boolean
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
@@ -3,5 +3,5 @@ package com.vci.vectorcamapp.core.domain.model
 data class Specimen(
     val id: String,
     val remoteId: Int?,
-    val wasSelectedForFurtherProcessing: Boolean
+    val shouldProcessFurther: Boolean
 )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -11,7 +11,7 @@ import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenIma
 data class ImagingState(
     val isLoading: Boolean = false,
     val isProcessing: Boolean = false,
-    val currentSpecimen: Specimen = Specimen(id = "", remoteId = null),
+    val currentSpecimen: Specimen = Specimen(id = "", remoteId = null, wasSelectedForFurtherProcessing = false),
     val currentSpecimenImage: SpecimenImage = SpecimenImage(
         localId = "",
         remoteId = null,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -11,7 +11,7 @@ import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenIma
 data class ImagingState(
     val isLoading: Boolean = false,
     val isProcessing: Boolean = false,
-    val currentSpecimen: Specimen = Specimen(id = "", remoteId = null, wasSelectedForFurtherProcessing = false),
+    val currentSpecimen: Specimen = Specimen(id = "", remoteId = null, shouldProcessFurther = false),
     val currentSpecimenImage: SpecimenImage = SpecimenImage(
         localId = "",
         remoteId = null,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -299,7 +299,7 @@ class ImagingViewModel @Inject constructor(
                     val saveResult = cameraRepository.saveImage(jpegBytes, filename, currentSession)
 
                     saveResult.onSuccess { imageUri ->
-                        val specimen = Specimen(id = specimenId, remoteId = null, wasSelectedForFurtherProcessing = false)
+                        val specimen = Specimen(id = specimenId, remoteId = null, shouldProcessFurther = false)
                         val specimenImage = SpecimenImage(
                             localId = calculateMd5(jpegBytes),
                             remoteId = null,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -299,7 +299,7 @@ class ImagingViewModel @Inject constructor(
                     val saveResult = cameraRepository.saveImage(jpegBytes, filename, currentSession)
 
                     saveResult.onSuccess { imageUri ->
-                        val specimen = Specimen(id = specimenId, remoteId = null)
+                        val specimen = Specimen(id = specimenId, remoteId = null, wasSelectedForFurtherProcessing = false)
                         val specimenImage = SpecimenImage(
                             localId = calculateMd5(jpegBytes),
                             remoteId = null,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -370,6 +370,7 @@ class ImagingViewModel @Inject constructor(
                 currentSpecimen = it.currentSpecimen.copy(
                     id = "",
                     remoteId = null,
+                    shouldProcessFurther = false
                 ),
                 currentSpecimenImage = it.currentSpecimenImage.copy(
                     localId = "",


### PR DESCRIPTION
This PR adds an additional field to the specimen class and all corresponding classes called wasSelectedForFurtherProcessing, this field will be used to track whether a specimen is selected for further processing and will be used in UI to indicate that to the user.