### PR TITLE
SOF-385: Add "Other" to list of collector titles

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/registration/domain/model/RegistrationDropdownOptions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/registration/domain/model/RegistrationDropdownOptions.kt
@@ -4,6 +4,7 @@ object RegistrationDropdownOptions {
 
     enum class CollectorTitleOption(val label: String) {
         VECTOR_CONTROL_OFFICER("Vector Control Officer (VCO)"),
-        VILLAGE_HEALTH_TEAM("Village Health Team (VHT)")
+        VILLAGE_HEALTH_TEAM("Village Health Team (VHT)"),
+        FIELD_OPERATIONS_TEAM("Field Operations Team (FOT)")
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/settings/domain/model/SettingsDropdownOptions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/settings/domain/model/SettingsDropdownOptions.kt
@@ -4,6 +4,7 @@ object SettingsDropdownOptions {
 
     enum class CollectorTitleOption(val label: String) {
         VECTOR_CONTROL_OFFICER("Vector Control Officer (VCO)"),
-        VILLAGE_HEALTH_TEAM("Village Health Team (VHT)")
+        VILLAGE_HEALTH_TEAM("Village Health Team (VHT)"),
+        FIELD_OPERATIONS_TEAM("Field Operations Team (FOT)")
     }
 }


### PR DESCRIPTION
This pull request adds "Field Operations Team (FOT)" to `CollectorTitleOption` in `RegistrationDropdownOptions` and `SettingsDropdownOptions` to serve as the "Other" option for collector titles.

The pull request has been tested on the Samsung A15.