### PR TITLE
SOF-432: Implement expected specimens and images columns

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
         // Uganda is listed first to be the default flavor
         create("uganda") {
             dimension = "region"
-            applicationIdSuffix = ".uganda"
+            //applicationIdSuffix = ".uganda"
             versionCode = 2007
             versionName = "1.0.7"
             

--- a/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/25.json
+++ b/app/schemas/com.vci.vectorcamapp.core.data.room.VectorCamDatabase/25.json
@@ -1,0 +1,799 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 25,
+    "identityHash": "b6955094ee25b1905beb70e599e986e2",
+    "entities": [
+      {
+        "tableName": "collector",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `title` TEXT NOT NULL, `lastTrainedOn` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTrainedOn",
+            "columnName": "lastTrainedOn",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "program",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `country` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_program_country",
+            "unique": false,
+            "columnNames": [
+              "country"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_program_country` ON `${TABLE_NAME}` (`country`)"
+          }
+        ]
+      },
+      {
+        "tableName": "location_type",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `programId` INTEGER NOT NULL, `name` TEXT NOT NULL, `level` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`programId`) REFERENCES `program`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "programId",
+            "columnName": "programId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_location_type_programId",
+            "unique": false,
+            "columnNames": [
+              "programId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_type_programId` ON `${TABLE_NAME}` (`programId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "program",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "programId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "site",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `programId` INTEGER NOT NULL, `district` TEXT, `subCounty` TEXT, `parish` TEXT, `villageName` TEXT, `houseNumber` TEXT, `healthCenter` TEXT, `isActive` INTEGER NOT NULL, `locationTypeId` INTEGER, `parentId` INTEGER, `name` TEXT, `locationHierarchy` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`programId`) REFERENCES `program`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`locationTypeId`) REFERENCES `location_type`(`id`) ON UPDATE CASCADE ON DELETE CASCADE , FOREIGN KEY(`parentId`) REFERENCES `site`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "programId",
+            "columnName": "programId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subCounty",
+            "columnName": "subCounty",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parish",
+            "columnName": "parish",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "villageName",
+            "columnName": "villageName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "houseNumber",
+            "columnName": "houseNumber",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "healthCenter",
+            "columnName": "healthCenter",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationTypeId",
+            "columnName": "locationTypeId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "locationHierarchy",
+            "columnName": "locationHierarchy",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_site_programId",
+            "unique": false,
+            "columnNames": [
+              "programId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_site_programId` ON `${TABLE_NAME}` (`programId`)"
+          },
+          {
+            "name": "index_site_locationTypeId",
+            "unique": false,
+            "columnNames": [
+              "locationTypeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_site_locationTypeId` ON `${TABLE_NAME}` (`locationTypeId`)"
+          },
+          {
+            "name": "index_site_parentId",
+            "unique": false,
+            "columnNames": [
+              "parentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_site_parentId` ON `${TABLE_NAME}` (`parentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "program",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "programId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "location_type",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "locationTypeId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "site",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "parentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `siteId` INTEGER NOT NULL, `remoteId` INTEGER, `hardwareId` TEXT, `collectorTitle` TEXT NOT NULL, `collectorName` TEXT NOT NULL, `collectorLastTrainedOn` INTEGER NOT NULL, `collectionDate` INTEGER NOT NULL, `collectionMethod` TEXT NOT NULL, `specimenCondition` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `completedAt` INTEGER, `submittedAt` INTEGER, `notes` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `type` TEXT NOT NULL, `expectedSpecimens` INTEGER NOT NULL, PRIMARY KEY(`localId`), FOREIGN KEY(`siteId`) REFERENCES `site`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "siteId",
+            "columnName": "siteId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "hardwareId",
+            "columnName": "hardwareId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "collectorTitle",
+            "columnName": "collectorTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorName",
+            "columnName": "collectorName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorLastTrainedOn",
+            "columnName": "collectorLastTrainedOn",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionDate",
+            "columnName": "collectionDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectionMethod",
+            "columnName": "collectionMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenCondition",
+            "columnName": "specimenCondition",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedSpecimens",
+            "columnName": "expectedSpecimens",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_session_completedAt",
+            "unique": false,
+            "columnNames": [
+              "completedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_completedAt` ON `${TABLE_NAME}` (`completedAt`)"
+          },
+          {
+            "name": "index_session_siteId",
+            "unique": false,
+            "columnNames": [
+              "siteId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_siteId` ON `${TABLE_NAME}` (`siteId`)"
+          },
+          {
+            "name": "index_session_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_type` ON `${TABLE_NAME}` (`type`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "site",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "siteId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `shouldProcessFurther` INTEGER NOT NULL, `expectedImages` INTEGER NOT NULL, PRIMARY KEY(`id`, `sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shouldProcessFurther",
+            "columnName": "shouldProcessFurther",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedImages",
+            "columnName": "expectedImages",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "sessionId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "specimen_image",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` TEXT NOT NULL, `specimenId` TEXT NOT NULL, `sessionId` TEXT NOT NULL, `remoteId` INTEGER, `species` TEXT, `sex` TEXT, `abdomenStatus` TEXT, `imageUri` TEXT NOT NULL, `metadataUploadStatus` TEXT NOT NULL, `imageUploadStatus` TEXT NOT NULL, `capturedAt` INTEGER NOT NULL, `submittedAt` INTEGER, PRIMARY KEY(`localId`), FOREIGN KEY(`specimenId`, `sessionId`) REFERENCES `specimen`(`id`, `sessionId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "localId",
+            "columnName": "localId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "specimenId",
+            "columnName": "specimenId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "species",
+            "columnName": "species",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sex",
+            "columnName": "sex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatus",
+            "columnName": "abdomenStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUri",
+            "columnName": "imageUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadataUploadStatus",
+            "columnName": "metadataUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUploadStatus",
+            "columnName": "imageUploadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "capturedAt",
+            "columnName": "capturedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "localId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_specimen_image_specimenId_sessionId",
+            "unique": false,
+            "columnNames": [
+              "specimenId",
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_specimen_image_specimenId_sessionId` ON `${TABLE_NAME}` (`specimenId`, `sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "specimen",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenId",
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id",
+              "sessionId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "inference_result",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`specimenImageId` TEXT NOT NULL, `bboxTopLeftX` REAL NOT NULL, `bboxTopLeftY` REAL NOT NULL, `bboxWidth` REAL NOT NULL, `bboxHeight` REAL NOT NULL, `bboxConfidence` REAL NOT NULL, `bboxClassId` INTEGER NOT NULL, `speciesLogits` TEXT, `sexLogits` TEXT, `abdomenStatusLogits` TEXT, `bboxDetectionDuration` INTEGER NOT NULL, `speciesInferenceDuration` INTEGER, `sexInferenceDuration` INTEGER, `abdomenStatusInferenceDuration` INTEGER, PRIMARY KEY(`specimenImageId`), FOREIGN KEY(`specimenImageId`) REFERENCES `specimen_image`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "specimenImageId",
+            "columnName": "specimenImageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftX",
+            "columnName": "bboxTopLeftX",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxTopLeftY",
+            "columnName": "bboxTopLeftY",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxWidth",
+            "columnName": "bboxWidth",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxHeight",
+            "columnName": "bboxHeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxConfidence",
+            "columnName": "bboxConfidence",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bboxClassId",
+            "columnName": "bboxClassId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speciesLogits",
+            "columnName": "speciesLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sexLogits",
+            "columnName": "sexLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "abdomenStatusLogits",
+            "columnName": "abdomenStatusLogits",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bboxDetectionDuration",
+            "columnName": "bboxDetectionDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speciesInferenceDuration",
+            "columnName": "speciesInferenceDuration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sexInferenceDuration",
+            "columnName": "sexInferenceDuration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "abdomenStatusInferenceDuration",
+            "columnName": "abdomenStatusInferenceDuration",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "specimenImageId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "specimen_image",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "specimenImageId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "surveillance_form",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `numPeopleSleptInHouse` INTEGER NOT NULL, `wasIrsConducted` INTEGER NOT NULL, `monthsSinceIrs` INTEGER, `numLlinsAvailable` INTEGER NOT NULL, `llinType` TEXT, `llinBrand` TEXT, `numPeopleSleptUnderLlin` INTEGER, `submittedAt` INTEGER, PRIMARY KEY(`sessionId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`localId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeopleSleptInHouse",
+            "columnName": "numPeopleSleptInHouse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wasIrsConducted",
+            "columnName": "wasIrsConducted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monthsSinceIrs",
+            "columnName": "monthsSinceIrs",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "numLlinsAvailable",
+            "columnName": "numLlinsAvailable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "llinType",
+            "columnName": "llinType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "llinBrand",
+            "columnName": "llinBrand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "numPeopleSleptUnderLlin",
+            "columnName": "numPeopleSleptUnderLlin",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "submittedAt",
+            "columnName": "submittedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sessionId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "localId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b6955094ee25b1905beb70e599e986e2')"
+    ]
+  }
+}

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsState.kt
@@ -27,6 +27,7 @@ data class CompleteSessionDetailsState(
         latitude = null,
         longitude = null,
         type = SessionType.SURVEILLANCE,
+        expectedSpecimens = 0
     ),
     val site: Site = Site(
         id = -1,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/CurrentSessionCacheImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/CurrentSessionCacheImplementation.kt
@@ -30,6 +30,7 @@ class CurrentSessionCacheImplementation @Inject constructor(
                 latitude = session.latitude,
                 longitude = session.longitude,
                 type = session.type,
+                expectedSpecimens = session.expectedSpecimens
             )
         }
     }
@@ -56,6 +57,7 @@ class CurrentSessionCacheImplementation @Inject constructor(
                 latitude = currentSessionCacheDto.latitude,
                 longitude = currentSessionCacheDto.longitude,
                 type = currentSessionCacheDto.type,
+                expectedSpecimens = currentSessionCacheDto.expectedSpecimens
             )
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/cache/CurrentSessionCacheDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/cache/CurrentSessionCacheDto.kt
@@ -27,6 +27,7 @@ data class CurrentSessionCacheDto(
     val longitude: Float? = null,
     @Serializable(with = SessionTypeSerializer::class)
     val type: SessionType = SessionType.SURVEILLANCE,
+    val expectedSpecimens: Int = 0
 ) {
     fun isEmpty() = localId == UUID(0, 0) && createdAt == 0L
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
@@ -24,6 +24,7 @@ data class PostSessionRequestDto(
     val longitude: Float? = null,
     @Serializable(with = SessionTypeSerializer::class)
     val type: SessionType = SessionType.SURVEILLANCE,
+    val expectedSpecimens: Int = 0,
     val siteId: Int = -1,
     val deviceId: Int = -1,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionDto.kt
@@ -26,6 +26,7 @@ data class SessionDto(
     val longitude: Float? = null,
     @Serializable(with = SessionTypeSerializer::class)
     val type: SessionType = SessionType.SURVEILLANCE,
+    val expectedSpecimens: Int = 0,
     val siteId: Int = -1,
     val deviceId: Int = -1,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PostSpecimenRequestDto(
     val specimenId: String = "",
-    val shouldProcessFurther: Boolean = false
+    val shouldProcessFurther: Boolean = false,
+    val expectedImages: Int = 0,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
@@ -7,5 +7,6 @@ data class SpecimenDto(
     val id: Int? = null,
     val specimenId: String = "",
     val sessionId: Int = -1,
-    val shouldProcessFurther: Boolean = false
+    val shouldProcessFurther: Boolean = false,
+    val expectedImages: Int = 0
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SessionMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SessionMapper.kt
@@ -21,6 +21,7 @@ fun SessionEntity.toDomain(): Session {
         latitude = this.latitude,
         longitude = this.longitude,
         type = this.type,
+        expectedSpecimens = this.expectedSpecimens
     )
 }
 
@@ -43,5 +44,6 @@ fun Session.toEntity(siteId: Int): SessionEntity {
         latitude = this.latitude,
         longitude = this.longitude,
         type = this.type,
+        expectedSpecimens = this.expectedSpecimens
     )
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenMapper.kt
@@ -8,7 +8,8 @@ fun SpecimenEntity.toDomain(): Specimen {
     return Specimen(
         id = this.id,
         remoteId = this.remoteId,
-        shouldProcessFurther = this.shouldProcessFurther
+        shouldProcessFurther = this.shouldProcessFurther,
+        expectedImages = this.expectedImages
     )
 }
 
@@ -17,6 +18,7 @@ fun Specimen.toEntity(sessionId: UUID): SpecimenEntity {
         id = this.id,
         sessionId = sessionId,
         remoteId = this.remoteId,
-        shouldProcessFurther = this.shouldProcessFurther
+        shouldProcessFurther = this.shouldProcessFurther,
+        expectedImages = this.expectedImages
     )
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
@@ -51,6 +51,7 @@ class RemoteSessionDataSource @Inject constructor(
                         latitude = session.latitude,
                         longitude = session.longitude,
                         type = session.type,
+                        expectedSpecimens = session.expectedSpecimens,
                         siteId = siteId,
                         deviceId = deviceId,
                     )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
@@ -33,7 +33,8 @@ class RemoteSpecimenDataSource @Inject constructor(
                 setBody(
                     PostSpecimenRequestDto(
                         specimenId = specimen.id,
-                        shouldProcessFurther = specimen.shouldProcessFurther
+                        shouldProcessFurther = specimen.shouldProcessFurther,
+                        expectedImages = specimen.expectedImages
                     )
                 )
             }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/VectorCamDatabase.kt
@@ -39,7 +39,7 @@ import com.vci.vectorcamapp.core.data.room.entities.SurveillanceFormEntity
         SpecimenImageEntity::class,
         InferenceResultEntity::class,
         SurveillanceFormEntity::class],
-    version = 24,
+    version = 25,
 )
 @TypeConverters(
     UuidConverter::class,

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SessionEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SessionEntity.kt
@@ -33,5 +33,6 @@ data class SessionEntity(
     val notes: String = "",
     val latitude: Float? = null,
     val longitude: Float? = null,
-    val type: SessionType,
+    val type: SessionType = SessionType.SURVEILLANCE,
+    val expectedSpecimens: Int
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/entities/SpecimenEntity.kt
@@ -18,5 +18,6 @@ data class SpecimenEntity(
     val id: String = "",
     val sessionId: UUID = UUID(0, 0),
     val remoteId: Int? = null,
-    val shouldProcessFurther: Boolean = false
+    val shouldProcessFurther: Boolean = false,
+    val expectedImages: Int,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/Migrations.kt
@@ -23,6 +23,7 @@ import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_20_21_C
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_21_22_UPDATE_SITE_TABLE
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_22_23_MAKE_SITE_LOCATION_COLUMNS_NULLABLE
 import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_23_24_ADD_LOCATION_TYPE_LEVEL_COLUMN
+import com.vci.vectorcamapp.core.data.room.migrations.versions.MIGRATION_24_25_ADD_EXPECTED_SPECIMENS_AND_EXPECTED_IMAGES_COLUMNS
 
 val ALL_MIGRATIONS = arrayOf(
     MIGRATION_1_2_CREATE_BOUNDING_BOX_TABLE,
@@ -47,5 +48,6 @@ val ALL_MIGRATIONS = arrayOf(
     MIGRATION_20_21_CREATE_LOCATION_TYPE_TABLE,
     MIGRATION_21_22_UPDATE_SITE_TABLE,
     MIGRATION_22_23_MAKE_SITE_LOCATION_COLUMNS_NULLABLE,
-    MIGRATION_23_24_ADD_LOCATION_TYPE_LEVEL_COLUMN
+    MIGRATION_23_24_ADD_LOCATION_TYPE_LEVEL_COLUMN,
+    MIGRATION_24_25_ADD_EXPECTED_SPECIMENS_AND_EXPECTED_IMAGES_COLUMNS
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_24_25_AddExpectedSpecimensAndExpectedImagesColumns.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/room/migrations/versions/Migration_24_25_AddExpectedSpecimensAndExpectedImagesColumns.kt
@@ -1,0 +1,32 @@
+package com.vci.vectorcamapp.core.data.room.migrations.versions
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_24_25_ADD_EXPECTED_SPECIMENS_AND_EXPECTED_IMAGES_COLUMNS = object : Migration(24, 25) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE `session` ADD COLUMN `expectedSpecimens` INTEGER NOT NULL DEFAULT 0")
+
+            db.execSQL("ALTER TABLE `specimen` ADD COLUMN `expectedImages` INTEGER NOT NULL DEFAULT 0")
+
+            db.execSQL(
+                """
+                UPDATE `session`
+                SET `expectedSpecimens` = (
+                    SELECT COUNT(*) FROM `specimen` WHERE `specimen`.`sessionId` = `session`.`localId`
+                )
+                """.trimIndent()
+            )
+
+            db.execSQL(
+                """
+                UPDATE `specimen`
+                SET `expectedImages` = (
+                    SELECT COUNT(*) FROM `specimen_image`
+                    WHERE `specimen_image`.`specimenId` = `specimen`.`id`
+                    AND `specimen_image`.`sessionId` = `specimen`.`sessionId`
+                )
+                """.trimIndent()
+            )
+        }
+    }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -308,6 +308,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 latitude = localSession.latitude,
                 longitude = localSession.longitude,
                 type = localSession.type,
+                expectedSpecimens = localSession.expectedSpecimens,
                 siteId = localSiteId,
                 deviceId = syncedDeviceId,
             )
@@ -349,6 +350,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 latitude = remoteSessionDto.latitude,
                 longitude = remoteSessionDto.longitude,
                 type = remoteSessionDto.type,
+                expectedSpecimens = remoteSessionDto.expectedSpecimens
             )
 
             if (localSessionDto != remoteSessionDto) {
@@ -444,7 +446,9 @@ class MetadataUploadWorker @AssistedInject constructor(
             val localSpecimenDto = SpecimenDto(
                 id = localSpecimen.remoteId,
                 specimenId = localSpecimen.id,
-                sessionId = syncedRemoteSessionId
+                sessionId = syncedRemoteSessionId,
+                shouldProcessFurther = localSpecimen.shouldProcessFurther,
+                expectedImages = localSpecimen.expectedImages
             )
 
             val remoteSpecimenDto =
@@ -472,7 +476,10 @@ class MetadataUploadWorker @AssistedInject constructor(
                 }
 
             val remoteSpecimen = Specimen(
-                id = remoteSpecimenDto.specimenId, remoteId = remoteSpecimenDto.id, shouldProcessFurther = remoteSpecimenDto.shouldProcessFurther
+                id = remoteSpecimenDto.specimenId,
+                remoteId = remoteSpecimenDto.id,
+                shouldProcessFurther = remoteSpecimenDto.shouldProcessFurther,
+                expectedImages = remoteSpecimenDto.expectedImages
             )
 
             if (remoteSpecimenDto != localSpecimenDto) {

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Session.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Session.kt
@@ -20,4 +20,5 @@ data class Session(
     val latitude: Float?,
     val longitude: Float?,
     val type: SessionType,
+    val expectedSpecimens: Int
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/model/Specimen.kt
@@ -3,5 +3,6 @@ package com.vci.vectorcamapp.core.domain.model
 data class Specimen(
     val id: String,
     val remoteId: Int?,
-    val shouldProcessFurther: Boolean
+    val shouldProcessFurther: Boolean,
+    val expectedImages: Int
 )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -12,7 +12,7 @@ import com.vci.vectorcamapp.imaging.domain.util.ImagingError
 data class ImagingState(
     val isLoading: Boolean = false,
     val isProcessing: Boolean = false,
-    val currentSpecimen: Specimen = Specimen(id = "", remoteId = null, shouldProcessFurther = false),
+    val currentSpecimen: Specimen = Specimen(id = "", remoteId = null, shouldProcessFurther = false, expectedImages = 0),
     val currentSpecimenImage: SpecimenImage = SpecimenImage(
         localId = "",
         remoteId = null,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -1,7 +1,6 @@
 package com.vci.vectorcamapp.imaging.presentation
 
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.compose.material3.SnackbarDuration
 import androidx.lifecycle.viewModelScope
@@ -416,7 +415,8 @@ class ImagingViewModel @Inject constructor(
 
                 ImagingAction.SaveImageToSession -> {
                     val currentSession = currentSessionCache.getSession()
-                    if (currentSession == null) {
+                    val currentSiteId = currentSessionCache.getSiteId()
+                    if (currentSession == null || currentSiteId == null) {
                         _events.send(ImagingEvent.NavigateBackToLandingScreen)
                         return@launch
                     }
@@ -469,10 +469,12 @@ class ImagingViewModel @Inject constructor(
 
                     saveResult.onSuccess { imageUri ->
                         val specimen = Specimen(
-                            id = specimenId,
-                            remoteId = null,
-                            shouldProcessFurther = shouldProcessFurther
-                        )
+                                id = specimenId,
+                                remoteId = null,
+                                shouldProcessFurther = shouldProcessFurther,
+                                expectedImages = 1
+                            )
+
                         val specimenImage = SpecimenImage(
                             localId = calculateMd5(jpegBytes),
                             remoteId = null,
@@ -487,25 +489,35 @@ class ImagingViewModel @Inject constructor(
                         )
 
                         val success = transactionHelper.runAsTransaction {
-                            val inferenceResult = _state.value.currentInferenceResult
-
-                            val specimenInsertionResult = if (existingSpecimen == null) {
-                                specimenRepository.insertSpecimen(specimen, currentSession.localId)
+                            val expectedSpecimensIncrementResult = if (existingSpecimen == null) {
+                                sessionRepository.upsertSession(currentSession.copy(expectedSpecimens = currentSession.expectedSpecimens + 1), currentSiteId)
                             } else {
                                 Result.Success(Unit)
                             }
+
+                            val specimenUpsertResult = if (existingSpecimen == null) {
+                                specimenRepository.insertSpecimen(specimen, currentSession.localId)
+                            } else {
+                                specimenRepository.updateSpecimen(existingSpecimen.copy(expectedImages = existingSpecimen.expectedImages + 1), currentSession.localId)
+                            }
+
                             val specimenImageInsertionResult =
                                 specimenImageRepository.insertSpecimenImage(
                                     specimenImage, specimen.id, currentSession.localId
                                 )
 
+                            val inferenceResult = _state.value.currentInferenceResult
                             val inferenceResultInsertionResult = inferenceResult?.let {
                                 inferenceResultRepository.insertInferenceResult(
                                     inferenceResult, specimenImage.localId
                                 )
                             } ?: Result.Success(Unit)
 
-                            specimenInsertionResult.onError { error ->
+                            expectedSpecimensIncrementResult.onError { error ->
+                                emitError(error)
+                            }
+
+                            specimenUpsertResult.onError { error ->
                                 emitError(error)
                             }
 
@@ -517,7 +529,7 @@ class ImagingViewModel @Inject constructor(
                                 emitError(error)
                             }
 
-                            (specimenInsertionResult !is Result.Error) && (specimenImageInsertionResult !is Result.Error) && (inferenceResultInsertionResult !is Result.Error)
+                            (specimenUpsertResult !is Result.Error) && (specimenImageInsertionResult !is Result.Error) && (inferenceResultInsertionResult !is Result.Error)
                         }
 
                         if (success) {

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeState.kt
@@ -39,6 +39,7 @@ data class IntakeState(
         latitude = null,
         longitude = null,
         type = SessionType.SURVEILLANCE,
+        expectedSpecimens = 0
     ),
     val surveillanceForm: SurveillanceForm? = null,
     val intakeErrors: IntakeErrors = IntakeErrors(

--- a/app/src/test/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModelTest.kt
+++ b/app/src/test/java/com/vci/vectorcamapp/incomplete_session/presentation/IncompleteSessionViewModelTest.kt
@@ -97,6 +97,7 @@ class IncompleteSessionViewModelTest {
         latitude = null,
         longitude = null,
         type = sessionType,
+        expectedSpecimens = 0,
     )
 
     private fun makeSessionAndSite(session: Session, siteId: Int): SessionAndSite {

--- a/app/src/test/java/com/vci/vectorcamapp/landing/presentation/LandingViewModelTest.kt
+++ b/app/src/test/java/com/vci/vectorcamapp/landing/presentation/LandingViewModelTest.kt
@@ -89,6 +89,7 @@ class LandingViewModelTest {
         latitude = null,
         longitude = null,
         type = type,
+        expectedSpecimens = 0
     )
 
     private fun makeDummySite() = Site(


### PR DESCRIPTION
This pull request adds support for tracking expected specimen and image counts throughout the app's data model, DTOs, database entities, migrations, and networking layers. These changes ensure that both sessions and specimens consistently record and sync the number of expected specimens and images, improving data integrity and enabling new features.

**Database Schema & Migration Updates**
* Added `expectedSpecimens` column to the `session` table and `expectedImages` column to the `specimen` table, with a migration to populate these fields based on existing data. (`Migration_24_25_AddExpectedSpecimensAndExpectedImagesColumns.kt`, `VectorCamDatabase.kt`, `Migrations.kt`) [[1]](diffhunk://#diff-02cddc2a4ebde167b7a75dd23525952e6dd4e98adfe7a81cd3a46ae87ae03c43R1-R32) [[2]](diffhunk://#diff-f3f23437621b48c822566384a5418ace060b2a9f614bdfc5d62259270d4ad316L42-R42) [[3]](diffhunk://#diff-7b232804c690429f8fa3d4d46178937b737db631a21914b3e36741b2c67fe718R26) [[4]](diffhunk://#diff-7b232804c690429f8fa3d4d46178937b737db631a21914b3e36741b2c67fe718L50-R52)

**Data Model, DTO, and Entity Changes**
* Updated `Session`, `Specimen`, and their DTOs/entities to include `expectedSpecimens` and `expectedImages` fields, ensuring these counts are available throughout the app's data layers. (`Session.kt`, `Specimen.kt`, `SessionDto.kt`, `SpecimenDto.kt`, `SessionEntity.kt`, `SpecimenEntity.kt`, `PostSessionRequestDto.kt`, `PostSpecimenRequestDto.kt`, `CurrentSessionCacheDto.kt`) [[1]](diffhunk://#diff-3ee79260cee451c3f70c920a7519ca2c0cc86574eca940c00921676c082df6ebR23) [[2]](diffhunk://#diff-4f1aec9b8e3c10b48017bdba578f0e1e649a7ffb61593d927b618d521ea0801aL6-R7) [[3]](diffhunk://#diff-29597be9ea5a4457e2b883b42cfb6ba11633553a57d01e7d3501bd4c2f3ecec9R29) [[4]](diffhunk://#diff-355afae7e6a00398ef981d5d133cd7bece2899d98265cd6aa874363f580d7ab3L10-R11) [[5]](diffhunk://#diff-8f0ef2da0a135dbe55a7d02b28097d7c2f0ccfc3e79abafb0a9ffcbcfdea4f40L36-R37) [[6]](diffhunk://#diff-512ae91d08a1855e984d60ecf07ed18afbd19b7f68c897065c7e28672a14458eL21-R22) [[7]](diffhunk://#diff-f28fc641051a33970fda21bb9c60ba7c2a20e5b407a7b333300761bb759af08fR27) [[8]](diffhunk://#diff-3af3649c5fbcd828709882e643d84686355936d04e8475807aedc6f529cb87a0L8-R9) [[9]](diffhunk://#diff-a712a0c0dda3f1ad51e98c30d269ef96d428b810200ee8071b8b4e15e244ef87R30)

**Mapper and Cache Layer Updates**
* Modified mappers and cache implementations to handle the new fields, ensuring correct conversion between domain, entity, and DTO representations. (`SessionMapper.kt`, `SpecimenMapper.kt`, `CurrentSessionCacheImplementation.kt`) [[1]](diffhunk://#diff-2295fb380fd5c6232c24fda5d5496798b1620f3f692666c235c1fb29fb9fc99fR24) [[2]](diffhunk://#diff-2295fb380fd5c6232c24fda5d5496798b1620f3f692666c235c1fb29fb9fc99fR47) [[3]](diffhunk://#diff-876c9f601c0c77cb318f1d4eca50598946983329a349919ec7d2ff3717c44c4eL11-R12) [[4]](diffhunk://#diff-876c9f601c0c77cb318f1d4eca50598946983329a349919ec7d2ff3717c44c4eL20-R22) [[5]](diffhunk://#diff-dd727b86f0910c1373f1daab1638945bdd9e09469eaeaa1e3616d0a68196400cR33) [[6]](diffhunk://#diff-dd727b86f0910c1373f1daab1638945bdd9e09469eaeaa1e3616d0a68196400cR60)

**Networking and Upload Logic**
* Updated remote data sources and upload workers to include `expectedSpecimens` and `expectedImages` in network requests and sync logic. (`RemoteSessionDataSource.kt`, `RemoteSpecimenDataSource.kt`, `MetadataUploadWorker.kt`) [[1]](diffhunk://#diff-ce61a0cd1a851b6430e9ae292ac14435bc52e55b560ebb15262de9593158ffcfR54) [[2]](diffhunk://#diff-d1ad4634b6b64200a23f6a0c008691cfcdfdf42ca134bf2278669d64479a0712L36-R37) [[3]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6R311) [[4]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6R353) [[5]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L447-R451) [[6]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L475-R482)

**Miscellaneous**
* Bumped database version to 25 and commented out the Uganda flavor's applicationIdSuffix to avoid conflicts during migration. (`VectorCamDatabase.kt`, `build.gradle.kts`) [[1]](diffhunk://#diff-f3f23437621b48c822566384a5418ace060b2a9f614bdfc5d62259270d4ad316L42-R42) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L52-R52)