### PR TITLE
SOF-463: Add additional fields to cache

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/DefaultIntakeFieldsCacheImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/DefaultIntakeFieldsCacheImplementation.kt
@@ -16,6 +16,8 @@
             hardwareId: String?,
             district: String,
             villageName: String,
+            formAnswers: Map<Int, String>,
+            locationSelections: Map<Int, String>
         ) {
             dataStore.updateData {
                 DefaultIntakeFieldsCacheDto(
@@ -24,7 +26,9 @@
                     collectorLastTrainedOn = collectorLastTrainedOn,
                     hardwareId = hardwareId,
                     district = district,
-                    villageName = villageName
+                    villageName = villageName,
+                    formAnswers = formAnswers,
+                    locationSelections = locationSelections
                 )
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/cache/DefaultIntakeFieldsCacheDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/cache/DefaultIntakeFieldsCacheDto.kt
@@ -10,4 +10,6 @@ data class DefaultIntakeFieldsCacheDto(
     val hardwareId: String? = null,
     val district: String = "",
     val villageName: String = "",
+    val formAnswers: Map<Int, String> = emptyMap(),
+    val locationSelections: Map<Int, String> = emptyMap()
 )

--- a/app/src/main/java/com/vci/vectorcamapp/core/domain/cache/DefaultIntakeFieldsCache.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/domain/cache/DefaultIntakeFieldsCache.kt
@@ -9,7 +9,9 @@ interface DefaultIntakeFieldsCache {
         collectorLastTrainedOn: Long,
         hardwareId: String?,
         district: String,
-        villageName: String
+        villageName: String,
+        formAnswers: Map<Int, String>,
+        locationSelections: Map<Int, String>
     )
 
     suspend fun getDefaultIntakeFields(): DefaultIntakeFieldsCacheDto?

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -281,6 +281,19 @@ class IntakeViewModel @Inject constructor(
 
                         if (success) {
                             currentSessionCache.saveSession(session, selectedSite.id)
+
+                            val answersToCache = _state.value.formAnswers.mapValues { (_, formAnswer) ->
+                                formAnswer.value
+                            }
+
+                            val allLocationTypes = _state.value.allLocationTypesInProgram
+                            val locationSelectionsToCache = if (allLocationTypes.isNotEmpty()) {
+                                val lowestLevelId = allLocationTypes.last().id
+                                _state.value.siteSelectionsByLocationTypeId.filterKeys { it != lowestLevelId }
+                            } else {
+                                _state.value.siteSelectionsByLocationTypeId
+                            }
+
                             defaultIntakeFieldsCache.saveDefaultIntakeFields(
                                 collectorName = session.collectorName,
                                 collectorTitle = session.collectorTitle,
@@ -288,6 +301,8 @@ class IntakeViewModel @Inject constructor(
                                 hardwareId = session.hardwareId,
                                 district = _state.value.selectedDistrict,
                                 villageName = _state.value.selectedVillageName,
+                                formAnswers = answersToCache,
+                                locationSelections = locationSelectionsToCache
                             )
                             _events.send(IntakeEvent.NavigateToImagingScreen)
                         }
@@ -627,6 +642,8 @@ class IntakeViewModel @Inject constructor(
             val cachedDefaultHardwareId = defaultFields?.hardwareId.orEmpty()
             val cachedDefaultDistrict = defaultFields?.district.orEmpty()
             val cachedDefaultVillageName = defaultFields?.villageName.orEmpty()
+            val cachedFormAnswers = defaultFields?.formAnswers ?: emptyMap()
+            val cachedLocationSelection = defaultFields?.locationSelection ?: emptyMap()
 
             val effectiveSession = currentSession ?: _state.value.session.copy(
                 type = resolvedSessionType,
@@ -659,7 +676,9 @@ class IntakeViewModel @Inject constructor(
                             }
                         }.toMap()
                     } else {
-                        emptyMap()
+                        cachedLocationSelection.filterKeys { cachedId ->
+                            currentAllLocationTypes.any { it.id == cachedId }
+                        }
                     }
 
                 val validatedDistrict = when {
@@ -701,7 +720,7 @@ class IntakeViewModel @Inject constructor(
                             question.id to (savedFormAnswers[question.id] ?: FormAnswer(
                                 localId = UUID.randomUUID(),
                                 remoteId = null,
-                                value = when (question.type) { "boolean" -> "false"; else -> "" },
+                                value = cachedFormAnswers[question.id] ?: when (question.type) { "boolean" -> "false"; else -> "" },
                                 dataType = question.type,
                                 submittedAt = 0L
                             ))

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -643,7 +643,7 @@ class IntakeViewModel @Inject constructor(
             val cachedDefaultDistrict = defaultFields?.district.orEmpty()
             val cachedDefaultVillageName = defaultFields?.villageName.orEmpty()
             val cachedFormAnswers = defaultFields?.formAnswers ?: emptyMap()
-            val cachedLocationSelection = defaultFields?.locationSelection ?: emptyMap()
+            val cachedLocationSelection = defaultFields?.locationSelections ?: emptyMap()
 
             val effectiveSession = currentSession ?: _state.value.session.copy(
                 type = resolvedSessionType,

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -669,14 +669,16 @@ class IntakeViewModel @Inject constructor(
 
                 val validatedSite = currentAllSites.find { it.id == currentSessionSiteId }
                 val validatedSiteSelectionsByLocationTypeId =
-                    if (validatedSite?.locationHierarchy != null) {
+                    if (validatedSite?.locationHierarchy?.isNotEmpty() == true) {
                         currentAllLocationTypes.mapNotNull { locationType ->
                             validatedSite.locationHierarchy[locationType.name]?.let { selectedLocationTypeSite ->
                                 locationType.id to selectedLocationTypeSite
                             }
                         }.toMap()
                     } else {
-                        emptyMap()
+                        cachedLocationSelection.filterKeys { cachedId ->
+                            currentAllLocationTypes.any { it.id == cachedId }
+                        }
                     }
 
                 val validatedDistrict = when {

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -668,18 +668,23 @@ class IntakeViewModel @Inject constructor(
                 locationTypeRepository.observeAllLocationTypesByProgramId(programId)) { currentAllSites, currentSavedSurveillanceForm, currentAllCollectors, currentAllLocationTypes ->
 
                 val validatedSite = currentAllSites.find { it.id == currentSessionSiteId }
-                val validatedSiteSelectionsByLocationTypeId =
-                    if (validatedSite?.locationHierarchy?.isNotEmpty() == true) {
+                val validatedSiteSelectionsByLocationTypeId = when {
+                    validatedSite == null -> {
+                        cachedLocationSelection.filterKeys { cachedId ->
+                            currentAllLocationTypes.any { it.id == cachedId }
+                        }
+                    }
+                    validatedSite.locationHierarchy?.isNotEmpty() == true -> {
                         currentAllLocationTypes.mapNotNull { locationType ->
                             validatedSite.locationHierarchy[locationType.name]?.let { selectedLocationTypeSite ->
                                 locationType.id to selectedLocationTypeSite
                             }
                         }.toMap()
-                    } else {
-                        cachedLocationSelection.filterKeys { cachedId ->
-                            currentAllLocationTypes.any { it.id == cachedId }
-                        }
                     }
+                    else -> {
+                        emptyMap()
+                    }
+                }
 
                 val validatedDistrict = when {
                     validatedSite != null -> validatedSite.district.orEmpty()

--- a/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/intake/presentation/IntakeViewModel.kt
@@ -291,7 +291,7 @@ class IntakeViewModel @Inject constructor(
                                 val lowestLevelId = allLocationTypes.last().id
                                 _state.value.siteSelectionsByLocationTypeId.filterKeys { it != lowestLevelId }
                             } else {
-                                _state.value.siteSelectionsByLocationTypeId
+                                emptyMap()
                             }
 
                             defaultIntakeFieldsCache.saveDefaultIntakeFields(
@@ -676,9 +676,7 @@ class IntakeViewModel @Inject constructor(
                             }
                         }.toMap()
                     } else {
-                        cachedLocationSelection.filterKeys { cachedId ->
-                            currentAllLocationTypes.any { it.id == cachedId }
-                        }
+                        emptyMap()
                     }
 
                 val validatedDistrict = when {

--- a/app/src/main/java/com/vci/vectorcamapp/settings/presentation/SettingsViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/settings/presentation/SettingsViewModel.kt
@@ -319,7 +319,9 @@ class SettingsViewModel @Inject constructor(
                         collectorLastTrainedOn = defaultFields.collectorLastTrainedOn,
                         hardwareId = defaultFields.hardwareId,
                         district = "",
-                        villageName = ""
+                        villageName = "",
+                        formAnswers = emptyMap(),
+                        locationSelections = emptyMap()
                     )
                 }
             } else {


### PR DESCRIPTION
This pull request enhances the caching and restoration of user input in the intake flow by extending the default intake fields cache to include form answers and location selections. The changes ensure that user progress is more thoroughly preserved and restored, improving the user experience when resuming or restarting the intake process.

**Enhancements to Intake Field Caching:**

* The `DefaultIntakeFieldsCacheDto`, its interface, and its implementation were updated to include new fields for `formAnswers` and `locationSelections`, allowing the app to cache and restore these values. [[1]](diffhunk://#diff-2e5243847180741ff1662cfabe7151f23b7deb125fd3756b0623802341388a43R13-R14) [[2]](diffhunk://#diff-fff280d6a5c588e8c27dff74bd1828f1e99852b7a4d2068f4f894a677574b327L12-R14) [[3]](diffhunk://#diff-664662a4a01e4778c455b90266bbbdf5271c6385a93a7eeb361f9e75fb4a2259R19-R20) [[4]](diffhunk://#diff-664662a4a01e4778c455b90266bbbdf5271c6385a93a7eeb361f9e75fb4a2259L27-R31)

**Improvements to Intake Flow State Restoration:**

* The `IntakeViewModel` now saves and restores form answers and location selections from the cache, ensuring that users return to their previous state when resuming an intake. [[1]](diffhunk://#diff-25efc10e1175f45d916cffa10e4b9faf10cafd0ef5240f02e9619c4654a2d217R284-R305) [[2]](diffhunk://#diff-25efc10e1175f45d916cffa10e4b9faf10cafd0ef5240f02e9619c4654a2d217R645-R646) [[3]](diffhunk://#diff-25efc10e1175f45d916cffa10e4b9faf10cafd0ef5240f02e9619c4654a2d217L662-R681) [[4]](diffhunk://#diff-25efc10e1175f45d916cffa10e4b9faf10cafd0ef5240f02e9619c4654a2d217L704-R723)

**Other updates:**

* The `SettingsViewModel` was updated to provide default empty maps for the new fields when saving default intake fields from settings.