### PR TITLE
SOF-455: Dynamic form date fields submit blank when the user does not re-select the default value

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/DatePickerField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/DatePickerField.kt
@@ -34,7 +34,7 @@ import java.util.Locale
 
 @Composable
 fun DatePickerField(
-    selectedDateInMillis: Long,
+    selectedDateInMillis: Long?,
     onDateSelected: (Long) -> Unit,
     modifier: Modifier = Modifier,
     label: String? = null,
@@ -44,7 +44,7 @@ fun DatePickerField(
 
     val calendar = remember(selectedDateInMillis) {
         Calendar.getInstance(TimeZone.getDefault(), Locale.getDefault()).apply {
-            timeInMillis = selectedDateInMillis
+            selectedDateInMillis?.let { timeInMillis = it }
         }
     }
 
@@ -53,7 +53,7 @@ fun DatePickerField(
     }
 
     val formattedDate = remember(selectedDateInMillis) {
-        dateFormatter.format(selectedDateInMillis)
+        selectedDateInMillis?.let { dateFormatter.format(it) }
     }
 
     Column(
@@ -103,8 +103,7 @@ fun DatePickerField(
                     ).apply {
                         datePicker.maxDate = System.currentTimeMillis()
                     }.show()
-                }
-        ) {
+                }) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -113,9 +112,9 @@ fun DatePickerField(
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(
-                    text = formattedDate,
+                    text = formattedDate ?: "Select a date",
                     style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colors.textPrimary
+                    color = if (formattedDate != null) MaterialTheme.colors.textPrimary else MaterialTheme.colors.textSecondary
                 )
 
                 Icon(

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/components/DynamicFormField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/components/DynamicFormField.kt
@@ -58,7 +58,7 @@ fun DynamicFormField(
         "date" -> {
             DatePickerField(
                 label = question.label,
-                selectedDateInMillis = value.toLongOrNull() ?: System.currentTimeMillis(),
+                selectedDateInMillis = value.toLongOrNull(),
                 onDateSelected = { onValueChange(it.toString()) },
                 error = error,
                 modifier = modifier.fillMaxWidth()


### PR DESCRIPTION
This pull request improves the `DatePickerField` component to better handle cases where no date is selected and enhances user experience by displaying a placeholder and adjusting text color accordingly. It also updates how date values are passed from the dynamic form field to support nullable dates.

**DatePickerField improvements:**

* Changed `selectedDateInMillis` in `DatePickerField` to accept nullable values (`Long?`) and updated internal logic to handle the absence of a selected date gracefully. [[1]](diffhunk://#diff-cb2ca39c27a9dfc8f07c80f725d6ce8b9d815a4865026eb80365fb146b5f9025L37-R37) [[2]](diffhunk://#diff-cb2ca39c27a9dfc8f07c80f725d6ce8b9d815a4865026eb80365fb146b5f9025L47-R47) [[3]](diffhunk://#diff-cb2ca39c27a9dfc8f07c80f725d6ce8b9d815a4865026eb80365fb146b5f9025L56-R56)
* Updated the displayed text to show a placeholder ("Select a date") and use a secondary text color when no date is selected.

**Integration with DynamicFormField:**

* Modified `DynamicFormField` to pass nullable values to `DatePickerField`, allowing the field to start with no date selected if the input value is invalid or empty.