### PR TITLE
fix: audit and harden error handling pipeline

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/MainActivity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/MainActivity.kt
@@ -89,7 +89,9 @@ class MainActivity : ComponentActivity() {
                     }
                     state.allGranted && state.isGpsEnabled -> {
                         when (val startDestination = state.startDestination) {
-                            null -> SplashScreen(modifier = Modifier.fillMaxSize())
+                            null -> BaseScaffold(modifier = Modifier.fillMaxSize()) {
+                                SplashScreen(modifier = Modifier.fillMaxSize())
+                            }
                             else -> NavGraph(startDestination = startDestination)
                         }
                     }

--- a/app/src/main/java/com/vci/vectorcamapp/MainActivity.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import com.vci.vectorcamapp.core.presentation.components.scaffold.BaseScaffold
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -93,7 +94,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                     else -> {
-                        Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                        BaseScaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                             PermissionScreen(
                                 state = state,
                                 onAction = viewModel::onAction,

--- a/app/src/main/java/com/vci/vectorcamapp/collection_batch/list/presentation/CollectionBatchListViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/collection_batch/list/presentation/CollectionBatchListViewModel.kt
@@ -16,7 +16,10 @@ import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SessionUnitRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenImageRepository
 import com.vci.vectorcamapp.core.domain.repository.WorkManagerRepository
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import com.vci.vectorcamapp.core.logging.analytics.VectorCamAnalytics
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlytics
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlyticsContext
 import com.vci.vectorcamapp.core.presentation.CoreViewModel
 import com.vci.vectorcamapp.core.presentation.util.error.ErrorMessageEmitter
 import com.vci.vectorcamapp.navigation.Destination
@@ -177,6 +180,15 @@ class CollectionBatchListViewModel @Inject constructor(
                     val currentSessionSiteId = currentSessionCache.getSiteId()
 
                     if (currentSession == null || currentSessionSiteId == null) {
+                        VectorCamCrashlytics.exception(
+                            throwable = IllegalStateException("Submit attempted with no active session in cache"),
+                            context = VectorCamCrashlyticsContext(
+                                screen = "CollectionBatchList",
+                                feature = "Session Submit",
+                                action = "ConfirmSubmitSession"
+                            )
+                        )
+                        emitError(RoomDbError.UNKNOWN_ERROR)
                         _events.send(CollectionBatchListEvent.NavigateBackToLandingScreen)
                         return@launch
                     }
@@ -188,6 +200,17 @@ class CollectionBatchListViewModel @Inject constructor(
                         )
                         currentSessionCache.clearSession()
                         _events.send(CollectionBatchListEvent.NavigateBackToLandingScreen)
+                    } else {
+                        VectorCamCrashlytics.exception(
+                            throwable = IllegalStateException("markSessionAsComplete returned false"),
+                            context = VectorCamCrashlyticsContext(
+                                screen = "CollectionBatchList",
+                                feature = "Session Submit",
+                                action = "markSessionAsComplete",
+                                sessionId = currentSession.localId.toString()
+                            )
+                        )
+                        emitError(RoomDbError.UNKNOWN_ERROR)
                     }
                 }
             }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/list/presentation/CompleteSessionListViewModel.kt
@@ -3,6 +3,7 @@ package com.vci.vectorcamapp.complete_session.list.presentation
 import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.domain.model.enums.UploadStatus
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import com.vci.vectorcamapp.core.domain.model.helpers.SessionUploadProgress
 import com.vci.vectorcamapp.core.domain.repository.SessionRepository
 import com.vci.vectorcamapp.core.domain.repository.SpecimenImageRepository
