### PR TITLE
SOF-466: Use sensor orientation for image rotation

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/extensions/ImageProxyExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/extensions/ImageProxyExtensions.kt
@@ -16,7 +16,12 @@ fun ImageProxy.toUprightBitmap(): Bitmap {
     rawBitmap.recycle()
 
     val dst = Mat()
-    Core.rotate(src, dst, Core.ROTATE_90_CLOCKWISE)
+    when (this.imageInfo.rotationDegrees) {
+        90 -> Core.rotate(src, dst, Core.ROTATE_90_CLOCKWISE)
+        180 -> Core.rotate(src, dst, Core.ROTATE_180)
+        270 -> Core.rotate(src, dst, Core.ROTATE_90_COUNTERCLOCKWISE)
+        else -> src.copyTo(dst)
+    }
     src.release()
 
     val result = createBitmap(dst.cols(), dst.rows())


### PR DESCRIPTION
This pull request updates the image rotation logic in the `toUprightBitmap` extension function to handle all possible rotation degrees, ensuring images are correctly oriented based on their metadata.

Image rotation improvements:

* Updated `ImageProxy.toUprightBitmap()` to rotate the image according to `rotationDegrees`, supporting 90, 180, and 270 degrees, and leaving the image unchanged if no rotation is needed. This ensures proper image orientation for all cases.