### PR TITLE
SOF-467: Create label for specimen + confidence with the bounding box overlay in the imaging screen

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/BoundingBoxOverlay.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/BoundingBoxOverlay.kt
@@ -1,12 +1,16 @@
 package com.vci.vectorcamapp.imaging.presentation.components.camera
 
-import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import com.vci.vectorcamapp.core.domain.model.InferenceResult
@@ -20,25 +24,39 @@ fun BoundingBoxOverlay(
     modifier: Modifier = Modifier
 ) {
     val density = LocalDensity.current
-    val strokeWidth = with(density) { MaterialTheme.dimensions.borderThicknessThick.toPx() }
-
+    val strokeWidth = MaterialTheme.dimensions.borderThicknessThick
     val boxColor = MaterialTheme.colors.successConfirm
 
-    Canvas(modifier = modifier) {
-        val topLeft = Offset(
-            x = inferenceResult.bboxTopLeftX * overlaySize.width,
-            y = inferenceResult.bboxTopLeftY * overlaySize.height
+    val xOffsetDp = with(density) { (inferenceResult.bboxTopLeftX * overlaySize.width).toDp() }
+    val yOffsetDp = with(density) { (inferenceResult.bboxTopLeftY * overlaySize.height).toDp() }
+    val widthDp = with(density) { (inferenceResult.bboxWidth * overlaySize.width).toDp() }
+    val heightDp = with(density) { (inferenceResult.bboxHeight * overlaySize.height).toDp() }
+
+    val formattedConfidence = "%.2f".format(inferenceResult.bboxConfidence)
+
+    Box(modifier = modifier.offset(x = xOffsetDp, y = yOffsetDp)) {
+        Text(
+            text = "specimen $formattedConfidence",
+            color = MaterialTheme.colors.buttonText,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier
+                .layout { measurable, constraints ->
+                    val placeable = measurable.measure(constraints)
+                    layout(placeable.width, placeable.height) {
+                        placeable.placeRelative(x = 0, y = -placeable.height)
+                    }
+                }
+                .background(boxColor)
+                .padding(
+                    horizontal = MaterialTheme.dimensions.paddingExtraSmall,
+                    vertical = MaterialTheme.dimensions.paddingExtraExtraSmall
+                )
         )
-        val boxSize = Size(
-            width = inferenceResult.bboxWidth * overlaySize.width,
-            height = inferenceResult.bboxHeight * overlaySize.height
-        )
-        
-        drawRect(
-            color = boxColor,
-            topLeft = topLeft,
-            size = boxSize,
-            style = Stroke(width = strokeWidth)
+
+        Box(
+            modifier = Modifier
+                .size(width = widthDp, height = heightDp)
+                .border(width = strokeWidth, color = boxColor)
         )
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/BoundingBoxOverlay.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/components/camera/BoundingBoxOverlay.kt
@@ -25,12 +25,18 @@ fun BoundingBoxOverlay(
 ) {
     val density = LocalDensity.current
     val strokeWidth = MaterialTheme.dimensions.borderThicknessThick
+    val halfStrokeWidth = strokeWidth / 2
     val boxColor = MaterialTheme.colors.successConfirm
 
-    val xOffsetDp = with(density) { (inferenceResult.bboxTopLeftX * overlaySize.width).toDp() }
-    val yOffsetDp = with(density) { (inferenceResult.bboxTopLeftY * overlaySize.height).toDp() }
-    val widthDp = with(density) { (inferenceResult.bboxWidth * overlaySize.width).toDp() }
-    val heightDp = with(density) { (inferenceResult.bboxHeight * overlaySize.height).toDp() }
+    val baseXOffsetDp = with(density) { (inferenceResult.bboxTopLeftX * overlaySize.width).toDp() }
+    val baseYOffsetDp = with(density) { (inferenceResult.bboxTopLeftY * overlaySize.height).toDp() }
+    val baseWidthDp = with(density) { (inferenceResult.bboxWidth * overlaySize.width).toDp() }
+    val baseHeightDp = with(density) { (inferenceResult.bboxHeight * overlaySize.height).toDp() }
+
+    val xOffsetDp = baseXOffsetDp - halfStrokeWidth
+    val yOffsetDp = baseYOffsetDp - halfStrokeWidth
+    val widthDp = baseWidthDp + strokeWidth
+    val heightDp = baseHeightDp + strokeWidth
 
     val formattedConfidence = "%.2f".format(inferenceResult.bboxConfidence)
 

--- a/app/src/main/java/com/vci/vectorcamapp/ui/theme/Dimensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/ui/theme/Dimensions.kt
@@ -11,6 +11,7 @@ data class Dimensions(
     private val scale: Float = 1f,
 
     // Padding & Spacing
+    val paddingExtraExtraSmall: Dp = (2 * scale).dp,
     val paddingExtraSmall: Dp = (4 * scale).dp,
     val paddingSmall: Dp = (8 * scale).dp,
     val paddingMedium: Dp = (16 * scale).dp,


### PR DESCRIPTION
This pull request refactors the `BoundingBoxOverlay` composable to improve how bounding boxes and their labels are rendered on the camera preview. The main change is switching from drawing with a `Canvas` to using `Box` layouts, which allows for easier positioning and styling of the bounding box and its associated confidence label. Additionally, a new padding dimension is introduced for finer control of label spacing.

Bounding box rendering improvements:
* Refactored the `BoundingBoxOverlay` composable to use `Box` layouts instead of `Canvas`, enabling easier overlay of text labels and bounding boxes, and simplifying the calculation of positions and dimensions using Compose's layout system. [[1]](diffhunk://#diff-51a7013c6a3dabf44339d18bb224570d3efa755063de7144f48f2ba7812f37bcL3-R13) [[2]](diffhunk://#diff-51a7013c6a3dabf44339d18bb224570d3efa755063de7144f48f2ba7812f37bcL23-R59)
* Added a confidence label above each bounding box, displaying the specimen confidence value with improved styling and positioning, including background color and padding.

UI consistency:
* Introduced a new `paddingExtraExtraSmall` value in the `Dimensions` class for more granular control of padding, used in the label styling.