### PR TITLE
Release: Update build.gradle version codes for Uganda and Ghana

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,8 +54,8 @@ android {
         create("uganda") {
             dimension = "region"
             // applicationIdSuffix = ".uganda"
-            versionCode = 2008
-            versionName = "1.0.8"
+            versionCode = 2010
+            versionName = "1.0.10"
             
             buildConfigField("String", "REGION", "\"uganda\"")
             buildConfigField("String", "REGION_CODE", "\"UG\"")
@@ -111,8 +111,8 @@ android {
         create("ghana") {
             dimension = "region"
             applicationIdSuffix = ".ghana"
-            versionCode = 5001
-            versionName = "1.0.1"
+            versionCode = 5002
+            versionName = "1.0.2"
             
             buildConfigField("String", "REGION", "\"ghana\"")
             buildConfigField("String", "REGION_CODE", "\"GH\"")


### PR DESCRIPTION
This pull request updates the versioning for the Uganda and Ghana regional build variants in the `app/build.gradle.kts` file. The main changes are incrementing the `versionCode` and updating the `versionName` for both regions.

**Uganda and Ghana build variant updates:**

* Increased the `versionCode` for the Uganda build variant from 2008 to 2010 and updated the `versionName` from "1.0.8" to "1.0.10" (`app/build.gradle.kts`)
* Increased the `versionCode` for the Ghana build variant from 5001 to 5002 and updated the `versionName` from "1.0.1" to "1.0.2" (`app/build.gradle.kts`)