@@ -25,7 +26,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -108,7 +108,7 @@ class CompleteSessionListViewModel @Inject constructor(
     val events = _events.receiveAsFlow()
 
     fun onAction(action: CompleteSessionListAction) {
-        viewModelScope.launch {
+        safeLaunch(screen = "CompleteSessionList") {
             when (action) {
                 CompleteSessionListAction.ReturnToLandingScreen -> {
                     _events.send(CompleteSessionListEvent.NavigateBackToLandingScreen)
@@ -119,27 +119,31 @@ class CompleteSessionListViewModel @Inject constructor(
                 }
 
                 is CompleteSessionListAction.UploadAllPendingSessions -> {
-                    val completeSessionsAndSites =
-                        sessionRepository.observeCompleteSessionsAndSites().first()
-                    for (sessionAndSite in completeSessionsAndSites) {
-                        val session = sessionAndSite.session
-                        val site = sessionAndSite.site
+                    runCatching {
+                        val completeSessionsAndSites =
+                            sessionRepository.observeCompleteSessionsAndSites().first()
+                        for (sessionAndSite in completeSessionsAndSites) {
+                            val session = sessionAndSite.session
+                            val site = sessionAndSite.site
 
-                        val isSessionUploaded = (session.submittedAt != null)
+                            val isSessionUploaded = (session.submittedAt != null)
 
-                        val specimens =
-                            specimenRepository.getSpecimenImagesAndInferenceResultsBySessionScope(
-                                session.localId, null
-                            )
-                        val areSpecimensUploaded = !specimens.any { specimen ->
-                            specimen.specimenImagesAndInferenceResults.any { (image, _) ->
-                                image.metadataUploadStatus != UploadStatus.COMPLETED || image.imageUploadStatus != UploadStatus.COMPLETED
+                            val specimens =
+                                specimenRepository.getSpecimenImagesAndInferenceResultsBySessionScope(
+                                    session.localId, null
+                                )
+                            val areSpecimensUploaded = !specimens.any { specimen ->
+                                specimen.specimenImagesAndInferenceResults.any { (image, _) ->
+                                    image.metadataUploadStatus != UploadStatus.COMPLETED || image.imageUploadStatus != UploadStatus.COMPLETED
+                                }
                             }
+
+                            if (isSessionUploaded && areSpecimensUploaded) continue
+
+                            workManagerRepository.enqueueSessionUpload(session.localId, site.id)
                         }
-
-                        if (isSessionUploaded && areSpecimensUploaded) continue
-
-                        workManagerRepository.enqueueSessionUpload(session.localId, site.id)
+                    }.onFailure {
+                        emitError(RoomDbError.UNKNOWN_ERROR)
                     }
                 }
 

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/CurrentSessionCacheDtoSerializer.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/CurrentSessionCacheDtoSerializer.kt
@@ -5,6 +5,7 @@ import com.vci.vectorcamapp.core.data.dto.cache.CurrentSessionCacheDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -25,7 +26,7 @@ object CurrentSessionCacheDtoSerializer : Serializer<CurrentSessionCacheDto> {
                 string = input.readBytes().decodeToString()
             )
         } catch (e: Exception) {
-            e.printStackTrace()
+            Timber.e(e, "CurrentSessionCache: deserialization failed, resetting to default")
             defaultValue
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/DefaultIntakeFieldsCacheDtoSerializer.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/DefaultIntakeFieldsCacheDtoSerializer.kt
@@ -5,6 +5,7 @@ import com.vci.vectorcamapp.core.data.dto.cache.DefaultIntakeFieldsCacheDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -25,7 +26,7 @@ object DefaultIntakeFieldsCacheDtoSerializer : Serializer<DefaultIntakeFieldsCac
                 string = input.readBytes().decodeToString()
             )
         } catch (e: Exception) {
-            e.printStackTrace()
+            Timber.e(e, "DefaultIntakeFieldsCache: deserialization failed, resetting to default")
             defaultValue
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/DeviceCacheDtoSerializer.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/cache/serializers/DeviceCacheDtoSerializer.kt
@@ -5,6 +5,7 @@ import com.vci.vectorcamapp.core.data.dto.cache.DeviceCacheDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -25,7 +26,7 @@ object DeviceCacheDtoSerializer : Serializer<DeviceCacheDto> {
                 string = input.readBytes().decodeToString()
             )
         } catch (e: Exception) {
-            e.printStackTrace()
+            Timber.e(e, "DeviceCache: deserialization failed, resetting to default")
             defaultValue
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/network/safeCall.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/network/safeCall.kt
@@ -6,6 +6,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.util.network.UnresolvedAddressException
 import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.SerializationException
+import timber.log.Timber
 import java.net.UnknownHostException
 import kotlin.coroutines.coroutineContext
 
@@ -15,17 +16,17 @@ suspend inline fun <reified T> safeCall(
     val response = try {
         execute()
     } catch (e: UnresolvedAddressException) {
-        e.printStackTrace()
+        Timber.w(e, "Network: no internet (UnresolvedAddressException)")
         return Result.Error(NetworkError.NO_INTERNET)
     } catch (e: UnknownHostException) {
-        e.printStackTrace()
+        Timber.w(e, "Network: no internet (UnknownHostException)")
         return Result.Error(NetworkError.NO_INTERNET)
     } catch (e: SerializationException) {
-        e.printStackTrace()
+        Timber.e(e, "Network: serialization error")
         return Result.Error(NetworkError.SERIALIZATION_ERROR)
     } catch (e: Exception) {
         coroutineContext.ensureActive()
-        e.printStackTrace()
+        Timber.e(e, "Network: unexpected error")
         return Result.Error(NetworkError.UNKNOWN_ERROR)
     }
 

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/CollectorRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/CollectorRepositoryImplementation.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import javax.inject.Inject
 
 class CollectorRepositoryImplementation @Inject constructor(
@@ -19,7 +20,7 @@ class CollectorRepositoryImplementation @Inject constructor(
             collectorDao.upsertCollector(collector.toEntity())
             Result.Success(Unit)
         } catch (e: Exception) {
-            e.printStackTrace()
+            Timber.e(e, "CollectorRepository: upsertCollector failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/FormAnswerRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/FormAnswerRepositoryImplementation.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -32,6 +33,7 @@ class FormAnswerRepositoryImplementation @Inject constructor(
             )
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "FormAnswerRepository: upsertFormAnswer failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/FormQuestionRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/FormQuestionRepositoryImplementation.kt
@@ -8,6 +8,7 @@ import com.vci.vectorcamapp.core.domain.model.enums.FormQuestionScope
 import com.vci.vectorcamapp.core.domain.repository.FormQuestionRepository
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
+import timber.log.Timber
 import javax.inject.Inject
 
 class FormQuestionRepositoryImplementation @Inject constructor(
@@ -21,6 +22,7 @@ class FormQuestionRepositoryImplementation @Inject constructor(
             formQuestionDao.upsertFormQuestion(formQuestion.toEntity(formId, parentId))
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "FormQuestionRepository: upsertFormQuestion failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/FormRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/FormRepositoryImplementation.kt
@@ -11,6 +11,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -23,6 +24,7 @@ class FormRepositoryImplementation @Inject constructor(
             formDao.upsertForm(form.toEntity(programId))
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "FormRepository: upsertForm failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/InferenceResultRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/InferenceResultRepositoryImplementation.kt
@@ -7,6 +7,7 @@ import com.vci.vectorcamapp.core.domain.model.InferenceResult
 import com.vci.vectorcamapp.core.domain.repository.InferenceResultRepository
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
+import timber.log.Timber
 import javax.inject.Inject
 
 class InferenceResultRepositoryImplementation @Inject constructor(
@@ -19,6 +20,7 @@ class InferenceResultRepositoryImplementation @Inject constructor(
         } catch (e: SQLiteConstraintException) {
             Result.Error(RoomDbError.CONSTRAINT_VIOLATION)
         } catch (e: Exception) {
+            Timber.e(e, "InferenceResultRepository: insertInferenceResult failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }
@@ -34,6 +36,7 @@ class InferenceResultRepositoryImplementation @Inject constructor(
         } catch (e: SQLiteConstraintException) {
             Result.Error(RoomDbError.CONSTRAINT_VIOLATION)
         } catch (e: Exception) {
+            Timber.e(e, "InferenceResultRepository: updateInferenceResult failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/LocationTypeRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/LocationTypeRepositoryImplementation.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import javax.inject.Inject
 
 class LocationTypeRepositoryImplementation @Inject constructor(
@@ -19,6 +20,7 @@ class LocationTypeRepositoryImplementation @Inject constructor(
             locationTypeDao.upsertLocationType(locationType.toEntity(programId))
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "LocationTypeRepository: upsertLocationType failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/ProgramRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/ProgramRepositoryImplementation.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import javax.inject.Inject
 
 class ProgramRepositoryImplementation @Inject constructor(
@@ -20,6 +21,7 @@ class ProgramRepositoryImplementation @Inject constructor(
             programDao.upsertProgram(program.toEntity())
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "ProgramRepository: upsertProgram failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionRepositoryImplementation.kt
@@ -12,6 +12,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -23,6 +24,7 @@ class SessionRepositoryImplementation @Inject constructor(
             sessionDao.upsertSession(session.toEntity(siteId))
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "SessionRepository: upsertSession failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionUnitRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SessionUnitRepositoryImplementation.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -21,6 +22,7 @@ class SessionUnitRepositoryImplementation @Inject constructor(
             sessionUnitDao.upsertSessionUnit(sessionUnit.toEntity(sessionId))
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "SessionUnitRepository: upsertSessionUnit failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SiteRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SiteRepositoryImplementation.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import javax.inject.Inject
 
 class SiteRepositoryImplementation @Inject constructor(
@@ -20,6 +21,7 @@ class SiteRepositoryImplementation @Inject constructor(
             siteDao.upsertSite(site.toEntity(programId, locationTypeId, parentId))
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "SiteRepository: upsertSite failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenImageRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenImageRepositoryImplementation.kt
@@ -8,6 +8,7 @@ import com.vci.vectorcamapp.core.domain.repository.SpecimenImageRepository
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -21,6 +22,7 @@ class SpecimenImageRepositoryImplementation @Inject constructor(
         } catch (e: SQLiteConstraintException) {
             Result.Error(RoomDbError.CONSTRAINT_VIOLATION)
         } catch (e: Exception) {
+            Timber.e(e, "SpecimenImageRepository: insertSpecimenImage failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }
@@ -36,6 +38,7 @@ class SpecimenImageRepositoryImplementation @Inject constructor(
         } catch (e: SQLiteConstraintException) {
             Result.Error(RoomDbError.CONSTRAINT_VIOLATION)
         } catch (e: Exception) {
+            Timber.e(e, "SpecimenImageRepository: updateSpecimenImage failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SpecimenRepositoryImplementation.kt
@@ -12,6 +12,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import timber.log.Timber
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -31,6 +32,7 @@ class SpecimenRepositoryImplementation @Inject constructor(
         } catch (e: SQLiteConstraintException) {
             Result.Error(RoomDbError.CONSTRAINT_VIOLATION)
         } catch (e: Exception) {
+            Timber.e(e, "SpecimenRepository: insertSpecimen failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }
@@ -48,6 +50,7 @@ class SpecimenRepositoryImplementation @Inject constructor(
         } catch (e: SQLiteConstraintException) {
             Result.Error(RoomDbError.CONSTRAINT_VIOLATION)
         } catch (e: Exception) {
+            Timber.e(e, "SpecimenRepository: updateSpecimen failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SurveillanceFormRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/SurveillanceFormRepositoryImplementation.kt
@@ -9,6 +9,7 @@ import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
 
@@ -22,6 +23,7 @@ class SurveillanceFormRepositoryImplementation @Inject constructor(
             surveillanceFormDao.upsertSurveillanceForm(surveillanceForm.toEntity(sessionId))
             Result.Success(Unit)
         } catch (e: Exception) {
+            Timber.e(e, "SurveillanceFormRepository: upsertSurveillanceForm failed")
             Result.Error(RoomDbError.UNKNOWN_ERROR)
         }
     }

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/CoreViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/CoreViewModel.kt
@@ -4,8 +4,14 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vci.vectorcamapp.core.domain.util.Error
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import com.vci.vectorcamapp.core.logging.analytics.VectorCamAnalytics
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlytics
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlyticsContext
 import com.vci.vectorcamapp.core.presentation.util.error.ErrorMessageEmitter
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 abstract class CoreViewModel(
@@ -32,5 +38,32 @@ abstract class CoreViewModel(
         viewModelScope.launch {
             errorMessageEmitter.emit(error, duration)
         }
+    }
+
+    /**
+     * Coroutine launcher with a last-resort exception handler.
+     *
+     * Catches any unhandled exception that escapes the [block], records it as a non-fatal to
+     * Crashlytics, and shows a generic error snackbar so the user is never left in a silent
+     * broken state. Each call site should still handle domain-level errors inline; this exists
+     * purely as a safety net for truly unexpected throws.
+     */
+    protected fun safeLaunch(
+        screen: String = "",
+        feature: String = "",
+        block: suspend CoroutineScope.() -> Unit
+    ): Job {
+        val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+            VectorCamCrashlytics.exception(
+                throwable = throwable,
+                context = VectorCamCrashlyticsContext(
+                    screen = screen,
+                    feature = feature,
+                    action = "safeLaunch"
+                )
+            )
+            emitError(RoomDbError.UNKNOWN_ERROR)
+        }
+        return viewModelScope.launch(exceptionHandler, block = block)
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenClassifier.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenClassifier.kt
@@ -6,6 +6,8 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
 import com.vci.vectorcamapp.core.domain.model.results.ClassifierResult
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlytics
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlyticsContext
 import com.vci.vectorcamapp.imaging.domain.SpecimenClassifier
 import org.opencv.android.Utils
 import org.opencv.core.Core
@@ -69,6 +71,15 @@ class TfLiteSpecimenClassifier(
                 Log.d(TAG, "TFLite interpreter initialized")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to initialize TFLite interpreter: ${e.message}")
+                VectorCamCrashlytics.exception(
+                    throwable = e,
+                    context = VectorCamCrashlyticsContext(
+                        screen = "Imaging",
+                        feature = "TfLiteSpecimenClassifier",
+                        action = "initializeInterpreter"
+                    ),
+                    tags = mapOf("model_file" to "classify.tflite")
+                )
             }
         }
     }
@@ -134,6 +145,14 @@ class TfLiteSpecimenClassifier(
                     ))
                 } catch (e: Exception) {
                     Log.e(TAG, "Inference failed: ${e.message}")
+                    VectorCamCrashlytics.exception(
+                        throwable = e,
+                        context = VectorCamCrashlyticsContext(
+                            screen = "Imaging",
+                            feature = "TfLiteSpecimenClassifier",
+                            action = "classify"
+                        )
+                    )
                     continuation.resume(null)
                 }
             }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/TfLiteSpecimenDetector.kt
@@ -6,6 +6,8 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.util.Log
 import com.vci.vectorcamapp.core.domain.model.results.DetectorResult
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlytics
+import com.vci.vectorcamapp.core.logging.crashlytics.VectorCamCrashlyticsContext
 import com.vci.vectorcamapp.imaging.domain.SpecimenDetector
 import org.opencv.android.Utils
 import org.opencv.core.CvType
@@ -93,6 +95,15 @@ class TfLiteSpecimenDetector(
                 Log.d(TAG, "TFLite interpreter initialized")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to initialize TFLite interpreter: ${e.message}")
+                VectorCamCrashlytics.exception(
+                    throwable = e,
+                    context = VectorCamCrashlyticsContext(
+                        screen = "Imaging",
+                        feature = "TfLiteSpecimenDetector",
+                        action = "initializeInterpreter"
+                    ),
+                    tags = mapOf("model_file" to "detect.tflite")
+                )
             }
         }
     }
@@ -151,6 +162,14 @@ class TfLiteSpecimenDetector(
                     continuation.resume(result)
                 } catch (e: Exception) {
                     Log.e(TAG, "Inference failed: ${e.message}")
+                    VectorCamCrashlytics.exception(
+                        throwable = e,
+                        context = VectorCamCrashlyticsContext(
+                            screen = "Imaging",
+                            feature = "TfLiteSpecimenDetector",
+                            action = "detect"
+                        )
+                    )
                     continuation.resume(emptyList())
                 }
             }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/InferenceRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/data/repository/InferenceRepositoryImplementation.kt
@@ -1,7 +1,6 @@
 package com.vci.vectorcamapp.imaging.data.repository
 
 import android.graphics.Bitmap
-import android.util.Log
 import androidx.compose.ui.geometry.Offset
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognizer
@@ -21,6 +20,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import org.opencv.android.Utils
+import timber.log.Timber
 import org.opencv.core.Core
 import org.opencv.core.Mat
 import org.opencv.imgproc.Imgproc
@@ -45,12 +45,12 @@ class InferenceRepositoryImplementation @Inject constructor(
                     val id = visionText.text.lineSequence().firstOrNull()?.trim().orEmpty()
                     continuation.resume(id)
                 }.addOnFailureListener { exception ->
-                    Log.e("Repository", "Text recognition failed: ${exception.message}")
+                    Timber.e(exception, "InferenceRepository: ML Kit text recognition failed")
                     continuation.resume("")
                 }
             }
         } catch (e: Exception) {
-            Log.e("Repository", "Specimen ID analysis exception: ${e.message}", e)
+            Timber.e(e, "InferenceRepository: readSpecimenId exception")
             ""
         }
     }
@@ -131,7 +131,7 @@ class InferenceRepositoryImplementation @Inject constructor(
         val normalizedFocusX = absolutePixelX.toFloat() / bitmap.width
         val normalizedFocusY = absolutePixelY.toFloat() / bitmap.height
 
-        Log.d("Repository", "AF centroid (norm)=($normalizedFocusX,$normalizedFocusY)")
+        Timber.d("AF centroid (norm)=($normalizedFocusX,$normalizedFocusY)")
         Offset(normalizedFocusX, normalizedFocusY)
     }
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingAction.kt
@@ -26,4 +26,5 @@ sealed interface ImagingAction {
     data object ClearPendingAction : ImagingAction
     data object ConfirmPendingAction : ImagingAction
     data object ReturnToCollectionBatchList : ImagingAction
+    data class CameraBindFailed(val throwable: Throwable) : ImagingAction
 }

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -3,6 +3,7 @@ package com.vci.vectorcamapp.imaging.presentation
 import android.view.Surface
 import androidx.camera.camera2.interop.Camera2Interop
 import androidx.camera.core.Camera
+import androidx.camera.core.CameraState
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageCapture
@@ -48,6 +49,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -55,6 +57,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.Observer
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -177,6 +180,20 @@ fun ImagingScreen(
         } catch (e: Exception) {
             onAction(ImagingAction.CameraBindFailed(e))
         }
+    }
+
+    // Observe CameraX state after a successful bind so errors that occur at runtime
+    // (e.g. camera permission revoked while the screen is active, hardware disconnect)
+    // are surfaced to the user rather than showing a silent black screen.
+    DisposableEffect(camera) {
+        val cameraInfo = camera?.cameraInfo ?: return@DisposableEffect onDispose {}
+        val observer = Observer<CameraState> { cameraState ->
+            if (cameraState.error != null) {
+                onAction(ImagingAction.CameraBindFailed(Exception("CameraX error ${cameraState.error!!.code}")))
+            }
+        }
+        cameraInfo.cameraState.observeForever(observer)
+        onDispose { cameraInfo.cameraState.removeObserver(observer) }
     }
 
     val pagerState = rememberPagerState(

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingScreen.kt
@@ -175,7 +175,7 @@ fun ImagingScreen(
             camera = boundCamera
 
         } catch (e: Exception) {
-            e.printStackTrace()
+            onAction(ImagingAction.CameraBindFailed(e))
         }
     }
 

--- a/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/imaging/presentation/ImagingViewModel.kt
@@ -331,6 +331,15 @@ class ImagingViewModel @Inject constructor(
                     val currentSessionSiteId = currentSessionCache.getSiteId()
 
                     if (currentSession == null || currentSessionSiteId == null) {
+                        VectorCamCrashlytics.exception(
+                            throwable = IllegalStateException("Submit attempted with no active session in cache"),
+                            context = VectorCamCrashlyticsContext(
+                                screen = "Imaging",
+                                feature = "Session Submit",
+                                action = "SubmitSession"
+                            )
+                        )
+                        emitError(ImagingError.NO_ACTIVE_SESSION)
                         _events.send(ImagingEvent.NavigateBackToLandingScreen)
                         return@launch
                     }
@@ -352,6 +361,17 @@ class ImagingViewModel @Inject constructor(
                         )
                         currentSessionCache.clearSession()
                         _events.send(ImagingEvent.NavigateBackToLandingScreen)
+                    } else {
+                        VectorCamCrashlytics.exception(
+                            throwable = IllegalStateException("markSessionAsComplete returned false"),
+                            context = VectorCamCrashlyticsContext(
+                                screen = "Imaging",
+                                feature = "Session Submit",
+                                action = "markSessionAsComplete",
+                                sessionId = currentSession.localId.toString()
+                            )
+                        )
+                        emitError(ImagingError.UNKNOWN_ERROR)
                     }
                 }
 
@@ -785,6 +805,18 @@ class ImagingViewModel @Inject constructor(
                     _events.send(
                         ImagingEvent.NavigateBackToCollectionBatchListScreen(currentSession.localId)
                     )
+                }
+
+                is ImagingAction.CameraBindFailed -> {
+                    VectorCamCrashlytics.exception(
+                        throwable = action.throwable,
+                        context = VectorCamCrashlyticsContext(
+                            screen = "Imaging",
+                            feature = "Camera",
+                            action = "bindToLifecycle"
+                        )
+                    )
+                    emitError(ImagingError.UNKNOWN_INITIALIZATION_ERROR)
                 }
             }
         }

--- a/app/src/main/java/com/vci/vectorcamapp/registration/presentation/RegistrationViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/registration/presentation/RegistrationViewModel.kt
@@ -318,7 +318,9 @@ class RegistrationViewModel @Inject constructor(
             )
             deviceCache.saveDevice(device, selectedProgram.id)
             currentSessionCache.clearSession()
-            collectorRepository.upsertCollector(_state.value.collector)
+            collectorRepository.upsertCollector(_state.value.collector).onError { error ->
+                throw Exception("Failed to save collector during registration: $error")
+            }
 
             // Wire user identity for Crashlytics + GA4 cohort analysis
             VectorCamAnalytics.setDevice(device, selectedProgram.id)

--- a/app/src/main/java/com/vci/vectorcamapp/settings/presentation/SettingsViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/settings/presentation/SettingsViewModel.kt
@@ -209,33 +209,29 @@ class SettingsViewModel @Inject constructor(
                         return@launch
                     }
 
-                    try {
-                        collectorRepository.upsertCollector(collector)
-                        _state.update {
+                    when (collectorRepository.upsertCollector(collector)) {
+                        is Result.Success -> _state.update {
                             it.copy(
                                 selectedCollector = null,
                                 isEditCollectorDialogVisible = false,
                                 similarCollector = null
                             )
                         }
-                    } catch (e: Exception) {
-                        emitError(SettingsError.COLLECTOR_SAVE_FAILED)
+                        is Result.Error -> emitError(SettingsError.COLLECTOR_SAVE_FAILED)
                     }
                 }
 
                 SettingsAction.ConfirmSaveCollector -> {
                     val collector = state.value.selectedCollector ?: return@launch
-                    try {
-                        collectorRepository.upsertCollector(collector)
-                        _state.update {
+                    when (collectorRepository.upsertCollector(collector)) {
+                        is Result.Success -> _state.update {
                             it.copy(
                                 selectedCollector = null,
                                 isEditCollectorDialogVisible = false,
                                 similarCollector = null
                             )
                         }
-                    } catch (e: Exception) {
-                        emitError(SettingsError.COLLECTOR_SAVE_FAILED)
+                        is Result.Error -> emitError(SettingsError.COLLECTOR_SAVE_FAILED)
                     }
                 }
 
@@ -261,8 +257,13 @@ class SettingsViewModel @Inject constructor(
 
                 SettingsAction.ConfirmDeleteCollector -> {
                     val collector = state.value.selectedCollector ?: return@launch
-                    try {
+                    val deleted = try {
                         collectorRepository.deleteCollector(collector)
+                    } catch (e: Exception) {
+                        emitError(SettingsError.COLLECTOR_DELETION_FAILED)
+                        return@launch
+                    }
+                    if (deleted) {
                         _state.update {
                             it.copy(
                                 selectedCollector = null,
@@ -270,7 +271,7 @@ class SettingsViewModel @Inject constructor(
                                 isDeleteCollectorDialogVisible = false
                             )
                         }
-                    } catch (e: Exception) {
+                    } else {
                         emitError(SettingsError.COLLECTOR_DELETION_FAILED)
                     }
                 }
@@ -419,9 +420,18 @@ class SettingsViewModel @Inject constructor(
 
     private fun loadSettingsDetails() {
         viewModelScope.launch {
-            val device = deviceCache.getDevice() ?: return@launch
-            val programId = deviceCache.getProgramId() ?: return@launch
-            val program = programRepository.getProgramById(programId) ?: return@launch
+            val device = deviceCache.getDevice() ?: run {
+                emitError(SettingsError.DATA_SYNC_FAILED)
+                return@launch
+            }
+            val programId = deviceCache.getProgramId() ?: run {
+                emitError(SettingsError.DATA_SYNC_FAILED)
+                return@launch
+            }
+            val program = programRepository.getProgramById(programId) ?: run {
+                emitError(SettingsError.DATA_SYNC_FAILED)
+                return@launch
+            }
 
             _state.update {
                 it.copy(

--- a/app/src/test/java/com/vci/vectorcamapp/settings/presentation/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/vci/vectorcamapp/settings/presentation/SettingsViewModelTest.kt
@@ -25,6 +25,7 @@ import com.vci.vectorcamapp.core.domain.repository.SiteRepository
 import com.vci.vectorcamapp.core.domain.use_cases.collector.CollectorValidationUseCases
 import com.vci.vectorcamapp.core.domain.util.Result
 import com.vci.vectorcamapp.core.domain.util.collector.CollectorValidationError
+import com.vci.vectorcamapp.core.domain.util.room.RoomDbError
 import com.vci.vectorcamapp.core.presentation.util.error.ErrorMessageEmitter
 import com.vci.vectorcamapp.core.rules.MainDispatcherRule
 import com.vci.vectorcamapp.settings.domain.util.SettingsError
@@ -397,9 +398,9 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun settingsVm_d05_saveCollector_onException_emitsError() = runTest {
+    fun settingsVm_d05_saveCollector_onError_emitsError() = runTest {
         collectorsFlow.value = emptyList()
-        coEvery { collectorRepository.upsertCollector(any()) } throws RuntimeException("DB write failed")
+        coEvery { collectorRepository.upsertCollector(any()) } returns Result.Error(RoomDbError.UNKNOWN_ERROR)
 
         backgroundScope.launch { viewModel.state.collect {} }
         advanceUntilIdle()


### PR DESCRIPTION
Summary
P0 — Silent success on failure fixed: SettingsViewModel collector save/delete now checks Result return values properly (the previous try/catch wrapped a non-throwing Result and always succeeded). ImagingViewModel and CollectionBatchListViewModel both emit an error and block navigation when markSessionAsComplete returns false. RegistrationViewModel now fails registration if upsertCollector returns Result.Error. Camera bind exceptions in ImagingScreen are surfaced to the user via a new ImagingAction.CameraBindFailed action instead of printStackTrace.

P1 — Safety net and startup visibility: CoreViewModel gains a safeLaunch wrapper that catches any unexpected coroutine exception, records it to Crashlytics, and shows a generic snackbar. MainActivity's permission/splash phase now uses BaseScaffold so startup errors emitted before the NavGraph mounts are visible. TfLite detector and classifier init/inference failures are now recorded to Crashlytics.

Timber → Crashlytics coverage for data layer: All remaining printStackTrace() and Log.e calls in the data layer (network safeCall, DataStore cache serializers, and all 12 Room repository implementations) replaced with Timber.e/Timber.w, which routes through the existing CrashlyticsTree to record non-fatals in production. No-internet errors use Timber.w (breadcrumb only); unexpected failures use Timber.e (non-fatal recorded).