### PR TITLE
feat: add hardcoded file name to image metadata

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/ImageMetadataDto.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/dto/specimen_image/ImageMetadataDto.kt
@@ -17,7 +17,8 @@ data class ImageMetadataDto(
     val imageHeight: Int = 0,
     val focalPointX: Float? = null,
     val focalPointY: Float? = null,
-    val afRegions: List<AfRegionDto> = emptyList()
+    val afRegions: List<AfRegionDto> = emptyList(),
+    val modelFileNames: List<String> = emptyList()
 )
 
 @Serializable

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenImageMapper.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/mappers/SpecimenImageMapper.kt
@@ -57,7 +57,8 @@ fun CameraMetadata.toImageMetadataDto(): ImageMetadataDto = ImageMetadataDto(
     imageHeight = imageHeight,
     focalPointX = focalPointX,
     focalPointY = focalPointY,
-    afRegions = afRegions.map { AfRegionDto(it.x, it.y, it.width, it.height, it.weight) }
+    afRegions = afRegions.map { AfRegionDto(it.x, it.y, it.width, it.height, it.weight) },
+    modelFileNames = modelFileNames
 )
 
 internal fun ImageMetadataDto.toCameraMetadata(): CameraMetadata = CameraMetadata(
@@ -78,5 +79,6 @@ internal fun ImageMetadataDto.toCameraMetadata(): CameraMetadata = CameraMetadat
     imageHeight = imageHeight,
     focalPointX = focalPointX,
     focalPointY = focalPointY,
-    afRegions = afRegions.map { AfRegion(it.x, it.y, it.width, it.height, it.weight) }
+    afRegions = afRegions.map { AfRegion(it.x, it.y, it.width, it.height, it.weight) },
+    modelFileNames = modelFileNames
 )

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
 import com.vci.vectorcamapp.core.domain.model.results.DetectorResult
+import com.vci.vectorcamapp.imaging.domain.ModelFileNames
 import com.vci.vectorcamapp.imaging.domain.SpecimenDetector
 import org.opencv.android.Utils
 import org.opencv.core.CvType
