### PR TITLE
feat: create background service during upload image

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,12 @@
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
 
+        <service
+            android:name=".core.data.upload.UploadForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            android:stopWithTask="false" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/repository/WorkManagerRepositoryImplementation.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/repository/WorkManagerRepositoryImplementation.kt
@@ -1,5 +1,6 @@
 package com.vci.vectorcamapp.core.data.repository
 
+import android.content.Context
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingWorkPolicy
@@ -10,9 +11,11 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import androidx.work.workDataOf
-import com.vci.vectorcamapp.core.domain.repository.WorkManagerRepository
+import com.vci.vectorcamapp.core.data.upload.UploadForegroundService
 import com.vci.vectorcamapp.core.data.upload.image.ImageUploadWorker
 import com.vci.vectorcamapp.core.data.upload.metadata.MetadataUploadWorker
+import com.vci.vectorcamapp.core.domain.repository.WorkManagerRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.UUID
@@ -20,6 +23,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 class WorkManagerRepositoryImplementation @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val workManager: WorkManager
 ) : WorkManagerRepository {
 
@@ -38,8 +42,11 @@ class WorkManagerRepositoryImplementation @Inject constructor(
             ExistingWorkPolicy.REPLACE,
             buildSessionMetadataWork(sessionId, siteId)
         ).then(buildSessionImageWork(sessionId)).enqueue()
+        // Start the sticky foreground service after work is enqueued so the process
+        // stays alive even while workers are queued waiting for constraints to be met.
+        UploadForegroundService.start(context)
     }
