### PR TITLE
SOF-378: On the imaging screen, add a way for users to see alignment of specimenID and specimen with the field of view.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -399,6 +399,7 @@ fun ImagingScreen(
                         ) {
                             LiveCameraPreview(
                                 controller = controller,
+                                specimenId = state.currentSpecimen.id,
                                 inferenceResults = state.previewInferenceResults,
                                 focusPoint = state.focusPoint,
                                 onFocusAt = { normalizedOffset -> onAction(ImagingAction.FocusAt(normalizedOffset)) },

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -69,7 +69,6 @@ fun ImagingScreen(
     state: ImagingState, onAction: (ImagingAction) -> Unit, modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
-    val density = LocalDensity.current
     val lifecycleOwner = LocalLifecycleOwner.current
 
     val scope = rememberCoroutineScope()

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -152,6 +152,10 @@ class ImagingViewModel @Inject constructor(
                             _state.update {
                                 it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
                             }
+                        }.onError {
+                            _state.update {
+                                it.copy(currentSpecimen = it.currentSpecimen.copy(id = ""))
+                            }
                         }
 
                         val suggestedAutofocusPoint = liveFrameProcessingResult.autofocusPoint

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt
@@ -73,6 +73,11 @@ fun LiveCameraPreview(
 
         AndroidView(factory = { previewView }, modifier = Modifier.fillMaxSize())
 
+        TrayAlignmentGuideOverlay(
+            overlaySize = containerSize,
+            modifier = Modifier.fillMaxSize()
+        )
+
         inferenceResults.map {
             BoundingBoxOverlay(
                 inferenceResult = it,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt
@@ -28,6 +28,7 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 @Composable
 fun LiveCameraPreview(
     controller: LifecycleCameraController,
+    specimenId: String,
     inferenceResults: List<InferenceResult>,
     focusPoint: Offset?,
     onFocusAt: (Offset) -> Unit,
@@ -75,6 +76,8 @@ fun LiveCameraPreview(
 
         TrayAlignmentGuideOverlay(
             overlaySize = containerSize,
+            hasSpecimenId = specimenId.isNotEmpty(),
+            hasSpecimenImage = inferenceResults.isNotEmpty(),
             modifier = Modifier.fillMaxSize()
         )
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/TrayAlignmentGuideOverlay.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/TrayAlignmentGuideOverlay.kt
@@ -1,0 +1,120 @@
+package com.vci.vectorcamapp.imaging.presentation.components.camera
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntSize
+import com.vci.vectorcamapp.R
+import com.vci.vectorcamapp.ui.extensions.colors
+import com.vci.vectorcamapp.ui.extensions.dimensions
+
+@Composable
+fun TrayAlignmentGuideOverlay(
+    overlaySize: IntSize,
+    modifier: Modifier = Modifier
+) {
+    val specimenIdTopFraction = 0.06f
+    val specimenIdHeightFraction = 0.16f
+    val specimenIdWidthFraction = 0.75f
+    val trayGapTopFraction = 0.06f
+    val trayHeightFraction = 0.65f
+    val trayWidthFraction = 0.85f
+
+    val density = LocalDensity.current
+    val strokeWidth = with(density) { MaterialTheme.dimensions.borderThicknessThick.toPx() }
+    val cornerRadius = with(density) { MaterialTheme.dimensions.cornerRadiusMedium.toPx() }
+    val dashInterval = with(density) { MaterialTheme.dimensions.spacingMedium.toPx() }
+    val dashGap = with(density) { MaterialTheme.dimensions.spacingExtraSmall.toPx() }
+    val guideColor = MaterialTheme.colors.accent.copy(alpha = 0.5f)
+
+    val width = overlaySize.width.toFloat()
+    val height = overlaySize.height.toFloat()
+
+    val specimenIdTopMargin = height * specimenIdTopFraction
+    val specimenIdHeight = height * specimenIdHeightFraction
+    val specimenIdWidth = width * specimenIdWidthFraction
+    val specimenIdLeft = (width - specimenIdWidth) / 2f
+
+    val trayTopMargin = specimenIdTopMargin + specimenIdHeight + (height * trayGapTopFraction)
+    val trayHeight = height * trayHeightFraction
+    val trayWidth = width * trayWidthFraction
+    val trayLeft = (width - trayWidth) / 2f
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val dashEffect = PathEffect.dashPathEffect(floatArrayOf(dashInterval, dashGap), 0f)
+
+            drawRoundRect(
+                color = guideColor,
+                topLeft = Offset(specimenIdLeft, specimenIdTopMargin),
+                size = Size(specimenIdWidth, specimenIdHeight),
+                cornerRadius = CornerRadius(cornerRadius, cornerRadius),
+                style = Stroke(width = strokeWidth, pathEffect = dashEffect)
+            )
+
+            drawRoundRect(
+                color = guideColor,
+                topLeft = Offset(trayLeft, trayTopMargin),
+                size = Size(trayWidth, trayHeight),
+                cornerRadius = CornerRadius(cornerRadius, cornerRadius),
+                style = Stroke(width = strokeWidth, pathEffect = dashEffect)
+            )
+        }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .width(with(density) { specimenIdWidth.toDp() })
+                .height(with(density) { specimenIdHeight.toDp() })
+                .offset(
+                    x = with(density) { specimenIdLeft.toDp() },
+                    y = with(density) { specimenIdTopMargin.toDp() }
+                )
+        ) {
+            Text(
+                text = "ABC123",
+                style = MaterialTheme.typography.displayLarge,
+                color = guideColor,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .width(with(density) { trayWidth.toDp() })
+                .height(with(density) { trayHeight.toDp() })
+                .offset(
+                    x = with(density) { trayLeft.toDp() },
+                    y = with(density) { trayTopMargin.toDp() }
+                )
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_specimen),
+                contentDescription = "Mosquito alignment guide",
+                tint = guideColor,
+                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeExtraExtraExtraLarge)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/TrayAlignmentGuideOverlay.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/TrayAlignmentGuideOverlay.kt
@@ -1,15 +1,23 @@
 package com.vci.vectorcamapp.imaging.presentation.components.camera
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,14 +38,15 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 @Composable
 fun TrayAlignmentGuideOverlay(
     overlaySize: IntSize,
+    hasSpecimenId: Boolean,
+    hasSpecimenImage: Boolean,
     modifier: Modifier = Modifier
 ) {
     val specimenIdTopFraction = 0.06f
     val specimenIdHeightFraction = 0.16f
     val specimenIdWidthFraction = 0.75f
-    val trayGapTopFraction = 0.06f
-    val trayHeightFraction = 0.65f
-    val trayWidthFraction = 0.85f
+    val trayGapTopFraction = 0.15f
+    val trayWidthFraction = 0.55f
 
     val density = LocalDensity.current
     val strokeWidth = with(density) { MaterialTheme.dimensions.borderThicknessThick.toPx() }
@@ -55,66 +64,124 @@ fun TrayAlignmentGuideOverlay(
     val specimenIdLeft = (width - specimenIdWidth) / 2f
 
     val trayTopMargin = specimenIdTopMargin + specimenIdHeight + (height * trayGapTopFraction)
-    val trayHeight = height * trayHeightFraction
-    val trayWidth = width * trayWidthFraction
-    val trayLeft = (width - trayWidth) / 2f
+    val traySize = width * trayWidthFraction
+    val trayLeft = (width - traySize) / 2f
 
     Box(modifier = modifier.fillMaxSize()) {
         Canvas(modifier = Modifier.fillMaxSize()) {
             val dashEffect = PathEffect.dashPathEffect(floatArrayOf(dashInterval, dashGap), 0f)
 
-            drawRoundRect(
-                color = guideColor,
-                topLeft = Offset(specimenIdLeft, specimenIdTopMargin),
-                size = Size(specimenIdWidth, specimenIdHeight),
-                cornerRadius = CornerRadius(cornerRadius, cornerRadius),
-                style = Stroke(width = strokeWidth, pathEffect = dashEffect)
-            )
+            if (!hasSpecimenId) {
+                drawRoundRect(
+                    color = guideColor,
+                    topLeft = Offset(specimenIdLeft, specimenIdTopMargin),
+                    size = Size(specimenIdWidth, specimenIdHeight),
+                    cornerRadius = CornerRadius(cornerRadius, cornerRadius),
+                    style = Stroke(width = strokeWidth, pathEffect = dashEffect)
+                )
+            }
 
-            drawRoundRect(
-                color = guideColor,
-                topLeft = Offset(trayLeft, trayTopMargin),
-                size = Size(trayWidth, trayHeight),
-                cornerRadius = CornerRadius(cornerRadius, cornerRadius),
-                style = Stroke(width = strokeWidth, pathEffect = dashEffect)
-            )
+            if (!hasSpecimenImage) {
+                drawRoundRect(
+                    color = guideColor,
+                    topLeft = Offset(trayLeft, trayTopMargin),
+                    size = Size(traySize, traySize),
+                    cornerRadius = CornerRadius(cornerRadius, cornerRadius),
+                    style = Stroke(width = strokeWidth, pathEffect = dashEffect)
+                )
+            }
         }
 
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .width(with(density) { specimenIdWidth.toDp() })
-                .height(with(density) { specimenIdHeight.toDp() })
-                .offset(
-                    x = with(density) { specimenIdLeft.toDp() },
-                    y = with(density) { specimenIdTopMargin.toDp() }
+        if (!hasSpecimenId) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .width(with(density) { specimenIdWidth.toDp() })
+                    .height(with(density) { specimenIdHeight.toDp() })
+                    .offset(
+                        x = with(density) { specimenIdLeft.toDp() },
+                        y = with(density) { specimenIdTopMargin.toDp() }
+                    )
+            ) {
+                Text(
+                    text = "ABC123",
+                    style = MaterialTheme.typography.displayLarge,
+                    color = guideColor,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
                 )
-        ) {
-            Text(
-                text = "ABC123",
-                style = MaterialTheme.typography.displayLarge,
-                color = guideColor,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
-            )
+            }
         }
 
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .width(with(density) { trayWidth.toDp() })
-                .height(with(density) { trayHeight.toDp() })
-                .offset(
-                    x = with(density) { trayLeft.toDp() },
-                    y = with(density) { trayTopMargin.toDp() }
+        if (!hasSpecimenImage) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .width(with(density) { traySize.toDp() })
+                    .height(with(density) { traySize.toDp() })
+                    .offset(
+                        x = with(density) { trayLeft.toDp() },
+                        y = with(density) { trayTopMargin.toDp() }
+                    )
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_specimen),
+                    contentDescription = "Mosquito alignment guide",
+                    tint = guideColor,
+                    modifier = Modifier.size(MaterialTheme.dimensions.iconSizeExtraExtraLarge)
                 )
+            }
+        }
+
+        Surface(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(MaterialTheme.dimensions.paddingMedium),
+            shape = RoundedCornerShape(MaterialTheme.dimensions.cornerRadiusMedium),
+            color = MaterialTheme.colors.appBackground.copy(alpha = 0.95f),
+            shadowElevation = MaterialTheme.dimensions.elevationSmall
         ) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_specimen),
-                contentDescription = "Mosquito alignment guide",
-                tint = guideColor,
-                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeExtraExtraExtraLarge)
-            )
+            Column(
+                modifier = Modifier.padding(MaterialTheme.dimensions.paddingSmall),
+                verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.paddingExtraSmall)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = hasSpecimenId,
+                        onCheckedChange = null,
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = MaterialTheme.colors.successConfirm,
+                            uncheckedColor = MaterialTheme.colors.disabled
+                        )
+                    )
+                    Text(
+                        text = "Specimen ID",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (hasSpecimenId) MaterialTheme.colors.textPrimary else MaterialTheme.colors.textSecondary,
+                        modifier = Modifier.padding(start = MaterialTheme.dimensions.paddingSmall)
+                    )
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = hasSpecimenImage,
+                        onCheckedChange = null,
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = MaterialTheme.colors.successConfirm,
+                            uncheckedColor = MaterialTheme.colors.disabled
+                        )
+                    )
+                    Text(
+                        text = "Specimen",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (hasSpecimenImage) MaterialTheme.colors.textPrimary else MaterialTheme.colors.textSecondary,
+                        modifier = Modifier.padding(start = MaterialTheme.dimensions.paddingSmall)
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/ui/theme/Dimensions.kt
@@ -42,6 +42,7 @@ data class Dimensions(
     val iconSizeLarge: Dp = 24.dp,
     val iconSizeExtraLarge: Dp = 32.dp,
     val iconSizeExtraExtraLarge: Dp = 64.dp,
+    val iconSizeExtraExtraExtraLarge: Dp = 96.dp,
 
     // Corner Radii
     val cornerRadiusSmall: Dp = 8.dp,

--- a/app/src/main/java/com/vci/vectorcamapp/ui/theme/Type.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/ui/theme/Type.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.googlefonts.GoogleFont
 import androidx.compose.ui.unit.sp
 import com.vci.vectorcamapp.R
 
-val displayLargeSize = 28.sp
+val displayLargeSize = 44.sp
 val displayMediumSize = 24.sp
 val displaySmallSize = 22.sp
 val headlineLargeSize = 20.sp


### PR DESCRIPTION
This pull request introduces a new overlay to the camera preview for guiding specimen alignment, improves feedback for specimen ID correction errors, and makes related UI enhancements. The main changes are the addition of the `TrayAlignmentGuideOverlay` composable, passing specimen state to the camera preview, and updating UI dimensions for better visibility.

### UI Feature Additions

* Added a new composable `TrayAlignmentGuideOverlay` to visually guide users in aligning the specimen and its ID in the camera preview. The overlay displays dashed rectangles and icons when specimen ID or image is missing, along with a checklist for completion status. (`app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/TrayAlignmentGuideOverlay.kt`)
* Integrated `TrayAlignmentGuideOverlay` into `LiveCameraPreview`, passing specimen ID and inference results to control overlay visibility. (`app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt`)

### State and Error Handling

* Updated error handling in `ImagingViewModel`: if specimen ID correction fails, the specimen ID is reset to an empty string, ensuring the overlay prompts for missing information. (`app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt`)

### API and Data Flow Updates

* Modified `LiveCameraPreview` and its usages to accept and use a `specimenId` parameter, enabling the overlay to reflect current specimen state. (`app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt`, `app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt`) [[1]](diffhunk://#diff-c42c1e41059e3e561092771d258695fa91ec39dff24f0f8802d5fd785fc545a4R31) [[2]](diffhunk://#diff-11da20e3054bcf862de03eb30f8770056c03a74d9224972d82ec8ad0a3e9aff2R402)

### UI Dimension Enhancements

* Increased the font size for `displayLarge` typography to improve visibility of specimen ID in overlays. (`app/src/main/java/com/vci/vectorcamapp/ui/theme/Type.kt`)
* Added a new extra-extra-extra-large icon size to theme dimensions for future scalability. (`app/src/main/java/com/vci/vectorcamapp/ui/theme/Dimensions.kt`)