### PR TITLE
feat(SOF-379): auto capture

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/ToggleField.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/components/form/ToggleField.kt
@@ -17,7 +17,8 @@ import com.vci.vectorcamapp.ui.extensions.dimensions
 fun ToggleField(
     label: String,
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
+    onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean = true,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -26,12 +27,13 @@ fun ToggleField(
         Text(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colors.textSecondary,
+            color = if (enabled) MaterialTheme.colors.textSecondary else MaterialTheme.colors.disabled,
             modifier = Modifier.weight(1f)
         )
         Switch(
             checked = checked,
             onCheckedChange = onCheckedChange,
+            enabled = enabled,
             colors = SwitchDefaults.colors(
                 checkedThumbColor = MaterialTheme.colors.successConfirm,
                 uncheckedThumbColor = MaterialTheme.colors.disabled,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
@@ -11,6 +11,7 @@ sealed interface ImagingAction {
     data object SaveSessionProgress : ImagingAction
     data object SubmitSession : ImagingAction
     data class ToggleModelInference(val isChecked: Boolean) : ImagingAction
+    data class ToggleAutoCapture(val isChecked: Boolean) : ImagingAction
     data class CaptureImage(
         val imageCapture: ImageCapture,
         val cameraMetadata: CameraMetadata? = null

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -101,14 +101,24 @@ fun ImagingScreen(
     var camera by remember { mutableStateOf<Camera?>(null) }
     val metadataListener = remember { CameraMetadataListenerImplementation() }
 
-    val isReviewing by rememberUpdatedState(newValue = state.currentImageBytes != null)
+    val isReviewingRef = rememberUpdatedState(newValue = state.currentImageBytes != null)
+    val pagerState = rememberPagerState(
+        initialPage = state.specimensWithImagesAndInferenceResults.size,
+        pageCount = { state.specimensWithImagesAndInferenceResults.size + 1 })
+    val currentPageRef = rememberUpdatedState(newValue = pagerState.currentPage)
+    val livePageIndexRef = rememberUpdatedState(newValue = state.specimensWithImagesAndInferenceResults.size)
+
     val analyzer = remember {
         SpecimenImageAnalyzer { frame ->
-            if (!isReviewing) {
-                onAction(ImagingAction.ProcessFrame(frame))
-            } else {
+            if (isReviewingRef.value) {
                 frame.close()
+                return@SpecimenImageAnalyzer
             }
+            if (currentPageRef.value != livePageIndexRef.value) {
+                frame.close()
+                return@SpecimenImageAnalyzer
+            }
+            onAction(ImagingAction.ProcessFrame(frame))
         }
     }
 
@@ -179,14 +189,17 @@ fun ImagingScreen(
         }
     }
 
-    val pagerState = rememberPagerState(
-        initialPage = state.specimensWithImagesAndInferenceResults.size,
-        pageCount = { state.specimensWithImagesAndInferenceResults.size + 1 })
-
     var isImageLoaded by remember { mutableStateOf(false) }
 
     LaunchedEffect(state.specimensWithImagesAndInferenceResults.size) {
         pagerState.scrollToPage(state.specimensWithImagesAndInferenceResults.size)
+    }
+
+    LaunchedEffect(state.autoCaptureSignal, imageCaptureUseCase) {
+        if (state.autoCaptureSignal <= 0L) return@LaunchedEffect
+        val ic = imageCaptureUseCase ?: return@LaunchedEffect
+        if (state.currentImageBytes != null || state.isProcessing) return@LaunchedEffect
+        onAction(ImagingAction.CaptureImage(ic, metadataListener.latestMetadata))
     }
 
     HorizontalPager(
@@ -759,6 +772,13 @@ fun ImagingScreen(
                                             )
                                             Spacer(modifier = Modifier.height(MaterialTheme.dimensions.spacingMedium))
                                         }
+
+                                        ToggleField(
+                                            label = "Auto-capture",
+                                            checked = state.isAutoCaptureEnabled,
+                                            onCheckedChange = { onAction(ImagingAction.ToggleAutoCapture(it)) },
+                                        )
+                                        Spacer(modifier = Modifier.height(MaterialTheme.dimensions.spacingMedium))
 
                                         Text(
                                             text = if (state.currentSpecimen.id == "") "Specimen ID will appear here" else state.currentSpecimen.id,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingState.kt
@@ -36,6 +36,8 @@ data class ImagingState(
     val focusPoint: Offset? = null,
     val allowModelInferenceToggle: Boolean = false,
     val shouldRunInference: Boolean = true,
+    val isAutoCaptureEnabled: Boolean = false,
+    val autoCaptureSignal: Long = 0L,
     val isManualFocusing: Boolean = false,
     val isCameraReady: Boolean = false,
     val showExitDialog: Boolean = false,

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -1,6 +1,7 @@
 package com.vci.vectorcamapp.imaging.presentation
 
 import android.graphics.Bitmap
+import android.os.SystemClock
 import android.net.Uri
 import android.util.Log
 import androidx.compose.material3.SnackbarDuration
@@ -52,6 +53,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 import org.opencv.core.MatOfByte
@@ -86,6 +88,8 @@ class ImagingViewModel @Inject constructor(
 
     private var lastAutoCaptureBbox: InferenceResult? = null
     private var autoCaptureStableFrameCount: Int = 0
+    /** [SystemClock.elapsedRealtime] when the current stable streak began; 0 = unset. */
+    private var autoCaptureStableStreakStartElapsedMs: Long = 0L
 
     @Inject
     lateinit var transactionHelper: TransactionHelper
@@ -668,11 +672,17 @@ class ImagingViewModel @Inject constructor(
         private const val MONTHLY_FURTHER_PROCESSING_CAP = 20
         private const val AUTO_CAPTURE_MIN_CONFIDENCE = 0.5f
         private const val AUTO_CAPTURE_MIN_BBOX_IOU = 0.7f
+        /** Max normalized (0–1) L∞ delta between bbox centers for consecutive frames to count as stable. */
+        private const val AUTO_CAPTURE_MAX_CENTER_SHIFT = 0.05f
+        /** Need at least this many consecutive stable frames (pairs with IoU/center checks) before time gate applies. */
+        private const val AUTO_CAPTURE_MIN_STABLE_FRAMES = 2
+        private const val AUTO_CAPTURE_MIN_STABLE_DURATION_MS = 2_000L
     }
 
     private fun resetAutoCaptureStability() {
         lastAutoCaptureBbox = null
         autoCaptureStableFrameCount = 0
+        autoCaptureStableStreakStartElapsedMs = 0L
     }
 
     private fun bboxIoU(a: InferenceResult, b: InferenceResult): Float {
@@ -693,6 +703,15 @@ class ImagingViewModel @Inject constructor(
         return if (union <= 0f) 0f else interArea / union
     }
 
+    /** Largest absolute normalized shift of bbox center along x or y between two detections. */
+    private fun bboxMaxCenterShiftNorm(a: InferenceResult, b: InferenceResult): Float {
+        val acx = a.bboxTopLeftX + a.bboxWidth * 0.5f
+        val acy = a.bboxTopLeftY + a.bboxHeight * 0.5f
+        val bcx = b.bboxTopLeftX + b.bboxWidth * 0.5f
+        val bcy = b.bboxTopLeftY + b.bboxHeight * 0.5f
+        return max(abs(acx - bcx), abs(acy - bcy))
+    }
+
     private fun maybeSignalAutoCapture(highestConfidenceDetection: InferenceResult?) {
         val snapshot = _state.value
         if (!snapshot.isAutoCaptureEnabled || !snapshot.shouldRunInference || snapshot.currentImageBytes != null) {
@@ -707,14 +726,26 @@ class ImagingViewModel @Inject constructor(
         }
 
         val prev = lastAutoCaptureBbox
-        if (prev != null && bboxIoU(prev, det) >= AUTO_CAPTURE_MIN_BBOX_IOU) {
+        val iouOk = prev != null && bboxIoU(prev, det) >= AUTO_CAPTURE_MIN_BBOX_IOU
+        val positionStable =
+            prev != null && bboxMaxCenterShiftNorm(prev, det) <= AUTO_CAPTURE_MAX_CENTER_SHIFT
+        if (iouOk && positionStable) {
             autoCaptureStableFrameCount++
         } else {
             autoCaptureStableFrameCount = 1
+            autoCaptureStableStreakStartElapsedMs = SystemClock.elapsedRealtime()
         }
         lastAutoCaptureBbox = det
 
-        if (autoCaptureStableFrameCount >= 2) {
+        val streakAgeMs =
+            if (autoCaptureStableStreakStartElapsedMs > 0L) {
+                SystemClock.elapsedRealtime() - autoCaptureStableStreakStartElapsedMs
+            } else {
+                0L
+            }
+        if (autoCaptureStableFrameCount >= AUTO_CAPTURE_MIN_STABLE_FRAMES &&
+            streakAgeMs >= AUTO_CAPTURE_MIN_STABLE_DURATION_MS
+        ) {
             resetAutoCaptureStability()
             _state.update { it.copy(autoCaptureSignal = it.autoCaptureSignal + 1L) }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -49,7 +49,11 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.math.max
+import kotlin.math.min
 import org.opencv.core.MatOfByte
 import org.opencv.imgcodecs.Imgcodecs
 import org.opencv.imgproc.Imgproc
@@ -77,6 +81,11 @@ class ImagingViewModel @Inject constructor(
     private val validateSpecimenIdUseCase: ValidateSpecimenIdUseCase,
     errorMessageEmitter: ErrorMessageEmitter,
 ) : CoreViewModel(errorMessageEmitter) {
+
+    private val processFrameMutex = Mutex()
+
+    private var lastAutoCaptureBbox: InferenceResult? = null
+    private var autoCaptureStableFrameCount: Int = 0
 
     @Inject
     lateinit var transactionHelper: TransactionHelper
@@ -158,89 +167,95 @@ class ImagingViewModel @Inject constructor(
                 }
 
                 is ImagingAction.ProcessFrame -> {
-                    try {
-                        if (!_state.value.isCameraReady) {
-                            _state.update { it.copy(isCameraReady = true) }
-                        }
-
-                        if (!_state.value.isProcessing) {
-                            val bitmap = action.frame.toUprightBitmap()
-
-                            val specimenId = inferenceRepository.readSpecimenId(bitmap)
-                            validateSpecimenIdUseCase(specimenId, shouldAutoCorrect = true).onSuccess { correctedSpecimenId ->
-                                _state.update {
-                                    it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
-                                }
-                            }.onError {
-                                _state.update {
-                                    it.copy(currentSpecimen = it.currentSpecimen.copy(id = ""))
-                                }
+                    processFrameMutex.withLock {
+                        try {
+                            if (!_state.value.isCameraReady) {
+                                _state.update { it.copy(isCameraReady = true) }
                             }
 
-                            if (_state.value.shouldRunInference) {
-                                val jpegStream = ByteArrayOutputStream()
-                                bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
-                                val jpegByteArray = jpegStream.toByteArray()
+                            if (!_state.value.isProcessing) {
+                                val bitmap = action.frame.toUprightBitmap()
 
-                                val bgrMatrix = Imgcodecs.imdecode(MatOfByte(*jpegByteArray), Imgcodecs.IMREAD_COLOR)
-                                val rgbaMatrix = Mat()
-                                Imgproc.cvtColor(bgrMatrix, rgbaMatrix, Imgproc.COLOR_BGR2RGBA)
-                                val jpegBitmap = createBitmap(rgbaMatrix.cols(), rgbaMatrix.rows())
-                                matToBitmap(rgbaMatrix, jpegBitmap)
-                                bgrMatrix.release()
-                                rgbaMatrix.release()
-
-                                val previewInferenceResults = inferenceRepository.detectSpecimen(jpegBitmap).map { detectorResult ->
-                                    InferenceResult(
-                                        bboxTopLeftX = detectorResult.bboxTopLeftX,
-                                        bboxTopLeftY = detectorResult.bboxTopLeftY,
-                                        bboxWidth = detectorResult.bboxWidth,
-                                        bboxHeight = detectorResult.bboxHeight,
-                                        bboxConfidence = detectorResult.bboxConfidence,
-                                        bboxClassId = detectorResult.bboxClassId,
-                                        speciesLogits = null,
-                                        sexLogits = null,
-                                        abdomenStatusLogits = null,
-                                        bboxDetectionDuration = detectorResult.bboxDetectionDuration,
-                                        speciesInferenceDuration = null,
-                                        sexInferenceDuration = null,
-                                        abdomenStatusInferenceDuration = null
-                                    )
-                                }
-                                val highestConfidenceDetection =
-                                    previewInferenceResults.maxByOrNull { it.bboxConfidence }
-                                val autofocusPoint = highestConfidenceDetection?.let { detection ->
-                                    inferenceRepository.computeAutofocusCentroid(jpegBitmap, detection)
+                                val specimenId = inferenceRepository.readSpecimenId(bitmap)
+                                validateSpecimenIdUseCase(specimenId, shouldAutoCorrect = true).onSuccess { correctedSpecimenId ->
+                                    _state.update {
+                                        it.copy(currentSpecimen = it.currentSpecimen.copy(id = correctedSpecimenId))
+                                    }
+                                }.onError {
+                                    _state.update {
+                                        it.copy(currentSpecimen = it.currentSpecimen.copy(id = ""))
+                                    }
                                 }
 
-                                _state.update {
-                                    val shouldUseAutofocusThisFrame =
-                                        !it.isManualFocusing || (it.focusPoint == null && autofocusPoint != null)
+                                if (_state.value.shouldRunInference) {
+                                    val jpegStream = ByteArrayOutputStream()
+                                    bitmap.compress(Bitmap.CompressFormat.JPEG, 100, jpegStream)
+                                    val jpegByteArray = jpegStream.toByteArray()
 
-                                    val nextFocusPoint = if (shouldUseAutofocusThisFrame) {
-                                        autofocusPoint ?: it.focusPoint
-                                    } else {
-                                        it.focusPoint
+                                    val bgrMatrix = Imgcodecs.imdecode(MatOfByte(*jpegByteArray), Imgcodecs.IMREAD_COLOR)
+                                    val rgbaMatrix = Mat()
+                                    Imgproc.cvtColor(bgrMatrix, rgbaMatrix, Imgproc.COLOR_BGR2RGBA)
+                                    val jpegBitmap = createBitmap(rgbaMatrix.cols(), rgbaMatrix.rows())
+                                    matToBitmap(rgbaMatrix, jpegBitmap)
+                                    bgrMatrix.release()
+                                    rgbaMatrix.release()
+
+                                    val previewInferenceResults = inferenceRepository.detectSpecimen(jpegBitmap).map { detectorResult ->
+                                        InferenceResult(
+                                            bboxTopLeftX = detectorResult.bboxTopLeftX,
+                                            bboxTopLeftY = detectorResult.bboxTopLeftY,
+                                            bboxWidth = detectorResult.bboxWidth,
+                                            bboxHeight = detectorResult.bboxHeight,
+                                            bboxConfidence = detectorResult.bboxConfidence,
+                                            bboxClassId = detectorResult.bboxClassId,
+                                            speciesLogits = null,
+                                            sexLogits = null,
+                                            abdomenStatusLogits = null,
+                                            bboxDetectionDuration = detectorResult.bboxDetectionDuration,
+                                            speciesInferenceDuration = null,
+                                            sexInferenceDuration = null,
+                                            abdomenStatusInferenceDuration = null
+                                        )
+                                    }
+                                    val highestConfidenceDetection =
+                                        previewInferenceResults.maxByOrNull { it.bboxConfidence }
+                                    val autofocusPoint = highestConfidenceDetection?.let { detection ->
+                                        inferenceRepository.computeAutofocusCentroid(jpegBitmap, detection)
                                     }
 
-                                    val nextIsAutofocusing = when {
-                                        !it.isManualFocusing -> true
-                                        it.focusPoint == null && autofocusPoint != null -> true
-                                        else -> false
+                                    _state.update {
+                                        val shouldUseAutofocusThisFrame =
+                                            !it.isManualFocusing || (it.focusPoint == null && autofocusPoint != null)
+
+                                        val nextFocusPoint = if (shouldUseAutofocusThisFrame) {
+                                            autofocusPoint ?: it.focusPoint
+                                        } else {
+                                            it.focusPoint
+                                        }
+
+                                        val nextIsAutofocusing = when {
+                                            !it.isManualFocusing -> true
+                                            it.focusPoint == null && autofocusPoint != null -> true
+                                            else -> false
+                                        }
+
+                                        it.copy(
+                                            previewInferenceResults = previewInferenceResults,
+                                            focusPoint = nextFocusPoint,
+                                            isManualFocusing = !nextIsAutofocusing
+                                        )
                                     }
 
-                                    it.copy(
-                                        previewInferenceResults = previewInferenceResults,
-                                        focusPoint = nextFocusPoint,
-                                        isManualFocusing = !nextIsAutofocusing
-                                    )
+                                    maybeSignalAutoCapture(highestConfidenceDetection)
+                                } else {
+                                    resetAutoCaptureStability()
                                 }
                             }
+                        } catch (e: Exception) {
+                            emitError(ImagingError.PROCESSING_ERROR)
+                        } finally {
+                            action.frame.close()
                         }
-                    } catch (e: Exception) {
-                        emitError(ImagingError.PROCESSING_ERROR)
-                    } finally {
-                        action.frame.close()
                     }
                 }
 
@@ -270,9 +285,11 @@ class ImagingViewModel @Inject constructor(
 
                 is ImagingAction.ToggleModelInference -> {
                     val shouldRunInference = action.isChecked
+                    resetAutoCaptureStability()
                     _state.update {
                         it.copy(
                             shouldRunInference = shouldRunInference,
+                            isAutoCaptureEnabled = if (shouldRunInference) it.isAutoCaptureEnabled else false,
                             previewInferenceResults = emptyList(),
                             currentInferenceResult = null,
                             focusPoint = null
@@ -280,10 +297,21 @@ class ImagingViewModel @Inject constructor(
                     }
                 }
 
+                is ImagingAction.ToggleAutoCapture -> {
+                    resetAutoCaptureStability()
+                    _state.update { it.copy(isAutoCaptureEnabled = action.isChecked) }
+                }
+
                 is ImagingAction.CaptureImage -> {
                     if (!_state.value.isCameraReady) return@launch
 
-                    _state.update { it.copy(isProcessing = true) }
+                    resetAutoCaptureStability()
+                    _state.update {
+                        it.copy(
+                            isProcessing = true,
+                            autoCaptureSignal = 0L,
+                        )
+                    }
 
                     val captureResult = cameraRepository.captureImage(action.imageCapture)
 
@@ -551,8 +579,10 @@ class ImagingViewModel @Inject constructor(
     }
 
     private fun clearStateFields() {
+        resetAutoCaptureStability()
         _state.update {
             it.copy(
+                autoCaptureSignal = 0L,
                 currentSpecimen = it.currentSpecimen.copy(
                     id = "", remoteId = null, shouldProcessFurther = false
                 ),
@@ -636,5 +666,57 @@ class ImagingViewModel @Inject constructor(
 
     private companion object {
         private const val MONTHLY_FURTHER_PROCESSING_CAP = 20
+        private const val AUTO_CAPTURE_MIN_CONFIDENCE = 0.5f
+        private const val AUTO_CAPTURE_MIN_BBOX_IOU = 0.7f
+    }
+
+    private fun resetAutoCaptureStability() {
+        lastAutoCaptureBbox = null
+        autoCaptureStableFrameCount = 0
+    }
+
+    private fun bboxIoU(a: InferenceResult, b: InferenceResult): Float {
+        val ax2 = a.bboxTopLeftX + a.bboxWidth
+        val ay2 = a.bboxTopLeftY + a.bboxHeight
+        val bx2 = b.bboxTopLeftX + b.bboxWidth
+        val by2 = b.bboxTopLeftY + b.bboxHeight
+        val interLeft = max(a.bboxTopLeftX, b.bboxTopLeftX)
+        val interTop = max(a.bboxTopLeftY, b.bboxTopLeftY)
+        val interRight = min(ax2, bx2)
+        val interBottom = min(ay2, by2)
+        val interW = max(0f, interRight - interLeft)
+        val interH = max(0f, interBottom - interTop)
+        val interArea = interW * interH
+        val areaA = a.bboxWidth * a.bboxHeight
+        val areaB = b.bboxWidth * b.bboxHeight
+        val union = areaA + areaB - interArea
+        return if (union <= 0f) 0f else interArea / union
+    }
+
+    private fun maybeSignalAutoCapture(highestConfidenceDetection: InferenceResult?) {
+        val snapshot = _state.value
+        if (!snapshot.isAutoCaptureEnabled || !snapshot.shouldRunInference || snapshot.currentImageBytes != null) {
+            resetAutoCaptureStability()
+            return
+        }
+
+        val det = highestConfidenceDetection
+        if (det == null || det.bboxConfidence <= AUTO_CAPTURE_MIN_CONFIDENCE) {
+            resetAutoCaptureStability()
+            return
+        }
+
+        val prev = lastAutoCaptureBbox
+        if (prev != null && bboxIoU(prev, det) >= AUTO_CAPTURE_MIN_BBOX_IOU) {
+            autoCaptureStableFrameCount++
+        } else {
+            autoCaptureStableFrameCount = 1
+        }
+        lastAutoCaptureBbox = det
+
+        if (autoCaptureStableFrameCount >= 2) {
+            resetAutoCaptureStability()
+            _state.update { it.copy(autoCaptureSignal = it.autoCaptureSignal + 1L) }
+        }
     }
 }


### PR DESCRIPTION
auto capture when the confident is above 50% and add toggle to the imaging screen for enable/disable auto capture
logic behavior: 
image streak must stay stable (same rules: confidence > 0.5, IoU ≥ 0.7, center shift ≤ 5%) for at least AUTO_CAPTURE_MIN_STABLE_DURATION_MS = 2 seconds of SystemClock.elapsedRealtime() (monotonic, not affected by wall-clock jumps).
Still required: At least AUTO_CAPTURE_MIN_STABLE_FRAMES = 2 consecutive stable frames so the first frame can seed lastAutoCaptureBbox and the second can validate IoU/center. After that, more frames can keep the streak alive until the 2s timer is satisfied.

- On any broken streak (else branch: new bbox or first frame), autoCaptureStableFrameCount is set to 1 and autoCaptureStableStreakStartElapsedMs is reset to “now,” so the 2s window always measures continuous stability.
- resetAutoCaptureStability() also clears the streak start time (with lastAutoCaptureBbox and the frame counter).