### PR TITLE
SOF-380-temp: Decouple MetadataUploadWorker from ImageUploadWorker to make the upload process truly greedy.

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -185,7 +185,7 @@ class MetadataUploadWorker @AssistedInject constructor(
             }
 
             return if (hasFailure) {
-                retryOrFailure("Upload failed for one or more images.")
+                retryOrComplete()
             } else {
                 WorkerResult.success()
             }
@@ -213,6 +213,15 @@ class MetadataUploadWorker @AssistedInject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun retryOrComplete(): WorkerResult {
+        showUploadRetryNotification("Upload failed for one or more images.")
+        return if (runAttemptCount < MAX_RETRIES) {
+            WorkerResult.retry()
+        } else {
+            WorkerResult.success()
         }
     }
 


### PR DESCRIPTION
This pull request updates the upload retry logic in the `MetadataUploadWorker` to improve how failed uploads are handled. Instead of failing the worker after all retries are exhausted, it now marks the job as successful, ensuring the worker does not get stuck in a failed state.

**Changes to upload retry handling:**

* Changed the logic in `MetadataUploadWorker` so that after reaching the maximum number of retries, the worker returns `WorkerResult.success()` instead of `WorkerResult.failure()`, preventing persistent failures.
* Added a new helper function `retryOrComplete()` to encapsulate the updated retry logic and notification handling.