### PR TITLE
SOF-389: Fix issue where the autofocus marker remains even after bounding box disappears

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/LiveCameraPreview.kt
@@ -108,12 +108,14 @@ fun LiveCameraPreview(
                     )
                     val dotColor = MaterialTheme.colors.warning
 
-                    Canvas(modifier = Modifier.fillMaxSize()) {
-                        drawCircle(
-                            color = dotColor,
-                            radius = DOT_RADIUS_DP.toPx(),
-                            center = centerPx
-                        )
+                    if (isManualFocusing || inferenceResults.isNotEmpty()) {
+                        Canvas(modifier = Modifier.fillMaxSize()) {
+                            drawCircle(
+                                color = dotColor,
+                                radius = DOT_RADIUS_DP.toPx(),
+                                center = centerPx
+                            )
+                        }
                     }
 
                     if (isManualFocusing) {


### PR DESCRIPTION
This pull request fixes an issue where the autofocus marker remains on the `LiveCameraPreview` even though `inferenceResults` is empty and `isManualFocusing` is false by adding an if condition. 

The pull request has been tested on a Motorola.

While this pull request addresses the issue from a UI perspective, it shows that the autofocus point is likely not set to `null` even when `inferenceResults` is empty and `isManualFocusing` is false. We may want to consider further exploring the issue.

 