@@ -57,7 +58,7 @@ class TfLiteSpecimenDetector(
             if (detector != null || isClosed) return
 
             try {
-                val model = FileUtil.loadMappedFile(context, "detect.tflite")
+                val model = FileUtil.loadMappedFile(context, ModelFileNames.DETECTOR)
                 val options = Interpreter.Options().apply {
                     useNNAPI = false
                     useXNNPACK = false

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/di/ImagingModule.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/di/ImagingModule.kt
@@ -6,6 +6,7 @@ import com.google.mlkit.vision.text.TextRecognizer
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import com.vci.vectorcamapp.imaging.data.TfLiteSpecimenClassifier
 import com.vci.vectorcamapp.imaging.data.TfLiteSpecimenDetector
+import com.vci.vectorcamapp.imaging.domain.ModelFileNames
 import com.vci.vectorcamapp.imaging.domain.SpecimenClassifier
 import com.vci.vectorcamapp.imaging.domain.SpecimenDetector
 import dagger.Module
@@ -37,14 +38,14 @@ object ImagingModule {
     @ViewModelScoped
     @SpeciesClassifier
     fun provideSpeciesClassifier(@ApplicationContext context: Context): SpecimenClassifier {
-        return TfLiteSpecimenClassifier(context, "species.tflite", "TFLiteSpeciesClassifierThread")
+        return TfLiteSpecimenClassifier(context, ModelFileNames.SPECIES_CLASSIFIER, "TFLiteSpeciesClassifierThread")
     }
 
     @Provides
     @ViewModelScoped
     @SexClassifier
     fun provideSexClassifier(@ApplicationContext context: Context): SpecimenClassifier {
-        return TfLiteSpecimenClassifier(context, "sex.tflite", "TFLiteSexClassifierThread")
+        return TfLiteSpecimenClassifier(context, ModelFileNames.SEX_CLASSIFIER, "TFLiteSexClassifierThread")
     }
 
     @Provides
@@ -52,7 +53,7 @@ object ImagingModule {
     @AbdomenStatusClassifier
     fun provideAbdomenStatusClassifier(@ApplicationContext context: Context): SpecimenClassifier {
         return TfLiteSpecimenClassifier(
-            context, "abdomen_status.tflite", "TFLiteAbdomenStatusClassifierThread"
+            context, ModelFileNames.ABDOMEN_STATUS_CLASSIFIER, "TFLiteAbdomenStatusClassifierThread"
         )
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/ModelFileNames.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/ModelFileNames.kt
@@ -1,0 +1,10 @@
+package com.vci.vectorcamapp.imaging.domain
+
+object ModelFileNames {
+    const val DETECTOR = "detect.tflite"
+    const val SPECIES_CLASSIFIER = "species.tflite"
+    const val SEX_CLASSIFIER = "sex.tflite"
+    const val ABDOMEN_STATUS_CLASSIFIER = "abdomen_status.tflite"
+
+    val ALL = listOf(DETECTOR, SPECIES_CLASSIFIER, SEX_CLASSIFIER, ABDOMEN_STATUS_CLASSIFIER)
+}

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/CameraMetadata.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/CameraMetadata.kt
@@ -11,7 +11,13 @@ data class CameraMetadata(
     val imageHeight: Int = 0,
     val focalPointX: Float? = null,
     val focalPointY: Float? = null,
-    val afRegions: List<AfRegion> = emptyList()
+    val afRegions: List<AfRegion> = emptyList(),
+    val modelFileNames: List<String> = listOf(
+        "detect.tflite",
+        "species.tflite",
+        "sex.tflite",
+        "abdomen-status.tflite"
+    )
 )
 
 data class ColorCorrectionGains(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/CameraMetadata.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/domain/model/CameraMetadata.kt
@@ -1,5 +1,7 @@
 package com.vci.vectorcamapp.imaging.domain.model
 
+import com.vci.vectorcamapp.imaging.domain.ModelFileNames
+
 data class CameraMetadata(
     val focusDistance: Float? = null,
     val aperture: Float? = null,
@@ -12,12 +14,7 @@ data class CameraMetadata(
     val focalPointX: Float? = null,
     val focalPointY: Float? = null,
     val afRegions: List<AfRegion> = emptyList(),
-    val modelFileNames: List<String> = listOf(
-        "detect.tflite",
-        "species.tflite",
-        "sex.tflite",
-        "abdomen-status.tflite"
-    )
+    val modelFileNames: List<String> = ModelFileNames.ALL
 )
 
 data class ColorCorrectionGains(


### PR DESCRIPTION
add hardcoded file name to image metadata and centralized hardcoded text to single place

sample api request sent to  https://test.api.vectorcam.org/specimens/26806/images/data

```
 {
                                                                                                        "filemd5": "e503800cd2db4207a26f9bcf8878bd03",
                                                                                                        "species": "Anopheles funestus",
                                                                                                        "sex": "Female",
                                                                                                        "abdomenStatus": "Fully Fed",
                                                                                                        "capturedAt": 1776410527756,
                                                                                                        "inferenceResult": {
                                                                                                            "bboxTopLeftX": 0.33702546,
                                                                                                            "bboxTopLeftY": 0.51951563,
                                                                                                            "bboxWidth": 0.20059979,
                                                                                                            "bboxHeight": 0.18431611,
                                                                                                            "bboxConfidence": 0.8908697,
                                                                                                            "bboxClassId": 1,
                                                                                                            "speciesLogits": [1.7443717, 0.70936817, -1.0557371, -3.6912556, -4.7382326, -4.4888964, -1.8291943],
                                                                                                            "sexLogits": [5.0194597, -4.6499834],
                                                                                                            "abdomenStatusLogits": [-4.262754, 2.5309863, -0.7730492],
                                                                                                            "bboxDetectionDuration": 1212,
                                                                                                            "speciesInferenceDuration": 2042,
                                                                                                            "sexInferenceDuration": 1391,
                                                                                                            "abdomenStatusInferenceDuration": 1354
                                                                                                        },
                                                                                                        "metadata": {
                                                                                                            "focusDistance": 5.6022153,
                                                                                                            "aperture": 1.89,
                                                                                                            "exposureTimeNs": 19996312,
                                                                                                            "iso": 349,
                                                                                                            "colorCorrectionGainsRed": 1.9822035,
                                                                                                            "colorCorrectionGainsGreenEven": 1.0,
                                                                                                            "colorCorrectionGainsGreenOdd": 1.0,
                                                                                                            "colorCorrectionGainsBlue": 1.5311828,
                                                                                                            "awbMode": 1,
                                                                                                            "imageWidth": 3024,
                                                                                                            "imageHeight": 4032,
                                                                                                            "focalPointX": 0.46041667,
                                                                                                            "focalPointY": 0.6140625,
                                                                                                            "afRegions": [{
                                                                                                                "x": 2161,
                                                                                                                "y": 1699,
                                                                                                                "width": 692,
                                                                                                                "height": 520,
                                                                                                                "weight": 1000
                                                                                                            }],
                                                                                                            "modelFileNames": ["detect.tflite", "species.tflite", "sex.tflite", "abdomen_status.tflite"]
                                                                                                        }
                                                                                                    }
```