### PR TITLE
SOF-421: Improve the UI for displaying Site location information

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/form/CompleteSessionForm.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/components/form/CompleteSessionForm.kt
@@ -140,13 +140,15 @@ fun CompleteSessionForm(
                     )
                 }
 
-                site.locationHierarchy?.let { locationHierarchy ->
-                    Text(
-                        text = "Location: $locationHierarchy",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colors.textPrimary
-                    )
-                }
+                site.locationHierarchy
+                    ?.filterValues { it.isNotBlank() }
+                    ?.forEach { (key, value) ->
+                        Text(
+                            text = "$key: $value",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colors.textPrimary
+                        )
+                    }
             }
 
             surveillanceForm?.let {

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListDetailRow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListDetailRow.kt
@@ -2,6 +2,7 @@ package com.vci.vectorcamapp.complete_session.list.presentation.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -16,19 +17,24 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
 fun CompleteSessionListDetailRow(
-    iconPainter: Painter, iconDescription: String, text: String, modifier: Modifier = Modifier
+    iconPainter: Painter?, iconDescription: String, text: String, modifier: Modifier = Modifier
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingExtraSmall),
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.fillMaxWidth()
     ) {
-        Icon(
-            painter = iconPainter,
-            contentDescription = iconDescription,
-            tint = MaterialTheme.colors.icon,
-            modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
-        )
+        if (iconPainter != null) {
+            Icon(
+                painter = iconPainter,
+                contentDescription = iconDescription,
+                tint = MaterialTheme.colors.icon,
+                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+            )
+        } else {
+            Spacer(modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall))
+        }
+
+        Spacer(modifier = Modifier.size(MaterialTheme.dimensions.spacingSmall))
 
         Text(
             text = text,

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListDetailRow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListDetailRow.kt
@@ -17,22 +17,18 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
 fun CompleteSessionListDetailRow(
-    iconPainter: Painter?, iconDescription: String, text: String, modifier: Modifier = Modifier
+    iconPainter: Painter, iconDescription: String, text: String, modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.fillMaxWidth()
     ) {
-        if (iconPainter != null) {
-            Icon(
-                painter = iconPainter,
-                contentDescription = iconDescription,
-                tint = MaterialTheme.colors.icon,
-                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
-            )
-        } else {
-            Spacer(modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall))
-        }
+        Icon(
+            painter = iconPainter,
+            contentDescription = iconDescription,
+            tint = MaterialTheme.colors.icon,
+            modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+        )
 
         Spacer(modifier = Modifier.size(MaterialTheme.dimensions.spacingSmall))
 

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -175,11 +175,21 @@ fun CompleteSessionListTile(
                     }
 
                     site.locationHierarchy?.let { locationHierarchy ->
-                        CompleteSessionListDetailRow(
-                            iconPainter = painterResource(R.drawable.ic_pin),
-                            iconDescription = "Location",
-                            text = "Location: $locationHierarchy",
-                        )
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(
+                                MaterialTheme.dimensions.spacingExtraSmall
+                            )
+                        ) {
+                            locationHierarchy.toList().forEachIndexed { index, (key, value) ->
+                                CompleteSessionListDetailRow(
+                                    iconPainter = if (index == 0)
+                                        painterResource(R.drawable.ic_pin)
+                                    else null,
+                                    iconDescription = "Location",
+                                    text = "$key: $value"
+                                )
+                            }
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/components/CompleteSessionListTile.kt
@@ -175,19 +175,29 @@ fun CompleteSessionListTile(
                     }
 
                     site.locationHierarchy?.let { locationHierarchy ->
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(
-                                MaterialTheme.dimensions.spacingExtraSmall
-                            )
+                        Row(
+                            verticalAlignment = Alignment.Top,
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)
                         ) {
-                            locationHierarchy.toList().forEachIndexed { index, (key, value) ->
-                                CompleteSessionListDetailRow(
-                                    iconPainter = if (index == 0)
-                                        painterResource(R.drawable.ic_pin)
-                                    else null,
-                                    iconDescription = "Location",
-                                    text = "$key: $value"
+                            Icon(
+                                painter = painterResource(R.drawable.ic_pin),
+                                contentDescription = "Location",
+                                tint = MaterialTheme.colors.icon,
+                                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+                            )
+
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(
+                                    MaterialTheme.dimensions.spacingExtraSmall
                                 )
+                            ) {
+                                locationHierarchy.forEach { (key, value) ->
+                                    Text(
+                                        text = "$key: $value",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colors.textPrimary
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -155,19 +155,29 @@ fun IncompleteSessionCard(
                     }
 
                     sessionAndSite.site.locationHierarchy?.let { locationHierarchy ->
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(
-                                MaterialTheme.dimensions.spacingExtraSmall
-                            )
+                        Row(
+                            verticalAlignment = Alignment.Top,
+                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)
                         ) {
-                            locationHierarchy.toList().forEachIndexed { index, (key, value) ->
-                                IncompleteSessionListDetailRow(
-                                    iconPainter = if (index == 0)
-                                        painterResource(R.drawable.ic_pin)
-                                    else null,
-                                    iconDescription = "Location",
-                                    text = "$key: $value"
+                            Icon(
+                                painter = painterResource(R.drawable.ic_pin),
+                                contentDescription = "Location",
+                                tint = MaterialTheme.colors.icon,
+                                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+                            )
+
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(
+                                    MaterialTheme.dimensions.spacingExtraSmall
                                 )
+                            ) {
+                                locationHierarchy.forEach { (key, value) ->
+                                    Text(
+                                        text = "$key: $value",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colors.textPrimary
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -155,11 +155,21 @@ fun IncompleteSessionCard(
                     }
 
                     sessionAndSite.site.locationHierarchy?.let { locationHierarchy ->
-                        IncompleteSessionListDetailRow(
-                            iconPainter = painterResource(R.drawable.ic_pin),
-                            iconDescription = "Location",
-                            text = "Location: $locationHierarchy",
-                        )
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(
+                                MaterialTheme.dimensions.spacingExtraSmall
+                            )
+                        ) {
+                            locationHierarchy.toList().forEachIndexed { index, (key, value) ->
+                                IncompleteSessionListDetailRow(
+                                    iconPainter = if (index == 0)
+                                        painterResource(R.drawable.ic_pin)
+                                    else null,
+                                    iconDescription = "Location",
+                                    text = "$key: $value"
+                                )
+                            }
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionListDetailRow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionListDetailRow.kt
@@ -2,6 +2,7 @@ package com.vci.vectorcamapp.incomplete_session.presentation.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -16,19 +17,24 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
 fun IncompleteSessionListDetailRow(
-    iconPainter: Painter, iconDescription: String, text: String, modifier: Modifier = Modifier
+    iconPainter: Painter?, iconDescription: String, text: String, modifier: Modifier = Modifier
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall),
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.fillMaxWidth()
     ) {
-        Icon(
-            painter = iconPainter,
-            contentDescription = iconDescription,
-            tint = MaterialTheme.colors.icon,
-            modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
-        )
+        if (iconPainter != null) {
+            Icon(
+                painter = iconPainter,
+                contentDescription = iconDescription,
+                tint = MaterialTheme.colors.icon,
+                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+            )
+        } else {
+            Spacer(modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall))
+        }
+
+        Spacer(modifier = Modifier.size(MaterialTheme.dimensions.spacingSmall))
 
         Text(
             text = text,

--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionListDetailRow.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionListDetailRow.kt
@@ -17,22 +17,18 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 
 @Composable
 fun IncompleteSessionListDetailRow(
-    iconPainter: Painter?, iconDescription: String, text: String, modifier: Modifier = Modifier
+    iconPainter: Painter, iconDescription: String, text: String, modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier.fillMaxWidth()
     ) {
-        if (iconPainter != null) {
-            Icon(
-                painter = iconPainter,
-                contentDescription = iconDescription,
-                tint = MaterialTheme.colors.icon,
-                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
-            )
-        } else {
-            Spacer(modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall))
-        }
+        Icon(
+            painter = iconPainter,
+            contentDescription = iconDescription,
+            tint = MaterialTheme.colors.icon,
+            modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+        )
 
         Spacer(modifier = Modifier.size(MaterialTheme.dimensions.spacingSmall))
 


### PR DESCRIPTION
This pull request improves the way location hierarchy information is displayed in both the Complete Session and Incomplete Session UI components. The changes ensure that each location level is shown on its own line with clearer formatting, and icons are handled more flexibly for better visual consistency.

**UI improvements for displaying location hierarchy:**

* Each location in the hierarchy is now displayed on its own line in both Complete Session and Incomplete Session cards, with the first line showing a pin icon and subsequent lines aligning text with a spacer for consistent layout. [[1]](diffhunk://#diff-1e637988e110ecd7fff0999056374d20c3aeb0c5b86f224c1f6073e0bfd9c6e7R178-R194) [[2]](diffhunk://#diff-f08834e844237606631fe07f37d50fe4639771dbb1437d27af754d0e7c2eb435R158-R174)
* The `CompleteSessionListDetailRow` and `IncompleteSessionListDetailRow` components now accept a nullable `iconPainter`. If no icon is provided, a spacer is used to maintain alignment. [[1]](diffhunk://#diff-ec4773caefd99cf493976f61b2a66d9a21f5c06b74aafabec74f5495ed32c7e3L19-R37) [[2]](diffhunk://#diff-72991319e51dc013bb5e70c70dc5d2e65a77780a1ae88561128026d4a4b9451aL19-R37)
* Added import of `Spacer` and related layout adjustments to support the new icon/spacer logic. [[1]](diffhunk://#diff-ec4773caefd99cf493976f61b2a66d9a21f5c06b74aafabec74f5495ed32c7e3R5) [[2]](diffhunk://#diff-72991319e51dc013bb5e70c70dc5d2e65a77780a1ae88561128026d4a4b9451aR5)

**Data handling and formatting:**

* When displaying location hierarchy, blank values are filtered out, and each key-value pair is shown as "`key: value`" instead of the previous concatenated string.

These changes improve the clarity and consistency of location information in session-related UI components.