-    
+
     override fun observeIsSessionActivelyUploading(sessionId: UUID): Flow<Boolean> {
         val chainName = "session_upload_chain_$sessionId"
         return workManager.getWorkInfosForUniqueWorkFlow(chainName)
@@ -52,6 +59,7 @@ class WorkManagerRepositoryImplementation @Inject constructor(
 
     private fun buildSessionMetadataWork(sessionId: UUID, siteId: Int): OneTimeWorkRequest {
         return OneTimeWorkRequestBuilder<MetadataUploadWorker>()
+            .addTag(UploadForegroundService.UPLOAD_WORK_TAG)
             .setInputData(workDataOf(
                 "session_id" to sessionId.toString(),
                 "site_id" to siteId,
@@ -63,6 +71,7 @@ class WorkManagerRepositoryImplementation @Inject constructor(
 
     private fun buildSessionImageWork(sessionId: UUID): OneTimeWorkRequest {
         return OneTimeWorkRequestBuilder<ImageUploadWorker>()
+            .addTag(UploadForegroundService.UPLOAD_WORK_TAG)
             .setInputData(workDataOf(
                 ImageUploadWorker.KEY_SESSION_ID to sessionId.toString()
             ))

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/UploadForegroundService.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/UploadForegroundService.kt
@@ -24,6 +24,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private enum class UploadState { WAITING, UPLOADING, IDLE }
+
 /**
  * Sticky foreground service (START_STICKY) that anchors the app process during active uploads.
  *
@@ -43,6 +45,9 @@ class UploadForegroundService : Service() {
 
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var observerJob: Job? = null
+    private val notificationManager by lazy {
+        getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+    }
 
     companion object {
         const val UPLOAD_WORK_TAG = "session_upload_work"
@@ -65,13 +70,14 @@ class UploadForegroundService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        startForeground(NOTIFICATION_ID, buildNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        startForeground(NOTIFICATION_ID, buildNotification("Preparing upload\u2026"), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
         startObservingWork()
         return START_STICKY
     }
 
     /**
-     * Observes WorkManager upload tags and stops the service once all upload work is settled.
+     * Observes WorkManager upload tags, updates the notification text to reflect the current
+     * state, and stops the service once all upload work is settled.
      *
      * Uses a `seenActiveWork` flag so we do not stop prematurely if the initial observation
      * happens before WorkManager has registered the enqueued tasks, and to correctly handle
@@ -82,20 +88,36 @@ class UploadForegroundService : Service() {
         observerJob = serviceScope.launch {
             var seenActiveWork = false
             workManager.getWorkInfosByTagFlow(UPLOAD_WORK_TAG).collect { workInfos ->
-                val hasActiveWork = workInfos.any {
-                    it.state == WorkInfo.State.RUNNING ||
-                    it.state == WorkInfo.State.ENQUEUED ||
-                    it.state == WorkInfo.State.BLOCKED
+                val isRunning = workInfos.any { it.state == WorkInfo.State.RUNNING || it.state == WorkInfo.State.BLOCKED }
+                val isEnqueued = workInfos.any { it.state == WorkInfo.State.ENQUEUED }
+                val hasActiveWork = isRunning || isEnqueued
+
+                val state = when {
+                    isRunning -> UploadState.UPLOADING
+                    isEnqueued -> UploadState.WAITING
+                    else -> UploadState.IDLE
                 }
 
-                when {
-                    hasActiveWork -> seenActiveWork = true
-                    seenActiveWork -> stopSelf() // active → idle transition: all done
-                    workInfos.isNotEmpty() -> stopSelf() // all work already completed/failed/cancelled
-                    // workInfos.isEmpty() → work not yet enqueued, keep waiting
+                if (hasActiveWork) {
+                    seenActiveWork = true
+                    updateNotification(state)
+                } else if (seenActiveWork) {
+                    stopSelf() // active → idle transition: all done
+                } else if (workInfos.isNotEmpty()) {
+                    stopSelf() // all work already completed/failed/cancelled
                 }
+                // workInfos.isEmpty() → work not yet enqueued, keep waiting
             }
         }
+    }
+
+    private fun updateNotification(state: UploadState) {
+        val text = when (state) {
+            UploadState.WAITING -> "Waiting for network connection\u2026"
+            UploadState.UPLOADING -> "Upload is running in the background\u2026"
+            UploadState.IDLE -> return
+        }
+        notificationManager.notify(NOTIFICATION_ID, buildNotification(text))
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -105,7 +127,7 @@ class UploadForegroundService : Service() {
         serviceScope.cancel()
     }
 
-    private fun buildNotification(): Notification {
+    private fun buildNotification(text: String): Notification {
         val pendingIntent = PendingIntent.getActivity(
             this,
             0,
@@ -116,7 +138,7 @@ class UploadForegroundService : Service() {
         )
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Uploading session data")
-            .setContentText("Upload is running in the background\u2026")
+            .setContentText(text)
             .setSmallIcon(R.drawable.ic_cloud_upload)
             .setOngoing(true)
             .setContentIntent(pendingIntent)
@@ -132,6 +154,6 @@ class UploadForegroundService : Service() {
             description = "Keeps data and image upload running in the background"
             setShowBadge(false)
         }
-        (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(channel)
+        notificationManager.createNotificationChannel(channel)
     }
 }

--- a/app/src/main/java/com/vci/vectorcamapp/core/data/upload/UploadForegroundService.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/data/upload/UploadForegroundService.kt
@@ -1,0 +1,137 @@
+package com.vci.vectorcamapp.core.data.upload
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import com.vci.vectorcamapp.MainActivity
+import com.vci.vectorcamapp.R
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Sticky foreground service (START_STICKY) that anchors the app process during active uploads.
+ *
+ * WorkManager's SystemForegroundService only starts a foreground service once doWork() begins,
+ * leaving a window where the process can be killed while work is still ENQUEUED. This service
+ * fills that gap and also ensures Android restarts the process if the service is killed mid-upload.
+ *
+ * Lifecycle:
+ *  - Started by WorkManagerRepository immediately before upload work is enqueued.
+ *  - Observes WorkManager state and calls stopSelf() when no upload work remains active.
+ *  - On system restart (START_STICKY), re-attaches to any in-flight WorkManager tasks.
+ */
+@AndroidEntryPoint
+class UploadForegroundService : Service() {
+
+    @Inject lateinit var workManager: WorkManager
+
+    private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var observerJob: Job? = null
+
+    companion object {
+        const val UPLOAD_WORK_TAG = "session_upload_work"
+
+        private const val NOTIFICATION_ID = 9001
+        private const val CHANNEL_ID = "upload_foreground_service_channel"
+        private const val CHANNEL_NAME = "Upload Service"
+
+        fun start(context: Context) {
+            ContextCompat.startForegroundService(
+                context,
+                Intent(context, UploadForegroundService::class.java)
+            )
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(NOTIFICATION_ID, buildNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        startObservingWork()
+        return START_STICKY
+    }
+
+    /**
+     * Observes WorkManager upload tags and stops the service once all upload work is settled.
+     *
+     * Uses a `seenActiveWork` flag so we do not stop prematurely if the initial observation
+     * happens before WorkManager has registered the enqueued tasks, and to correctly handle
+     * the START_STICKY restart path where some work may have already completed.
+     */
+    private fun startObservingWork() {
+        observerJob?.cancel()
+        observerJob = serviceScope.launch {
+            var seenActiveWork = false
+            workManager.getWorkInfosByTagFlow(UPLOAD_WORK_TAG).collect { workInfos ->
+                val hasActiveWork = workInfos.any {
+                    it.state == WorkInfo.State.RUNNING ||
+                    it.state == WorkInfo.State.ENQUEUED ||
+                    it.state == WorkInfo.State.BLOCKED
+                }
+
+                when {
+                    hasActiveWork -> seenActiveWork = true
+                    seenActiveWork -> stopSelf() // active → idle transition: all done
+                    workInfos.isNotEmpty() -> stopSelf() // all work already completed/failed/cancelled
+                    // workInfos.isEmpty() → work not yet enqueued, keep waiting
+                }
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
+    }
+
+    private fun buildNotification(): Notification {
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Uploading session data")
+            .setContentText("Upload is running in the background\u2026")
+            .setSmallIcon(R.drawable.ic_cloud_upload)
+            .setOngoing(true)
+            .setContentIntent(pendingIntent)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_LOW
+        ).apply {
+            description = "Keeps data and image upload running in the background"
+            setShowBadge(false)
+        }
+        (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).createNotificationChannel(channel)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `UploadForegroundService`, a `START_STICKY` foreground service that anchors the app process for the entire duration of an upload — from the moment work is enqueued through completion of both the metadata and image upload workers.
- Tags both `MetadataUploadWorker` and `ImageUploadWorker` with `session_upload_work` so the service can observe all active upload work via `WorkManager.getWorkInfosByTagFlow()`.
- Injects `@ApplicationContext` into `WorkManagerRepositoryImplementation` and calls `UploadForegroundService.start()` immediately after enqueuing work, closing the process-kill window that existed while workers were in the ENQUEUED state.
## Why
WorkManager's `SystemForegroundService` only runs as a foreground service once `doWork()` begins. While work is **ENQUEUED** (e.g. waiting for network), there is no foreground service — the OS is free to kill the process if the app is in the background. Additionally, `SystemForegroundService` is not `START_STICKY`, so Android will not restart it if it is terminated mid-upload.
`UploadForegroundService` solves both problems:
1. Starts a foreground service **before** workers run (eliminating the ENQUEUED window).
2. Returns `START_STICKY` so the OS recreates and restarts the service if it is killed, then re-attaches to in-flight WorkManager tasks.
3. Declared with `android:stopWithTask="false"` so it continues running even after the user swipes the app away from recents.
4. Self-terminates by observing WorkManager state and calling `stopSelf()` once no upload work remains active.


<img width="300"  alt="1000009193" src="https://github.com/user-attachments/assets/b28fa6fc-a9a3-4d58-b5d9-2737766f7bd4" />
<img width="300"  alt="1000009192" src="https://github.com/user-attachments/assets/5e8cb07a-01e1-4a04-a0de-e91f29b58cdc" />
<img width="300" alt="1000009191" src="https://github.com/user-attachments/assets/b2826c2c-f58a-496e-bd82-7417042b8485" />
