### PR TITLE
SOF-485: Fix pin icon showing up on IncompleteSessionScreen when locationHierarchy is empty

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/incomplete_session/presentation/components/IncompleteSessionCard.kt
@@ -154,32 +154,35 @@ fun IncompleteSessionCard(
                         )
                     }
 
-                    sessionAndSite.site.locationHierarchy?.let { locationHierarchy ->
-                        Row(
-                            verticalAlignment = Alignment.Top,
-                            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_pin),
-                                contentDescription = "Location",
-                                tint = MaterialTheme.colors.icon,
-                                modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
-                            )
-
-                            Column(
-                                verticalArrangement = Arrangement.spacedBy(
-                                    MaterialTheme.dimensions.spacingExtraSmall
-                                )
+                    sessionAndSite.site.locationHierarchy
+                        ?.filterValues { it.isNotBlank() }
+                        ?.takeIf { it.isNotEmpty() }
+                        ?.let { locationHierarchy ->
+                            Row(
+                                verticalAlignment = Alignment.Top,
+                                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.spacingSmall)
                             ) {
-                                locationHierarchy.forEach { (key, value) ->
-                                    Text(
-                                        text = "$key: $value",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colors.textPrimary
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_pin),
+                                    contentDescription = "Location",
+                                    tint = MaterialTheme.colors.icon,
+                                    modifier = Modifier.size(MaterialTheme.dimensions.iconSizeSmall)
+                                )
+
+                                Column(
+                                    verticalArrangement = Arrangement.spacedBy(
+                                        MaterialTheme.dimensions.spacingExtraSmall
                                     )
+                                ) {
+                                    locationHierarchy.forEach { (key, value) ->
+                                        Text(
+                                            text = "$key: $value",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colors.textPrimary
+                                        )
+                                    }
                                 }
                             }
-                        }
                     }
                 }
 


### PR DESCRIPTION
This pull request makes a small improvement to how the location hierarchy is displayed in the `IncompleteSessionCard` component. Now, only non-blank and non-empty values from `locationHierarchy` are shown, which prevents displaying unnecessary or empty location data.

* Only non-blank and non-empty entries from `locationHierarchy` are passed to the UI, improving data quality in the `IncompleteSessionCard` component (`IncompleteSessionCard.kt`).