### PR TITLE
SOF-392: Add intake case for missing collector and emit error for IntakeScreen validation

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/specimens/CompleteSessionSpecimens.kt
@@ -55,8 +55,8 @@ fun CompleteSessionSpecimens(
                     top = MaterialTheme.dimensions.spacingSmall
                 ),
                 isTooltipVisible = isSearchTooltipVisible,
-                onShowSearchTooltip = { onShowSearchTooltip },
-                onDismissSearchTooltip = { onDismissSearchTooltip }
+                onShowSearchTooltip = onShowSearchTooltip,
+                onDismissSearchTooltip = onDismissSearchTooltip,
             ) {
                 SearchHelpTooltipContent()
             }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/search/SearchTextField.kt
@@ -1,13 +1,16 @@
 package com.vci.vectorcamapp.core.presentation.search
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import com.vci.vectorcamapp.core.presentation.components.form.TextEntryField
 import com.vci.vectorcamapp.core.presentation.components.tooltip.Tooltip
+import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
 fun SearchTextField(
@@ -45,7 +48,7 @@ fun SearchTextField(
             onClick = onShowSearchTooltip,
             onDismiss = onDismissSearchTooltip,
             buttonText = "Tap to learn more about searching",
-            modifier = modifier
+            modifier = modifier.padding(bottom = MaterialTheme.dimensions.spacingExtraSmall)
         ) {
             tooltipContent()
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
@@ -89,8 +89,11 @@ fun Error.toString(context: Context): String {
         is IntakeError -> when (this) {
             IntakeError.SITE_NOT_FOUND -> R.string.intake_error_site_not_found
             IntakeError.PROGRAM_NOT_FOUND -> R.string.intake_error_missing_program_id
+            IntakeError.MISSING_COLLECTOR -> R.string.intake_error_missing_collector
+            IntakeError.COLLECTOR_SAVE_FAILED -> R.string.intake_error_collector_save_failed
             IntakeError.LOCATION_PERMISSION_DENIED -> R.string.intake_error_location_permission_denied
             IntakeError.LOCATION_GPS_TIMEOUT -> R.string.intake_error_location_gps_timeout
+            IntakeError.FORM_INVALID -> R.string.intake_error_form_invalid
             IntakeError.UNKNOWN_ERROR -> R.string.intake_error_unknown_error
         }
 

--- a/app/src/main/java/com/vci/vectorcamapp/intake/domain/util/IntakeError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/domain/util/IntakeError.kt
@@ -5,7 +5,10 @@ import com.vci.vectorcamapp.core.domain.util.Error
 enum class IntakeError : Error {
     SITE_NOT_FOUND,
     PROGRAM_NOT_FOUND,
+    MISSING_COLLECTOR,
+    COLLECTOR_SAVE_FAILED,
     LOCATION_PERMISSION_DENIED,
     LOCATION_GPS_TIMEOUT,
+    FORM_INVALID,
     UNKNOWN_ERROR;
 }

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -145,7 +145,14 @@ class IntakeViewModel @Inject constructor(
                         specimenConditionResult
                     ).any { it is Result.Error }
 
-                    if (!hasError) {
+                    if (hasError) {
+                        emitError(IntakeError.FORM_INVALID)
+                        return@launch
+                    }
+                    else if (state.value.isCurrentCollectorMissing) {
+                        emitError(IntakeError.COLLECTOR_SAVE_FAILED)
+                    }
+                    else {
                         val selectedSite = _state.value.allSitesInProgram.find {
                             it.district == _state.value.selectedDistrict &&
                                     it.villageName == _state.value.selectedVillageName &&
@@ -406,7 +413,8 @@ class IntakeViewModel @Inject constructor(
                 is IntakeAction.HideCollectionMethodTooltipDialog -> {
                     _state.update { it.copy(isCollectionMethodTooltipVisible = false) }
                 }
-                IntakeAction.RegisterMissingCollector -> {
+
+                is IntakeAction.RegisterMissingCollector -> {
                     val name = _state.value.session.collectorName
                     val title = _state.value.session.collectorTitle
                     val lastTrainedOn = _state.value.session.collectorLastTrainedOn
@@ -429,7 +437,7 @@ class IntakeViewModel @Inject constructor(
                             )
                         }
                     }.onError {
-                        emitError(IntakeError.UNKNOWN_ERROR)
+                        emitError(IntakeError.COLLECTOR_SAVE_FAILED)
                     }
                 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -147,10 +147,9 @@ class IntakeViewModel @Inject constructor(
 
                     if (hasError) {
                         emitError(IntakeError.FORM_INVALID)
-                        return@launch
                     }
                     else if (state.value.isCurrentCollectorMissing) {
-                        emitError(IntakeError.COLLECTOR_SAVE_FAILED)
+                        emitError(IntakeError.MISSING_COLLECTOR)
                     }
                     else {
                         val selectedSite = _state.value.allSitesInProgram.find {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,7 +146,7 @@
     <string name="intake_error_location_gps_timeout">GPS Timeout. Please move to a different location and try again.</string>
 
     <!-- Intake error: Missing collector -->
-    <string name="intake_error_missing_collector">Collector is missing.</string>
+    <string name="intake_error_missing_collector">Please select a registered collector.</string>
 
     <!-- Intake error: Collector save failed -->
     <string name="intake_error_collector_save_failed">Could not save collector. Please try again.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,7 +40,7 @@
     <!-- Network error: Unknown error -->
     <string name="network_error_unknown_error">An unknown error occurred. Please try again or contact support if the issue persists.</string>
 
-    <!-- Form validation error: Blank collector title -->
+    <!-- Form validation error: Blank collector -->
     <string name="form_validation_error_blank_collector">Collector is required.</string>
 
     <!-- Form validation error: Blank district -->
@@ -144,6 +144,15 @@
 
     <!-- Intake error: GPS timeout -->
     <string name="intake_error_location_gps_timeout">GPS Timeout. Please move to a different location and try again.</string>
+
+    <!-- Intake error: Missing collector -->
+    <string name="intake_error_missing_collector">Collector is missing.</string>
+
+    <!-- Intake error: Collector save failed -->
+    <string name="intake_error_collector_save_failed">Could not save collector. Please try again.</string>
+
+    <!-- Intake error: Form invalid -->
+    <string name="intake_error_form_invalid">One or more fields in this form are invalid.</string>
 
     <!-- Intake error: Unknown error -->
     <string name="intake_error_unknown_error">An unknown error occurred. Please try again or contact support if the issue persists.</string>


### PR DESCRIPTION
This pull request checks if `isCurrentCollectorMissing` is true when the user attempts to submit the Intake form and adds an `IntakeError` to prevent users from submitting the Intake form if the collector is missing. Furthermore, for UI clarity, the pull request also emits `ValidationErrors` and shows a `Snackbar` to inform the user that at least one field in the `IntakeScreen` form is invalid.

The pull request was tested on the Samsung A32.