### PR TITLE
SOF-432: Submit expected specimen count in metadata when uploading a session

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
         // Uganda is listed first to be the default flavor
         create("uganda") {
             dimension = "region"
-            applicationIdSuffix = ".uganda"
+            // applicationIdSuffix = ".uganda"
             versionCode = 2007
             versionName = "1.0.7"
             

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/PostSessionRequestDto.kt
@@ -24,6 +24,7 @@ data class PostSessionRequestDto(
     val longitude: Float? = null,
     @Serializable(with = SessionTypeSerializer::class)
     val type: SessionType = SessionType.SURVEILLANCE,
+    val expectedSpecimens: Int = 0,
     val siteId: Int = -1,
     val deviceId: Int = -1,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/session/SessionDto.kt
@@ -26,6 +26,7 @@ data class SessionDto(
     val longitude: Float? = null,
     @Serializable(with = SessionTypeSerializer::class)
     val type: SessionType = SessionType.SURVEILLANCE,
+    val expectedSpecimens: Int = 0,
     val siteId: Int = -1,
     val deviceId: Int = -1,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/PostSpecimenRequestDto.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PostSpecimenRequestDto(
     val specimenId: String = "",
-    val shouldProcessFurther: Boolean = false
+    val shouldProcessFurther: Boolean = false,
+    val expectedImages: Int = 0,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen/SpecimenDto.kt
@@ -7,5 +7,6 @@ data class SpecimenDto(
     val id: Int? = null,
     val specimenId: String = "",
     val sessionId: Int = -1,
-    val shouldProcessFurther: Boolean = false
+    val shouldProcessFurther: Boolean = false,
+    val expectedImages: Int = 0,
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSessionDataSource.kt
@@ -25,7 +25,7 @@ class RemoteSessionDataSource @Inject constructor(
 ) : SessionDataSource {
 
     override suspend fun postSession(
-        session: Session, siteId: Int, deviceId: Int
+        session: Session, siteId: Int, deviceId: Int, expectedSpecimens: Int
     ): Result<PostSessionResponseDto, NetworkError> {
         if (session.completedAt == null) {
             return Result.Error(NetworkError.SESSION_NOT_COMPLETED)
@@ -51,6 +51,7 @@ class RemoteSessionDataSource @Inject constructor(
                         latitude = session.latitude,
                         longitude = session.longitude,
                         type = session.type,
+                        expectedSpecimens = expectedSpecimens,
                         siteId = siteId,
                         deviceId = deviceId,
                     )

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/api/RemoteSpecimenDataSource.kt
@@ -24,7 +24,7 @@ class RemoteSpecimenDataSource @Inject constructor(
 ) : SpecimenDataSource {
 
     override suspend fun postSpecimen(
-        specimen: Specimen, sessionId: Int
+        specimen: Specimen, sessionId: Int, expectedImages: Int
     ): Result<PostSpecimenResponseDto, NetworkError> {
         return safeCall<PostSpecimenResponseDto> {
             httpClient.post(constructUrl("sessions/$sessionId/specimens")) {
@@ -33,7 +33,8 @@ class RemoteSpecimenDataSource @Inject constructor(
                 setBody(
                     PostSpecimenRequestDto(
                         specimenId = specimen.id,
-                        shouldProcessFurther = specimen.shouldProcessFurther
+                        shouldProcessFurther = specimen.shouldProcessFurther,
+                        expectedImages = expectedImages
                     )
                 )
             }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/metadata/MetadataUploadWorker.kt
@@ -107,8 +107,12 @@ class MetadataUploadWorker @AssistedInject constructor(
                     )
                 }
 
+            val localSpecimensWithImagesAndInferenceResults =
+                specimenRepository.getSpecimenImagesAndInferenceResultsBySession(localSessionId)
+            val totalSpecimensForSession = localSpecimensWithImagesAndInferenceResults.size
+
             val syncedSession = when (val syncSessionResult =
-                syncSessionIfNeeded(localSession, localSiteId, syncedDevice.id)) {
+                syncSessionIfNeeded(localSession, localSiteId, syncedDevice.id, totalSpecimensForSession)) {
                 is DomainResult.Success -> syncSessionResult.data
                 is DomainResult.Error -> return retryOrFailure(
                     syncSessionResult.error.toString(context)
@@ -131,18 +135,15 @@ class MetadataUploadWorker @AssistedInject constructor(
                 }
             }
 
-            val localSpecimensWithImagesAndInferenceResults =
-                specimenRepository.getSpecimenImagesAndInferenceResultsBySession(syncedSession.localId)
-            val totalSpecimens = localSpecimensWithImagesAndInferenceResults.size
             var hasFailure = false
-
             localSpecimensWithImagesAndInferenceResults.forEachIndexed { specimenIndex, specimenWithImagesAndInferenceResults ->
-                val totalImages =
+                val totalImagesForSpecimen =
                     specimenWithImagesAndInferenceResults.specimenImagesAndInferenceResults.size
                 val syncedSpecimen = when (val syncSpecimenResult = syncSpecimenIfNeeded(
                     specimenWithImagesAndInferenceResults.specimen,
                     syncedSession.localId,
-                    syncedSession.remoteId
+                    syncedSession.remoteId,
+                    totalImagesForSpecimen
                 )) {
                     is DomainResult.Success -> syncSpecimenResult.data
                     is DomainResult.Error -> {
@@ -168,9 +169,9 @@ class MetadataUploadWorker @AssistedInject constructor(
                             showSpecimenProgressNotification(
                                 specimenId = syncedSpecimen.id,
                                 currentSpecimenIndex = specimenIndex,
-                                totalSpecimens = totalSpecimens,
+                                totalSpecimens = totalSpecimensForSession,
                                 currentImageIndex = imageIndex,
-                                totalImagesForSpecimen = totalImages
+                                totalImagesForSpecimen = totalImagesForSpecimen
                             )
                         }.onError {
                             hasFailure = true
@@ -288,7 +289,7 @@ class MetadataUploadWorker @AssistedInject constructor(
     }
 
     private suspend fun syncSessionIfNeeded(
-        localSession: Session, localSiteId: Int, syncedDeviceId: Int
+        localSession: Session, localSiteId: Int, syncedDeviceId: Int, expectedSpecimens: Int
     ): DomainResult<Session, NetworkError> {
         return try {
             val localSessionDto = SessionDto(
@@ -308,6 +309,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                 latitude = localSession.latitude,
                 longitude = localSession.longitude,
                 type = localSession.type,
+                expectedSpecimens = expectedSpecimens,
                 siteId = localSiteId,
                 deviceId = syncedDeviceId,
             )
@@ -319,7 +321,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                     when (remoteSessionResult.error) {
                         NetworkError.NOT_FOUND -> {
                             val postSessionResult = sessionDataSource.postSession(
-                                localSession, localSiteId, syncedDeviceId
+                                localSession, localSiteId, syncedDeviceId, expectedSpecimens
                             )
                             when (postSessionResult) {
                                 is DomainResult.Success -> postSessionResult.data.session
@@ -438,13 +440,14 @@ class MetadataUploadWorker @AssistedInject constructor(
     }
 
     private suspend fun syncSpecimenIfNeeded(
-        localSpecimen: Specimen, syncedLocalSessionId: UUID, syncedRemoteSessionId: Int
+        localSpecimen: Specimen, syncedLocalSessionId: UUID, syncedRemoteSessionId: Int, expectedImages: Int
     ): DomainResult<Specimen, NetworkError> {
         return try {
             val localSpecimenDto = SpecimenDto(
                 id = localSpecimen.remoteId,
                 specimenId = localSpecimen.id,
-                sessionId = syncedRemoteSessionId
+                sessionId = syncedRemoteSessionId,
+                expectedImages = expectedImages
             )
 
             val remoteSpecimenDto =
@@ -456,7 +459,7 @@ class MetadataUploadWorker @AssistedInject constructor(
                         when (remoteSpecimenResult.error) {
                             NetworkError.NOT_FOUND -> {
                                 val postSpecimenResult = specimenDataSource.postSpecimen(
-                                    localSpecimen, syncedRemoteSessionId
+                                    localSpecimen, syncedRemoteSessionId, expectedImages
                                 )
                                 when (postSpecimenResult) {
                                     is DomainResult.Success -> postSpecimenResult.data.specimen

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SessionDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SessionDataSource.kt
@@ -8,6 +8,6 @@ import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 import java.util.UUID
 
 interface SessionDataSource {
-    suspend fun postSession(session: Session, siteId: Int, deviceId: Int): Result<PostSessionResponseDto, NetworkError>
+    suspend fun postSession(session: Session, siteId: Int, deviceId: Int, expectedSpecimens: Int): Result<PostSessionResponseDto, NetworkError>
     suspend fun getSessionByFrontendId(localId: UUID): Result<SessionDto, NetworkError>
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenDataSource.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/network/api/SpecimenDataSource.kt
@@ -8,7 +8,7 @@ import com.vci.vectorcamapp.core.domain.util.network.NetworkError
 
 interface SpecimenDataSource {
     suspend fun postSpecimen(
-        specimen: Specimen, sessionId: Int
+        specimen: Specimen, sessionId: Int, expectedImages: Int
     ): Result<PostSpecimenResponseDto, NetworkError>
 
     suspend fun getSpecimenByIdAndSessionId(


### PR DESCRIPTION
This pull request introduces support for tracking expected specimen and image counts in session and specimen data models, and ensures these values are propagated through the network and upload layers. The changes improve metadata accuracy for uploads and enhance progress notifications. The main updates are grouped below:

**Data Model Enhancements:**

* Added `expectedSpecimens` to both `SessionDto` and `PostSessionRequestDto`, and added `expectedImages` to both `SpecimenDto` and `PostSpecimenRequestDto` to capture expected counts for sessions and specimens. [[1]](diffhunk://#diff-29597be9ea5a4457e2b883b42cfb6ba11633553a57d01e7d3501bd4c2f3ecec9R29) [[2]](diffhunk://#diff-f28fc641051a33970fda21bb9c60ba7c2a20e5b407a7b333300761bb759af08fR27) [[3]](diffhunk://#diff-355afae7e6a00398ef981d5d133cd7bece2899d98265cd6aa874363f580d7ab3L10-R11) [[4]](diffhunk://#diff-3af3649c5fbcd828709882e643d84686355936d04e8475807aedc6f529cb87a0L8-R9)

**Network Layer Updates:**

* Updated `SessionDataSource` and `SpecimenDataSource` interfaces and their `Remote*DataSource` implementations to accept and forward `expectedSpecimens` and `expectedImages` parameters when posting sessions or specimens. [[1]](diffhunk://#diff-29b8622de099597e3b9c17f34bcca992b74ef2d8170489a98b67933db2510b9bL11-R11) [[2]](diffhunk://#diff-d117bd61d81082877292b93ac62aa27cc8195029af80081d3ea6b6568c3b35e5L11-R11) [[3]](diffhunk://#diff-ce61a0cd1a851b6430e9ae292ac14435bc52e55b560ebb15262de9593158ffcfL28-R28) [[4]](diffhunk://#diff-ce61a0cd1a851b6430e9ae292ac14435bc52e55b560ebb15262de9593158ffcfR54) [[5]](diffhunk://#diff-d1ad4634b6b64200a23f6a0c008691cfcdfdf42ca134bf2278669d64479a0712L27-R27) [[6]](diffhunk://#diff-d1ad4634b6b64200a23f6a0c008691cfcdfdf42ca134bf2278669d64479a0712L36-R37)

**Metadata Upload Logic Improvements:**

* Modified `MetadataUploadWorker` to calculate and pass `expectedSpecimens` and `expectedImages` during session and specimen synchronization, ensuring correct metadata is uploaded and reflected in progress notifications. [[1]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6R110-R115) [[2]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L134-R146) [[3]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L171-R174) [[4]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L291-R292) [[5]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6R312) [[6]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L322-R324) [[7]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L441-R450) [[8]](diffhunk://#diff-0a85b8166f7d9b8ecc2c0d115bb22734a2d18473d6100f72a07250ce31653ac6L459-R462)

**Miscellaneous:**

* Commented out the `applicationIdSuffix` for the Uganda flavor in `app/build.gradle.kts` to prevent its use.