### PR TITLE
SOF-350: Make Specimen ID text field on Imaging Screen red when error related to specimen ID is emitted

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
@@ -34,6 +34,8 @@ fun TextEntryField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     maxCharacters: Int = 200,
+    showErrorMessage: Boolean = true,
+    changeTextColorOnError: Boolean = false,
 ) {
     val context = LocalContext.current
 
@@ -73,6 +75,12 @@ fun TextEntryField(
                 }
             },
             maxLines = 8,
+            textStyle = MaterialTheme.typography.bodyMedium.copy(
+                color = if (error != null && changeTextColorOnError)
+                    MaterialTheme.colors.error
+                else
+                    MaterialTheme.colors.textPrimary
+            ),
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = MaterialTheme.colors.transparent,
                 unfocusedBorderColor = MaterialTheme.colors.transparent,
@@ -97,7 +105,7 @@ fun TextEntryField(
                 .heightIn(min = MaterialTheme.dimensions.componentHeightMedium)
         )
 
-        if (error != null) {
+        if (error != null && showErrorMessage) {
             Text(
                 text = error.toString(context),
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/TextEntryField.kt
@@ -35,7 +35,6 @@ fun TextEntryField(
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     maxCharacters: Int = 200,
     showErrorMessage: Boolean = true,
-    changeTextColorOnError: Boolean = false,
 ) {
     val context = LocalContext.current
 
@@ -76,7 +75,7 @@ fun TextEntryField(
             },
             maxLines = 8,
             textStyle = MaterialTheme.typography.bodyMedium.copy(
-                color = if (error != null && changeTextColorOnError)
+                color = if (error != null)
                     MaterialTheme.colors.error
                 else
                     MaterialTheme.colors.textPrimary

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -427,7 +427,6 @@ fun ImagingScreen(
                                     singleLine = true,
                                     error = state.specimenIdError,
                                     showErrorMessage = false,
-                                    changeTextColorOnError = true
                                 )
 
                                 Row(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -423,7 +423,11 @@ fun ImagingScreen(
                                     label = "Specimen ID",
                                     value = state.currentSpecimen.id, onValueChange = {
                                         onAction(ImagingAction.CorrectSpecimenId(it))
-                                    }, singleLine = true
+                                    },
+                                    singleLine = true,
+                                    error = state.specimenIdError,
+                                    showErrorMessage = false,
+                                    changeTextColorOnError = true
                                 )
 
                                 Row(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -7,6 +7,7 @@ import com.vci.vectorcamapp.core.domain.model.Specimen
 import com.vci.vectorcamapp.core.domain.model.SpecimenImage
 import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
 import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
+import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 
 data class ImagingState(
     val isLoading: Boolean = false,
@@ -32,5 +33,6 @@ data class ImagingState(
     val isManualFocusing: Boolean = false,
     val isCameraReady: Boolean = false,
     val showExitDialog: Boolean = false,
-    val pendingAction: ImagingAction? = null
+    val pendingAction: ImagingAction? = null,
+    val specimenIdError: ImagingError? = null
 )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -130,7 +130,8 @@ class ImagingViewModel @Inject constructor(
                 is ImagingAction.CorrectSpecimenId -> {
                     _state.update {
                         it.copy(
-                            currentSpecimen = it.currentSpecimen.copy(id = action.specimenId)
+                            currentSpecimen = it.currentSpecimen.copy(id = action.specimenId),
+                            specimenIdError = null
                         )
                     }
                 }
@@ -280,8 +281,12 @@ class ImagingViewModel @Inject constructor(
                     val specimenId = when (val validationResult = validateSpecimenIdUseCase(
                         _state.value.currentSpecimen.id, shouldAutoCorrect = false
                     )) {
-                        is Result.Success -> validationResult.data
+                        is Result.Success -> {
+                            _state.update { it.copy(specimenIdError = null) }
+                            validationResult.data
+                        }
                         is Result.Error -> {
+                            _state.update { it.copy(specimenIdError = validationResult.error) }
                             emitError(validationResult.error)
                             return@launch
                         }
@@ -388,7 +393,8 @@ class ImagingViewModel @Inject constructor(
                 isCameraReady = false,
                 previewInferenceResults = emptyList(),
                 focusPoint = null,
-                isManualFocusing = false
+                isManualFocusing = false,
+                specimenIdError = null
             )
         }
     }


### PR DESCRIPTION
This PR implements a functionality where the text entry field in imaging screen will turn the text red upon emitting an error related to specimen ID validation.