### PR TITLE
SOF-493: Display matching form on CompleteSessionDetails screen

### DIFF
--- a/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
+++ b/app/src/main/java/com/vci/vectorcamapp/complete_session/details/presentation/CompleteSessionDetailsViewModel.kt
@@ -186,7 +186,8 @@ class CompleteSessionDetailsViewModel @Inject constructor(
                 emitError(CompleteSessionDetailsError.PROGRAM_NOT_FOUND)
                 return@launch
             }
-            val form = program.formVersion?.let { formRepository.getFormByVersion(it) }
+            val form = formRepository.getFormsWithFormAnswersAndQuestionsBySessionId(sessionId)
+                .firstOrNull()?.form
 
             val allFormQuestions = form?.let {
                 formQuestionRepository.getQuestionsByFormIdAndScope(it.id, answerScope = null)


### PR DESCRIPTION
This pull request updates how the `CompleteSessionDetailsViewModel` fetches form data for a session. Instead of retrieving the form by its version, it now fetches the form along with its answers and questions directly by `sessionId`, improving data consistency and simplifying the logic.

**Data fetching improvements:**

* Changed the logic to retrieve the form using `formRepository.getFormsWithFormAnswersAndQuestionsBySessionId(sessionId)` instead of `formRepository.getFormByVersion(it)`, ensuring that the form, its answers, and questions are fetched together based on the session ID.