### PR TITLE
SOF-492: Fix CompleteSessionDetails screen not loading form for the Uganda program

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/domain/util/CompleteSessionDetailsError.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/domain/util/CompleteSessionDetailsError.kt
@@ -7,6 +7,5 @@ enum class CompleteSessionDetailsError : Error {
     SITE_NOT_FOUND,
     SPECIMENS_NOT_FOUND,
     PROGRAM_NOT_FOUND,
-    FORM_NOT_FOUND,
     UNKNOWN_ERROR;
 }

--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
@@ -186,30 +186,22 @@ class CompleteSessionDetailsViewModel @Inject constructor(
                 emitError(CompleteSessionDetailsError.PROGRAM_NOT_FOUND)
                 return@launch
             }
-            val formVersion = program.formVersion
-            if (formVersion == null) {
-                emitError(CompleteSessionDetailsError.FORM_NOT_FOUND)
-                return@launch
-            }
-            val form = formRepository.getFormByVersion(formVersion)
-            if (form == null) {
-                emitError(CompleteSessionDetailsError.FORM_NOT_FOUND)
-                return@launch
-            }
+            val form = program.formVersion?.let { formRepository.getFormByVersion(it) }
 
-            val allFormQuestions =
-                formQuestionRepository.getQuestionsByFormIdAndScope(form.id, answerScope = null)
+            val allFormQuestions = form?.let {
+                formQuestionRepository.getQuestionsByFormIdAndScope(it.id, answerScope = null)
+            } ?: emptyList()
             val formQuestionsById = allFormQuestions.associateBy { it.id }
 
-            val sessionScopedAnswersByQuestionId =
+            val sessionScopedFormAnswersAndQuestions = form?.let {
                 formAnswerRepository.getSessionScopedFormAnswers(sessionId)
-            val sessionScopedFormAnswersAndQuestions = sessionScopedAnswersByQuestionId
-                .mapNotNull { (questionId, formAnswer) ->
-                    formQuestionsById[questionId]?.let { formQuestion ->
-                        FormAnswerAndQuestion(answer = formAnswer, question = formQuestion)
+                    .mapNotNull { (questionId, formAnswer) ->
+                        formQuestionsById[questionId]?.let { formQuestion ->
+                            FormAnswerAndQuestion(answer = formAnswer, question = formQuestion)
+                        }
                     }
-                }
-                .sortedBy { it.question.order }
+                    .sortedBy { it.question.order }
+            } ?: emptyList()
 
             val sessionUnits = sessionUnitRepository
                 .getSessionUnitsForSession(sessionId)
@@ -220,8 +212,9 @@ class CompleteSessionDetailsViewModel @Inject constructor(
             val bucketNameBySessionUnitId = mutableMapOf<UUID, String>()
 
             sessionUnits.forEach { sessionUnit ->
-                val answersByQuestionId =
+                val answersByQuestionId = form?.let {
                     formAnswerRepository.getSessionUnitScopedFormAnswers(sessionUnit.localId)
+                } ?: emptyMap()
 
                 sessionUnitAnswersAndQuestionsByUnitId[sessionUnit.localId] = answersByQuestionId
                     .mapNotNull { (questionId, formAnswer) ->

--- a/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/core/presentation/util/error/ErrorExtensions.kt
@@ -45,7 +45,6 @@ fun Error.toString(context: Context): String {
             CompleteSessionDetailsError.SITE_NOT_FOUND -> R.string.complete_session_error_site_not_found
             CompleteSessionDetailsError.SPECIMENS_NOT_FOUND -> R.string.complete_session_error_specimens_not_found
             CompleteSessionDetailsError.PROGRAM_NOT_FOUND -> R.string.complete_session_error_program_not_found
-            CompleteSessionDetailsError.FORM_NOT_FOUND -> R.string.complete_session_error_form_not_found
             CompleteSessionDetailsError.UNKNOWN_ERROR -> R.string.complete_session_error_unknown_error
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,9 +232,6 @@
     <!-- Complete session error: Program not found -->
     <string name="complete_session_error_program_not_found">Could not load program details. Please try again or contact support if the issue persists.</string>
 
-    <!-- Complete session error: Form not found -->
-    <string name="complete_session_error_form_not_found">Could not load form details. Please try again or contact support if the issue persists.</string>
-
     <!-- Complete session error: Unknown error -->
     <string name="complete_session_error_unknown_error">An unknown error occurred. Please try again or contact support if the issue persists.</string>
 


### PR DESCRIPTION
This pull request refactors error handling in the Complete Session Details feature by removing the `FORM_NOT_FOUND` error case. The code now gracefully handles missing forms by returning empty lists instead of emitting a specific error. This simplifies the error model and reduces user-facing error messages.

Error handling simplification:

* Removed the `FORM_NOT_FOUND` case from the `CompleteSessionDetailsError` enum and all related logic that emitted this error when a form was missing. [[1]](diffhunk://#diff-a482009b9b37362b14d425eb7552f68738d02a155588c4315833109bf01facdeL10) [[2]](diffhunk://#diff-1490b8a3f6ba100c5bdf89ae01be42ef27a05df3e5297dc62331586f5de876cfL189-R204)
* Updated the ViewModel to handle missing forms by returning empty lists for questions and answers, preventing unnecessary errors. [[1]](diffhunk://#diff-1490b8a3f6ba100c5bdf89ae01be42ef27a05df3e5297dc62331586f5de876cfL189-R204) [[2]](diffhunk://#diff-1490b8a3f6ba100c5bdf89ae01be42ef27a05df3e5297dc62331586f5de876cfL223-R217)

User interface and messaging:

* Removed the string resource and error message for "Form not found" from `strings.xml` and error string mapping. [[1]](diffhunk://#diff-29f77924e9dcd053b2a34a5cc827fdc65443da0918704030b5207d27f74f2999L48) [[2]](diffhunk://#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103L235-L237)