### PR TITLE
SOF-388: Fix incorrect description for the Pyrethrum Spray Catch in the the tooltip

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeScreen.kt
@@ -270,7 +270,7 @@ fun IntakeScreen(
                         )
                         CollectionMethodTooltipRow(
                             title = "CDC Light Trap",
-                            description = "A light trap that uses a battery to attract and collect mosquitoes during the night.",
+                            description = "A battery powered trap that uses a light to attract and collect mosquitoes at night.",
                             iconPainter = painterResource(id = R.drawable.ic_light_trap),
                             iconDescription = "CDC Light Trap Icon",
                         )
@@ -282,7 +282,7 @@ fun IntakeScreen(
                         )
                         CollectionMethodTooltipRow(
                             title = "Pyrethrum Spray Catch",
-                            description = "A battery powered trap that uses a light to attract and collect mosquitoes at night.",
+                            description = "An indoor collection method that uses insecticide spray to knock down resting mosquitoes onto a sheet.",
                             iconPainter = painterResource(id = R.drawable.ic_spray),
                             iconDescription = "Pyrethrum Spray Catch"
                         )


### PR DESCRIPTION
This pull request simply replaces an incorrect description for the Pyrethrum Spray Catch in `CollectionMethodTooltip` with the correct description. The previous description for the Pyrethrum Spray Catch was intended for the CDC Light Trap.

The pull request was tested on the Motorola.