### PR TITLE
SOF-252: Unit tests - Complete Sessions Detail Screen

### DIFF
--- a/app/src/androidTest/java/com/vci/vectorcamapp/complete_session/presentation/CompleteSessionDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/vci/vectorcamapp/complete_session/presentation/CompleteSessionDetailsScreenTest.kt
@@ -1,0 +1,439 @@
+package com.vci.vectorcamapp.complete_session.presentation
+
+import android.net.Uri
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.vci.vectorcamapp.MainActivity
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsAction
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsScreen
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsState
+import com.vci.vectorcamapp.complete_session.details.presentation.enums.CompleteSessionDetailsTab
+import com.vci.vectorcamapp.core.domain.model.Session
+import com.vci.vectorcamapp.core.domain.model.Site
+import com.vci.vectorcamapp.core.domain.model.Specimen
+import com.vci.vectorcamapp.core.domain.model.SpecimenImage
+import com.vci.vectorcamapp.core.domain.model.SurveillanceForm
+import com.vci.vectorcamapp.core.domain.model.composites.SpecimenImageAndInferenceResult
+import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
+import com.vci.vectorcamapp.core.presentation.components.scaffold.BaseScaffold
+import com.vci.vectorcamapp.ui.theme.VectorcamappTheme
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.UUID
+
+@HiltAndroidTest
+class CompleteSessionDetailsScreenTest {
+
+    private lateinit var navController: TestNavHostController
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        navController = TestNavHostController(ApplicationProvider.getApplicationContext()).apply {
+            navigatorProvider.addNavigator(ComposeNavigator())
+        }
+    }
+
+    // ========================================
+    // Test Harness / Helpers
+    // ========================================
+
+    private object TestDestinations {
+        const val Details = "details"
+        const val List = "list"
+    }
+
+    private fun makeSession(): Session {
+        val now = System.currentTimeMillis()
+        return Session(
+            localId = UUID.randomUUID(),
+            remoteId = 101,
+            hardwareId = "TEST-HW-123",
+            collectorTitle = "Dr.",
+            collectorName = "Jane Doe",
+            collectorLastTrainedOn = now,
+            collectionDate = now,
+            collectionMethod = "HLC",
+            specimenCondition = "Fresh",
+            createdAt = now,
+            completedAt = now + 3600000,
+            submittedAt = null,
+            notes = "Test notes for session.",
+            latitude = 0.0f,
+            longitude = 0.0f,
+            type = SessionType.SURVEILLANCE
+        )
+    }
+
+    private fun makeSite(): Site {
+        return Site(
+            id = 1,
+            district = "Test District",
+            subCounty = "Test SubCounty",
+            parish = "Test Parish",
+            villageName = "Test Village",
+            houseNumber = "H-101",
+            healthCenter = "Test HC",
+            isActive = true
+        )
+    }
+
+    private fun makeSurveillanceForm(): SurveillanceForm {
+        return SurveillanceForm(
+            numPeopleSleptInHouse = 5,
+            wasIrsConducted = true,
+            monthsSinceIrs = 3,
+            numLlinsAvailable = 2,
+            llinType = "Test Type",
+            llinBrand = "Test Brand",
+            numPeopleSleptUnderLlin = 4,
+            submittedAt = System.currentTimeMillis()
+        )
+    }
+
+    private fun makeSpecimens(count: Int): List<SpecimenWithSpecimenImagesAndInferenceResults> {
+        return (1..count).map { index ->
+            val specimenId = "SPEC-$index"
+            val specimen = Specimen(
+                id = specimenId,
+                remoteId = index,
+                shouldProcessFurther = true
+            )
+            val image = SpecimenImage(
+                localId = UUID.randomUUID().toString(),
+                remoteId = index,
+                species = "Anopheles gambiae",
+                sex = "Female",
+                abdomenStatus = "Fed",
+                imageUri = Uri.parse("file://test/uri/$index"),
+                metadataUploadStatus = UploadStatus.COMPLETED,
+                imageUploadStatus = UploadStatus.COMPLETED,
+                capturedAt = System.currentTimeMillis(),
+                submittedAt = System.currentTimeMillis()
+            )
+            SpecimenWithSpecimenImagesAndInferenceResults(
+                specimen = specimen,
+                specimenImagesAndInferenceResults = listOf(
+                    SpecimenImageAndInferenceResult(
+                        specimenImage = image,
+                        inferenceResult = null
+                    )
+                )
+            )
+        }
+    }
+
+    private fun launchCompleteSessionDetailsScreen(
+        initialState: CompleteSessionDetailsState
+    ) {
+        composeRule.activity.setContent {
+            var state by remember { mutableStateOf(initialState) }
+
+            VectorcamappTheme {
+                NavHost(
+                    navController = navController,
+                    startDestination = TestDestinations.Details
+                ) {
+                    composable(TestDestinations.Details) {
+                        BaseScaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                            CompleteSessionDetailsScreen(
+                                state = state,
+                                onAction = { action ->
+                                    when (action) {
+                                        is CompleteSessionDetailsAction.ReturnToCompleteSessionListScreen -> {
+                                            navController.navigate(TestDestinations.List)
+                                        }
+
+                                        is CompleteSessionDetailsAction.ChangeSelectedTab -> {
+                                            state = state.copy(selectedTab = action.selectedTab)
+                                        }
+
+                                        is CompleteSessionDetailsAction.UpdateSearchQuery -> {
+                                            state = state.copy(searchQuery = action.searchQuery)
+                                        }
+
+                                        CompleteSessionDetailsAction.ShowSearchTooltipDialog -> {
+                                            state = state.copy(isSearchTooltipVisible = true)
+                                        }
+
+                                        CompleteSessionDetailsAction.HideSearchTooltipDialog -> {
+                                            state = state.copy(isSearchTooltipVisible = false)
+                                        }
+                                    }
+                                },
+                                modifier = Modifier.padding(innerPadding)
+                            )
+                        }
+                    }
+                    composable(TestDestinations.List) { }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun assertOnDetails() {
+        composeRule.waitForIdle()
+        assertThat(navController.currentDestination?.route).isEqualTo(TestDestinations.Details)
+    }
+
+    private fun assertOnList() {
+        composeRule.waitForIdle()
+        assertThat(navController.currentDestination?.route).isEqualTo(TestDestinations.List)
+    }
+
+    // ========================================
+    // A. Static UI & Header
+    // ========================================
+
+    @Test
+    fun cplUi_a01_headersAndBackVisibleOnInitialRender() {
+        val session = makeSession()
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = makeSite()
+            )
+        )
+
+        composeRule.onNodeWithText("Session Information").assertIsDisplayed()
+        composeRule.onNodeWithText("ID: ${session.localId}").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Back Button").assertIsDisplayed()
+
+        composeRule.onNodeWithText(CompleteSessionDetailsTab.SESSION_FORM.label).assertIsDisplayed()
+        composeRule.onNodeWithText(CompleteSessionDetailsTab.SESSION_SPECIMENS.label).assertIsDisplayed()
+    }
+
+    // ========================================
+    // B. Form Tab (Default) Rendering
+    // ========================================
+
+    @Test
+    fun cplUi_b01_formTab_showsSessionStatusAndGeneralInfo() {
+        val session = makeSession()
+        val site = makeSite()
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = site,
+                selectedTab = CompleteSessionDetailsTab.SESSION_FORM
+            )
+        )
+
+        composeRule.onNodeWithText("Session Status", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+
+        val dateFormat = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
+        composeRule.onNodeWithText("Collection Date: ${dateFormat.format(session.collectionDate)}", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+
+        composeRule.onNodeWithText("General Information", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Collector: ${session.collectorName}, ${session.collectorTitle}", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+    }
+
+    @Test
+    fun cplUi_b02_formTab_showsGeographicalAndSurveillanceInfo() {
+        val session = makeSession()
+        val site = makeSite()
+        val surveillance = makeSurveillanceForm()
+
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = site,
+                surveillanceForm = surveillance,
+                selectedTab = CompleteSessionDetailsTab.SESSION_FORM
+            )
+        )
+
+        composeRule.onNodeWithText("Geographical Information", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("District: ${site.district}", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Village Name: ${site.villageName}", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+
+        composeRule.onNodeWithText("Surveillance Form", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Number of People who Slept in the House: ${surveillance.numPeopleSleptInHouse}", useUnmergedTree = true)
+            .performScrollTo().assertIsDisplayed()
+    }
+
+    // ========================================
+    // C. Tab Interactions
+    // ========================================
+
+    @Test
+    fun cplUi_c01_switchingTabsChangesContent() {
+        val session = makeSession()
+        val site = makeSite()
+
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = site,
+                selectedTab = CompleteSessionDetailsTab.SESSION_FORM
+            )
+        )
+
+        composeRule.onNodeWithText("Geographical Information", useUnmergedTree = true).assertExists()
+
+        composeRule.onNodeWithText(CompleteSessionDetailsTab.SESSION_SPECIMENS.label).performClick()
+
+        composeRule.onNodeWithText("Geographical Information").assertDoesNotExist()
+
+        composeRule.onNodeWithText("No specimens were captured during this session.").assertIsDisplayed()
+    }
+
+    // ========================================
+    // D. Specimens Tab Rendering
+    // ========================================
+
+    @Test
+    fun cplUi_d01_specimensTab_emptyState() {
+        val session = makeSession()
+        val site = makeSite()
+
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = site,
+                specimensWithImagesAndInferenceResults = emptyList(),
+                selectedTab = CompleteSessionDetailsTab.SESSION_SPECIMENS
+            )
+        )
+
+        composeRule.onNodeWithText("No specimens were captured during this session.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun cplUi_d02_specimensTab_showsSpecimenTiles() {
+        val session = makeSession()
+        val site = makeSite()
+        val specimens = makeSpecimens(3)
+
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = site,
+                specimensWithImagesAndInferenceResults = specimens,
+                selectedTab = CompleteSessionDetailsTab.SESSION_SPECIMENS
+            )
+        )
+
+        val newestSpecimenId = specimens.last().specimen.id
+
+        composeRule.onNodeWithText("Specimen ID: $newestSpecimenId", useUnmergedTree = true)
+            .performScrollTo()
+            .assertExists()
+
+        val species = specimens.last().specimenImagesAndInferenceResults.first().specimenImage.species
+        composeRule.onAllNodesWithText("Species: $species", useUnmergedTree = true)
+            .onFirst()
+            .assertExists()
+    }
+
+    @Test
+    fun cplUi_d03_specimenBadgeShowsCorrectCount() {
+        val session = makeSession()
+        val specimens = makeSpecimens(1)
+
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = makeSite(),
+                specimensWithImagesAndInferenceResults = specimens,
+                selectedTab = CompleteSessionDetailsTab.SESSION_SPECIMENS
+            )
+        )
+
+        composeRule.onNodeWithText("1 of 1", useUnmergedTree = true)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    // ========================================
+    // E. Interactions - Search
+    // ========================================
+
+    @Test
+    fun cplUi_e01_searchBarInputUpdatesState() {
+        val session = makeSession()
+        val site = makeSite()
+        val specimens = makeSpecimens(1)
+
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = site,
+                specimensWithImagesAndInferenceResults = specimens,
+                selectedTab = CompleteSessionDetailsTab.SESSION_SPECIMENS
+            )
+        )
+
+        val searchText = "SPEC-1"
+        composeRule.onNodeWithText("Search by specimen ID, species, etc.")
+            .performTextInput(searchText)
+
+        composeRule.onNodeWithText(searchText).assertIsDisplayed()
+    }
+
+    // ========================================
+    // F. Interactions - Navigation
+    // ========================================
+
+    @Test
+    fun cplUi_f01_backNavigatesToList() {
+        val session = makeSession()
+        launchCompleteSessionDetailsScreen(
+            CompleteSessionDetailsState(
+                session = session,
+                site = makeSite()
+            )
+        )
+
+        assertOnDetails()
+        composeRule.onNodeWithContentDescription("Back Button")
+            .assertHasClickAction()
+            .performClick()
+        assertOnList()
+    }
+}

--- a/app/src/test/java/com/vci/vectorcamapp/complete_session/presentation/CompleteSessionDetailsViewModelTest.kt
+++ b/app/src/test/java/com/vci/vectorcamapp/complete_session/presentation/CompleteSessionDetailsViewModelTest.kt
@@ -1,0 +1,348 @@
+package com.vci.vectorcamapp.complete_session.presentation
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.vci.vectorcamapp.complete_session.details.domain.util.CompleteSessionDetailsError
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsAction
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsEvent
+import com.vci.vectorcamapp.complete_session.details.presentation.CompleteSessionDetailsViewModel
+import com.vci.vectorcamapp.complete_session.details.presentation.enums.CompleteSessionDetailsTab
+import com.vci.vectorcamapp.core.domain.model.Session
+import com.vci.vectorcamapp.core.domain.model.Site
+import com.vci.vectorcamapp.core.domain.model.Specimen
+import com.vci.vectorcamapp.core.domain.model.SpecimenImage
+import com.vci.vectorcamapp.core.domain.model.composites.SessionAndSite
+import com.vci.vectorcamapp.core.domain.model.composites.SessionAndSurveillanceForm
+import com.vci.vectorcamapp.core.domain.model.composites.SpecimenImageAndInferenceResult
+import com.vci.vectorcamapp.core.domain.model.composites.SpecimenWithSpecimenImagesAndInferenceResults
+import com.vci.vectorcamapp.core.domain.model.enums.SessionType
+import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
+import com.vci.vectorcamapp.core.domain.repository.SessionRepository
+import com.vci.vectorcamapp.core.domain.repository.SpecimenRepository
+import com.vci.vectorcamapp.core.presentation.util.error.ErrorMessageBus
+import com.vci.vectorcamapp.core.presentation.util.search.SearchUtils
+import com.vci.vectorcamapp.core.rules.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CompleteSessionDetailsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var context: Context
+    private lateinit var savedStateHandle: SavedStateHandle
+    private lateinit var sessionRepository: SessionRepository
+    private lateinit var specimenRepository: SpecimenRepository
+    private lateinit var viewModel: CompleteSessionDetailsViewModel
+
+    private lateinit var specimensFlow: MutableStateFlow<List<SpecimenWithSpecimenImagesAndInferenceResults>>
+
+    private val testSessionId = UUID.randomUUID()
+
+    @Before
+    fun setUp() {
+        mockkStatic(Uri::class)
+        mockkStatic(Log::class)
+        mockkStatic(SearchUtils::class)
+        mockkObject(SearchUtils)
+        mockkObject(ErrorMessageBus)
+        coEvery { ErrorMessageBus.emit(any(), any()) } returns Unit
+        every { Uri.parse(any()) } answers { mockk(relaxed = true) }
+        every { Log.e(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+
+        every { SearchUtils.matchesQuery(any(), any<List<String?>>()) } returns true
+
+        context = mockk(relaxed = true)
+        every { context.getString(any()) } returns "MockString"
+
+        sessionRepository = mockk()
+        specimenRepository = mockk()
+
+        savedStateHandle = SavedStateHandle().apply {
+            set("sessionId", testSessionId.toString())
+        }
+
+        specimensFlow = MutableStateFlow(emptyList())
+        every { specimenRepository.observeSpecimenImagesAndInferenceResultsBySession(any()) } returns specimensFlow
+
+        val session = makeSession()
+        val site = makeSite()
+        coEvery { sessionRepository.getSessionAndSiteById(testSessionId) } returns SessionAndSite(session, site)
+        coEvery { sessionRepository.getSessionAndSurveillanceFormById(testSessionId) } returns SessionAndSurveillanceForm(session, null)
+
+        viewModel = CompleteSessionDetailsViewModel(
+            context = context,
+            savedStateHandle = savedStateHandle,
+            sessionRepository = sessionRepository,
+            specimenRepository = specimenRepository
+        )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("android.net.Uri")
+        unmockkStatic("android.util.Log")
+        unmockkStatic(SearchUtils::class)
+        unmockkObject(ErrorMessageBus)
+    }
+
+    // ========================================
+    // Test Harness / Helpers
+    // ========================================
+
+    private fun makeSession() = Session(
+        localId = testSessionId,
+        remoteId = 123,
+        hardwareId = "HW-TEST",
+        collectorTitle = "Mr.",
+        collectorName = "John",
+        collectorLastTrainedOn = 0L,
+        collectionDate = 1000L,
+        collectionMethod = "Trap",
+        specimenCondition = "Good",
+        createdAt = 1000L,
+        completedAt = 2000L,
+        submittedAt = null,
+        notes = "Notes",
+        latitude = 1.0f,
+        longitude = 1.0f,
+        type = SessionType.SURVEILLANCE
+    )
+
+    private fun makeSite() = Site(
+        id = 1,
+        district = "D1",
+        subCounty = "SC1",
+        parish = "P1",
+        villageName = "V1",
+        houseNumber = "H1",
+        healthCenter = "HC1",
+        isActive = true
+    )
+
+    private fun makeSpecimenWithImage(id: String): SpecimenWithSpecimenImagesAndInferenceResults {
+        val specimen = Specimen(id = id, remoteId = null, shouldProcessFurther = true)
+        val image = SpecimenImage(
+            localId = UUID.randomUUID().toString(),
+            remoteId = null,
+            species = "Anopheles",
+            sex = "Female",
+            abdomenStatus = "Fed",
+            imageUri = Uri.parse("file://test"),
+            metadataUploadStatus = UploadStatus.COMPLETED,
+            imageUploadStatus = UploadStatus.COMPLETED,
+            capturedAt = 1000L,
+            submittedAt = null
+        )
+        return SpecimenWithSpecimenImagesAndInferenceResults(
+            specimen = specimen,
+            specimenImagesAndInferenceResults = listOf(
+                SpecimenImageAndInferenceResult(image, null)
+            )
+        )
+    }
+
+    // ========================================
+    // A. Initialization & Loading
+    // ========================================
+
+    @Test
+    fun cplVm_a01_initialization_loadsSessionSiteAndSpecimens() = runTest {
+        val specimens = listOf(makeSpecimenWithImage("SPEC-1"))
+        specimensFlow.value = specimens
+
+        viewModel.state.test {
+            awaitItem()
+
+            advanceUntilIdle()
+
+            val loadedState = awaitItem()
+
+            assertThat(loadedState.session.localId).isEqualTo(testSessionId)
+            assertThat(loadedState.site.district).isEqualTo("D1")
+
+            assertThat(loadedState.specimensWithImagesAndInferenceResults).hasSize(1)
+            assertThat(loadedState.specimensWithImagesAndInferenceResults.first().specimen.id).isEqualTo("SPEC-1")
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        coVerify(exactly = 1) { sessionRepository.getSessionAndSiteById(testSessionId) }
+    }
+
+    @Test
+    fun cplVm_a02_initialization_missingSessionId_emitsError() = runTest {
+        savedStateHandle = SavedStateHandle()
+        viewModel = CompleteSessionDetailsViewModel(
+            context,
+            savedStateHandle,
+            sessionRepository,
+            specimenRepository
+        )
+
+        viewModel.state.test {
+            awaitItem()
+            advanceUntilIdle()
+            expectNoEvents()
+        }
+
+        coVerify(exactly = 1) { ErrorMessageBus.emit(CompleteSessionDetailsError.SESSION_NOT_FOUND, any()) }
+    }
+
+    @Test
+    fun cplVm_a03_initialization_sessionNotFoundInRepo_emitsError() = runTest {
+        coEvery { sessionRepository.getSessionAndSiteById(testSessionId) } returns null
+
+        viewModel.state.test {
+            awaitItem()
+            advanceUntilIdle()
+            expectNoEvents()
+        }
+
+        coVerify(exactly = 1) { ErrorMessageBus.emit(CompleteSessionDetailsError.SESSION_NOT_FOUND, any()) }
+    }
+
+    @Test
+    fun cplVm_a04_initialization_siteNotFoundInRepo_emitsError() = runTest {
+        val validSession = makeSession()
+
+        val mockComposite = mockk<SessionAndSite>()
+        every { mockComposite.session } returns validSession
+        every { mockComposite.site } answers { unsafeNull() }
+
+        coEvery { sessionRepository.getSessionAndSiteById(testSessionId) } returns mockComposite
+
+        viewModel.state.test {
+            awaitItem()
+            advanceUntilIdle()
+            expectNoEvents()
+        }
+
+        coVerify(exactly = 1) { ErrorMessageBus.emit(CompleteSessionDetailsError.SITE_NOT_FOUND, any()) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> unsafeNull(): T = null as T
+
+    // ========================================
+    // B. Search & Filtering
+    // ========================================
+
+    @Test
+    fun cplVm_b01_searchQuery_updatesState_andFiltersSpecimens() = runTest {
+        val s1 = makeSpecimenWithImage("MATCH")
+        val s2 = makeSpecimenWithImage("NOPE")
+        specimensFlow.value = listOf(s1, s2)
+
+        every { SearchUtils.matchesQuery(eq("query"), any<List<String?>>()) } answers {
+            val fields = secondArg<List<String?>>()
+            fields.contains("MATCH")
+        }
+
+        viewModel.state.test {
+            awaitItem()
+            advanceUntilIdle()
+            awaitItem()
+
+            viewModel.onAction(CompleteSessionDetailsAction.UpdateSearchQuery("query"))
+
+            val searchState = awaitItem()
+            assertThat(searchState.searchQuery).isEqualTo("query")
+            assertThat(searchState.specimensWithImagesAndInferenceResults).hasSize(1)
+            assertThat(searchState.specimensWithImagesAndInferenceResults.first().specimen.id).isEqualTo("MATCH")
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun cplVm_b02_emptySearchQuery_showsAllSpecimens() = runTest {
+        val s1 = makeSpecimenWithImage("A")
+        val s2 = makeSpecimenWithImage("B")
+        specimensFlow.value = listOf(s1, s2)
+
+        viewModel.state.test {
+            awaitItem()
+            advanceUntilIdle()
+            val loaded = awaitItem()
+            assertThat(loaded.specimensWithImagesAndInferenceResults).hasSize(2)
+
+            viewModel.onAction(CompleteSessionDetailsAction.UpdateSearchQuery("   "))
+            val blankState = awaitItem()
+            assertThat(blankState.searchQuery).isEqualTo("   ")
+            assertThat(blankState.specimensWithImagesAndInferenceResults).hasSize(2)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ========================================
+    // C. Tabs & UI State
+    // ========================================
+
+    @Test
+    fun cplVm_c01_changeSelectedTab_updatesState() = runTest {
+        viewModel.state.test {
+            val initial = awaitItem()
+            assertThat(initial.selectedTab).isEqualTo(CompleteSessionDetailsTab.SESSION_FORM)
+
+            viewModel.onAction(CompleteSessionDetailsAction.ChangeSelectedTab(CompleteSessionDetailsTab.SESSION_SPECIMENS))
+
+            val updated = awaitItem()
+            assertThat(updated.selectedTab).isEqualTo(CompleteSessionDetailsTab.SESSION_SPECIMENS)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun cplVm_c02_tooltipDialogs_updateState() = runTest {
+        viewModel.state.test {
+            val initial = awaitItem()
+            assertThat(initial.isSearchTooltipVisible).isFalse()
+
+            viewModel.onAction(CompleteSessionDetailsAction.ShowSearchTooltipDialog)
+            assertThat(awaitItem().isSearchTooltipVisible).isTrue()
+
+            viewModel.onAction(CompleteSessionDetailsAction.HideSearchTooltipDialog)
+            assertThat(awaitItem().isSearchTooltipVisible).isFalse()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ========================================
+    // D. Navigation
+    // ========================================
+
+    @Test
+    fun cplVm_d01_returnToList_emitsNavigateEvent() = runTest {
+        viewModel.events.test {
+            viewModel.onAction(CompleteSessionDetailsAction.ReturnToCompleteSessionListScreen)
+            val event = awaitItem()
+            assertThat(event).isEqualTo(CompleteSessionDetailsEvent.NavigateBackToCompleteSessionListScreen)
+            expectNoEvents()
+        }
+    }
+}


### PR DESCRIPTION
This PR implements unit tests and instrumental tests for the complete session screen. It covered cases like normal happy route (normal workflow) and error cases. Testers should run the tests locally to ensure that the tests would pass.